### PR TITLE
Work around the lack of -M on macOS for ar

### DIFF
--- a/binaryen/package.yaml
+++ b/binaryen/package.yaml
@@ -20,6 +20,12 @@ custom-setup:
     - Cabal
     - directory
     - filepath
+    # we need ghc technically only on macOS
+    # to work around the lack of MRI scripts
+    # via -M support of the `ar` that's
+    # shipped with macOS.  We here rely in
+    # GHC's built in Ar.
+    - ghc
 
 ghc-options: -Wall
 


### PR DESCRIPTION
The ar on macOS ships without support for MRI scripts, and it is
non-trivial to obtain a proper copy on macOS.  Instead we now just
use the Ar support that's in GHC for the precisly same reason.

We'll special case macOS here, as gnu ar is supposed to work on
windows and linux.