### PR TITLE
Make `ahc` accept user code

### DIFF
--- a/asterius/src/Asterius/FrontendPlugin.hs
+++ b/asterius/src/Asterius/FrontendPlugin.hs
@@ -13,54 +13,63 @@ import Control.Monad
 import Control.Monad.IO.Class
 import Data.IORef
 import Data.Maybe
+import qualified GHC
 import qualified GhcPlugins as GHC
 import Language.Haskell.GHC.Toolkit.Compiler
 import Language.Haskell.GHC.Toolkit.FrontendPlugin
 import Language.Haskell.GHC.Toolkit.Orphans.Show
+import qualified Panic as GHC
 import System.Environment.Blank
 import System.FilePath
 
 frontendPlugin :: GHC.FrontendPlugin
 frontendPlugin =
-  makeFrontendPlugin $
-  liftIO $ do
-    Just obj_topdir <- getEnv "ASTERIUS_LIB_DIR"
-    is_debug <- isJust <$> getEnv "ASTERIUS_DEBUG"
-    store_ref <- decodeStore (obj_topdir </> "asterius_store") >>= newIORef
-    get_ffi_mod_ref <- newIORef $ error "get_ffi_mod_ref not initialized"
-    (c, get_ffi_mod) <-
-      addFFIProcessor
-        mempty
-          { withHaskellIR =
-              \GHC.ModSummary {..} ir@HaskellIR {..} -> do
-                let mod_sym = marshalToModuleSymbol ms_mod
-                dflags <- GHC.getDynFlags
-                setDynFlagsRef dflags
-                liftIO $
-                  case runCodeGen (marshalHaskellIR ir) dflags ms_mod of
-                    Left err -> throwIO err
-                    Right m' -> do
-                      get_ffi_mod <- readIORef get_ffi_mod_ref
-                      ffi_mod <- get_ffi_mod mod_sym
-                      let m = ffi_mod <> m'
-                      encodeAsteriusModule obj_topdir mod_sym m
-                      atomicModifyIORef' store_ref $ \store ->
-                        (registerModule obj_topdir mod_sym m store, ())
-                      when is_debug $ do
-                        let p = asteriusModulePath obj_topdir mod_sym
-                        writeFile (p "dump-wasm-ast") $ show m
-                        writeFile (p "dump-cmm-raw-ast") $ show cmmRaw
-                        asmPrint dflags (p "dump-cmm-raw") cmmRaw
-                        writeFile (p "dump-cmm-ast") $ show cmm
-                        asmPrint dflags (p "dump-cmm") cmm
-                        writeFile (p "dump-stg-ast") $ show stg
-                        asmPrint dflags (p "dump-stg") stg
-                        writeFile (p "dump-core-ast") $ show core
-                        asmPrint dflags (p "dump-core") $ GHC.cg_binds core
-          , finalize =
-              liftIO $ do
-                store <- readIORef store_ref
-                encodeStore (obj_topdir </> "asterius_store") store
-          }
-    writeIORef get_ffi_mod_ref get_ffi_mod
-    pure c
+  makeFrontendPlugin $ do
+    obj_topdir <-
+      do GHC.DynFlags {pkgDatabase = pkg_db} <- GHC.getSessionDynFlags
+         case pkg_db of
+           Just ((global_pkg_db, _):_) -> pure $ takeDirectory global_pkg_db
+           _ ->
+             liftIO $
+             GHC.throwGhcExceptionIO $
+             GHC.Panic "Asterius.FrontendPlugin: invalid package database state"
+    liftIO $ do
+      is_debug <- isJust <$> getEnv "ASTERIUS_DEBUG"
+      store_ref <- decodeStore (obj_topdir </> "asterius_store") >>= newIORef
+      get_ffi_mod_ref <- newIORef $ error "get_ffi_mod_ref not initialized"
+      (c, get_ffi_mod) <-
+        addFFIProcessor
+          mempty
+            { withHaskellIR =
+                \GHC.ModSummary {..} ir@HaskellIR {..} -> do
+                  let mod_sym = marshalToModuleSymbol ms_mod
+                  dflags <- GHC.getDynFlags
+                  setDynFlagsRef dflags
+                  liftIO $
+                    case runCodeGen (marshalHaskellIR ir) dflags ms_mod of
+                      Left err -> throwIO err
+                      Right m' -> do
+                        get_ffi_mod <- readIORef get_ffi_mod_ref
+                        ffi_mod <- get_ffi_mod mod_sym
+                        let m = ffi_mod <> m'
+                        encodeAsteriusModule obj_topdir mod_sym m
+                        atomicModifyIORef' store_ref $ \store ->
+                          (registerModule obj_topdir mod_sym m store, ())
+                        when is_debug $ do
+                          let p = asteriusModulePath obj_topdir mod_sym
+                          writeFile (p "dump-wasm-ast") $ show m
+                          writeFile (p "dump-cmm-raw-ast") $ show cmmRaw
+                          asmPrint dflags (p "dump-cmm-raw") cmmRaw
+                          writeFile (p "dump-cmm-ast") $ show cmm
+                          asmPrint dflags (p "dump-cmm") cmm
+                          writeFile (p "dump-stg-ast") $ show stg
+                          asmPrint dflags (p "dump-stg") stg
+                          writeFile (p "dump-core-ast") $ show core
+                          asmPrint dflags (p "dump-core") $ GHC.cg_binds core
+            , finalize =
+                liftIO $ do
+                  store <- readIORef store_ref
+                  encodeStore (obj_topdir </> "asterius_store") store
+            }
+      writeIORef get_ffi_mod_ref get_ffi_mod
+      pure c

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/FakeGHC.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/FakeGHC.hs
@@ -22,28 +22,27 @@ data FakeGHCOptions = FakeGHCOptions
 fakeGHCMain :: FakeGHCOptions -> IO ()
 fakeGHCMain FakeGHCOptions {..} = do
   args0 <- getArgs
-  case partition (== "--make") args0 of
-    ([], _) -> callProcess ghc args0
-    (_, args1) ->
-      let (minusB_args, args2) = partition ("-B" `isPrefixOf`) args1
-          new_ghc_libdir =
-            case minusB_args of
-              [minusB_arg] -> drop 2 minusB_arg
-              _ -> ghcLibDir
-       in GHC.defaultErrorHandler GHC.defaultFatalMessager GHC.defaultFlushOut $
-          GHC.runGhc (Just new_ghc_libdir) $ do
-            dflags0 <- GHC.getSessionDynFlags
-            (dflags1, fileish_args, _) <-
-              GHC.parseDynamicFlags dflags0 (map GHC.noLoc args2)
-            void $
-              GHC.setSessionDynFlags
-                dflags1
-                  { GHC.ghcMode = GHC.CompManager
-                  , GHC.ghcLink = GHC.NoLink
-                  , GHC.hscTarget = GHC.HscAsm
-                  , GHC.verbosity = 1
-                  }
-            GHC.frontend
-              frontendPlugin
-              []
-              [(GHC.unLoc m, Nothing) | m <- fileish_args]
+  let (minusB_args, args1) = partition ("-B" `isPrefixOf`) args0
+      new_ghc_libdir =
+        case minusB_args of
+          [minusB_arg] -> drop 2 minusB_arg
+          _ -> ghcLibDir
+  case partition (== "--make") args1 of
+    ([], _) -> callProcess ghc $ ("-B" <> new_ghc_libdir) : args1
+    (_, args2) ->
+      GHC.defaultErrorHandler GHC.defaultFatalMessager GHC.defaultFlushOut $
+      GHC.runGhc (Just new_ghc_libdir) $ do
+        dflags0 <- GHC.getSessionDynFlags
+        (dflags1, fileish_args, _) <-
+          GHC.parseDynamicFlags dflags0 (map GHC.noLoc args2)
+        void $
+          GHC.setSessionDynFlags
+            dflags1
+              { GHC.ghcMode = GHC.CompManager
+              , GHC.ghcLink = GHC.NoLink
+              , GHC.hscTarget = GHC.HscAsm
+              }
+        GHC.frontend
+          frontendPlugin
+          []
+          [(GHC.unLoc m, Nothing) | m <- fileish_args]


### PR DESCRIPTION
Tracking issue: #53 

Goal: `ahc` is our `ghc` wrapper executable which works only when invoked from the boot script. We shall make it accept user code as well, so `ahc --make Foo.hs` will work the same way as compiling boot libs. As for linking & stub generation, those logic used to belong to `ahc-link` and will stay there for a while.