### PR TITLE
Replace host object files with wasm ones

### DIFF
--- a/asterius/src/Asterius/Boot.hs
+++ b/asterius/src/Asterius/Boot.hs
@@ -47,7 +47,7 @@ defaultBootArgs =
   BootArgs
     { bootDir = dataDir </> ".boot"
     , configureOptions =
-        "--disable-shared --disable-profiling --disable-debug-info --disable-library-for-ghci --disable-split-objs --disable-split-sections --disable-library-stripping -O2"
+        "--disable-shared --disable-profiling --disable-debug-info --disable-library-for-ghci --disable-split-objs --disable-split-sections --disable-library-stripping -O2 --ghc-option=-v1"
     , buildOptions = ""
     , installOptions = ""
     , builtinsOptions = defaultBuiltinsOptions

--- a/asterius/src/Asterius/Boot.hs
+++ b/asterius/src/Asterius/Boot.hs
@@ -114,7 +114,7 @@ bootRTSCmm BootArgs {..} =
                     encodeAsteriusModule obj_topdir mod_sym m
                     modifyIORef' store_ref $ registerModule obj_topdir mod_sym m
                     when is_debug $ do
-                      let p = asteriusModulePath obj_topdir mod_sym
+                      let p = (obj_path -<.>)
                       writeFile (p "dump-wasm-ast") $ show m
                       writeFile (p "dump-cmm-raw-ast") $ show cmmRaw
                       asmPrint dflags (p "dump-cmm-raw") cmmRaw

--- a/asterius/src/Asterius/FrontendPlugin.hs
+++ b/asterius/src/Asterius/FrontendPlugin.hs
@@ -43,9 +43,9 @@ frontendPlugin =
           mempty
             { withHaskellIR =
                 \GHC.ModSummary {..} ir@HaskellIR {..} obj_path -> do
-                  let mod_sym = marshalToModuleSymbol ms_mod
                   dflags <- GHC.getDynFlags
                   setDynFlagsRef dflags
+                  let mod_sym = marshalToModuleSymbol ms_mod
                   liftIO $
                     case runCodeGen (marshalHaskellIR ir) dflags ms_mod of
                       Left err -> throwIO err
@@ -58,7 +58,7 @@ frontendPlugin =
                         atomicModifyIORef' store_ref $ \store ->
                           (registerModule obj_topdir mod_sym m store, ())
                         when is_debug $ do
-                          let p = asteriusModulePath obj_topdir mod_sym
+                          let p = (obj_path -<.>)
                           writeFile (p "dump-wasm-ast") $ show m
                           writeFile (p "dump-cmm-raw-ast") $ show cmmRaw
                           asmPrint dflags (p "dump-cmm-raw") cmmRaw
@@ -68,6 +68,25 @@ frontendPlugin =
                           asmPrint dflags (p "dump-stg") stg
                           writeFile (p "dump-core-ast") $ show core
                           asmPrint dflags (p "dump-core") $ GHC.cg_binds core
+            , withCmmIR =
+                \ir@CmmIR {..} obj_path -> do
+                  dflags <- GHC.getDynFlags
+                  setDynFlagsRef dflags
+                  let ms_mod =
+                        GHC.Module GHC.rtsUnitId $
+                        GHC.mkModuleName $ takeBaseName obj_path
+                  liftIO $
+                    case runCodeGen (marshalCmmIR ir) dflags ms_mod of
+                      Left err -> throwIO err
+                      Right m -> do
+                        encodeFile obj_path m
+                        when is_debug $ do
+                          let p = (obj_path -<.>)
+                          writeFile (p "dump-wasm-ast") $ show m
+                          writeFile (p "dump-cmm-raw-ast") $ show cmmRaw
+                          asmPrint dflags (p "dump-cmm-raw") cmmRaw
+                          writeFile (p "dump-cmm-ast") $ show cmm
+                          asmPrint dflags (p "dump-cmm") cmm
             , finalize =
                 liftIO $ do
                   store <- readIORef store_ref

--- a/asterius/src/Asterius/FrontendPlugin.hs
+++ b/asterius/src/Asterius/FrontendPlugin.hs
@@ -5,6 +5,7 @@ module Asterius.FrontendPlugin
   ) where
 
 import Asterius.CodeGen
+import Asterius.Internals
 import Asterius.JSFFI
 import Asterius.Store
 import Asterius.TypesConv
@@ -41,7 +42,7 @@ frontendPlugin =
         addFFIProcessor
           mempty
             { withHaskellIR =
-                \GHC.ModSummary {..} ir@HaskellIR {..} -> do
+                \GHC.ModSummary {..} ir@HaskellIR {..} obj_path -> do
                   let mod_sym = marshalToModuleSymbol ms_mod
                   dflags <- GHC.getDynFlags
                   setDynFlagsRef dflags
@@ -52,6 +53,7 @@ frontendPlugin =
                         get_ffi_mod <- readIORef get_ffi_mod_ref
                         ffi_mod <- get_ffi_mod mod_sym
                         let m = ffi_mod <> m'
+                        encodeFile obj_path m
                         encodeAsteriusModule obj_topdir mod_sym m
                         atomicModifyIORef' store_ref $ \store ->
                           (registerModule obj_topdir mod_sym m store, ())

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Compiler.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Compiler.hs
@@ -31,8 +31,8 @@ data CmmIR = CmmIR
 data Compiler = Compiler
   { patchParsed :: ModSummary -> HsParsedModule -> Hsc HsParsedModule
   , patchTypechecked :: ModSummary -> TcGblEnv -> Hsc TcGblEnv
-  , withHaskellIR :: ModSummary -> HaskellIR -> CompPipeline ()
-  , withCmmIR :: CmmIR -> CompPipeline ()
+  , withHaskellIR :: ModSummary -> HaskellIR -> FilePath -> CompPipeline ()
+  , withCmmIR :: CmmIR -> FilePath -> CompPipeline ()
   , finalize :: Ghc ()
   }
 
@@ -48,13 +48,13 @@ instance Semigroup Compiler where
             tc_mod' <- patchTypechecked c0 mod_summary tc_mod
             patchTypechecked c1 mod_summary tc_mod'
       , withHaskellIR =
-          \mod_summary hs_ir -> do
-            withHaskellIR c0 mod_summary hs_ir
-            withHaskellIR c1 mod_summary hs_ir
+          \mod_summary hs_ir obj_path -> do
+            withHaskellIR c0 mod_summary hs_ir obj_path
+            withHaskellIR c1 mod_summary hs_ir obj_path
       , withCmmIR =
-          \cmm_ir -> do
-            withCmmIR c0 cmm_ir
-            withCmmIR c1 cmm_ir
+          \cmm_ir obj_path -> do
+            withCmmIR c0 cmm_ir obj_path
+            withCmmIR c1 cmm_ir obj_path
       , finalize =
           do finalize c0
              finalize c1
@@ -65,7 +65,7 @@ instance Monoid Compiler where
     Compiler
       { patchParsed = const pure
       , patchTypechecked = const pure
-      , withHaskellIR = \_ _ -> pure ()
-      , withCmmIR = \_ -> pure ()
+      , withHaskellIR = \_ _ _ -> pure ()
+      , withCmmIR = \_ _ -> pure ()
       , finalize = pure ()
       }

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/FakeGHC.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/FakeGHC.hs
@@ -11,7 +11,7 @@ import Data.List
 import qualified DynFlags as GHC
 import qualified GHC
 import qualified Plugins as GHC
-import System.Environment
+import System.Environment.Blank
 import System.Process
 
 data FakeGHCOptions = FakeGHCOptions
@@ -21,6 +21,7 @@ data FakeGHCOptions = FakeGHCOptions
 
 fakeGHCMain :: FakeGHCOptions -> IO ()
 fakeGHCMain FakeGHCOptions {..} = do
+  unsetEnv "GHC_PACKAGE_PATH"
   args0 <- getArgs
   let (minusB_args, args1) = partition ("-B" `isPrefixOf`) args0
       new_ghc_libdir =

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Hooks.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Hooks.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Language.Haskell.GHC.Toolkit.Hooks
   ( hooksFromCompiler
@@ -9,15 +8,12 @@ module Language.Haskell.GHC.Toolkit.Hooks
 
 import qualified CmmInfo as GHC
 import Control.Concurrent
-import Control.Monad
 import Control.Monad.IO.Class
-import Data.Data (Data, gmapQl)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified DriverPhases as GHC
 import qualified DriverPipeline as GHC
 import qualified DynFlags as GHC
-import qualified ForeignCall as GHC
 import qualified Hooks as GHC
 import qualified HscMain as GHC
 import qualified HscTypes as GHC
@@ -26,16 +22,6 @@ import qualified Module as GHC
 import qualified PipelineMonad as GHC
 import qualified StgCmm as GHC
 import qualified Stream
-import Type.Reflection
-
-hasJSFFI :: Data a => a -> Bool
-hasJSFFI t =
-  case eqTypeRep (typeOf t) (typeRep @GHC.CCallConv) of
-    Just HRefl ->
-      case t of
-        GHC.JavaScriptCallConv -> True
-        _ -> False
-    _ -> gmapQl (||) False hasJSFFI t
 
 hooksFromCompiler :: Compiler -> IO GHC.Hooks
 hooksFromCompiler Compiler {..} = do
@@ -47,7 +33,6 @@ hooksFromCompiler Compiler {..} = do
   cmm_raw_map_ref <- newMVar Map.empty
   cmm_ref <- newEmptyMVar
   cmm_raw_ref <- newEmptyMVar
-  jsffi_set_ref <- newMVar Set.empty
   pure
     GHC.emptyHooks
       { GHC.tcRnModuleHook =
@@ -61,8 +46,6 @@ hooksFromCompiler Compiler {..} = do
             liftIO $ do
               store parsed_map_ref parsed_module
               store typechecked_map_ref typechecked_module
-              when (hasJSFFI $ GHC.hpm_module parsed_module_orig) $
-                modifyMVar_ jsffi_set_ref $ pure . Set.insert ms_mod
             pure typechecked_module
       , GHC.stgCmmHook =
           Just $ \dflags this_mod data_tycons cost_centre_info stg_binds hpc_info -> do
@@ -93,28 +76,16 @@ hooksFromCompiler Compiler {..} = do
             case phase of
               GHC.HscOut src_flavour _ (GHC.HscRecomp cgguts mod_summary@GHC.ModSummary {..}) -> do
                 r <-
-                  do skip_gcc <-
-                       liftIO $ do
-                         s <- readMVar jsffi_set_ref
-                         pure $ Set.member ms_mod s
-                     if skip_gcc
-                       then do
-                         output_fn <-
-                           GHC.phaseOutputFilename $
-                           GHC.hscPostBackendPhase dflags src_flavour $
-                           GHC.hscTarget dflags
-                         GHC.PipeState {GHC.hsc_env = hsc_env'} <-
-                           GHC.getPipeState
-                         (outputFilename, _, _) <-
-                           liftIO $
-                           GHC.hscGenHardCode
-                             hsc_env'
-                             cgguts
-                             mod_summary
-                             output_fn
-                         GHC.setForeignOs []
-                         pure (GHC.RealPhase GHC.StopLn, outputFilename)
-                       else GHC.runPhase phase input_fn dflags
+                  do output_fn <-
+                       GHC.phaseOutputFilename $
+                       GHC.hscPostBackendPhase dflags src_flavour $
+                       GHC.hscTarget dflags
+                     GHC.PipeState {GHC.hsc_env = hsc_env'} <- GHC.getPipeState
+                     (outputFilename, _, _) <-
+                       liftIO $
+                       GHC.hscGenHardCode hsc_env' cgguts mod_summary output_fn
+                     GHC.setForeignOs []
+                     pure (GHC.RealPhase GHC.StopLn, outputFilename)
                 f <-
                   liftIO $
                   modifyMVar mods_set_ref $ \s ->

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Hooks.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Hooks.hs
@@ -121,8 +121,7 @@ hooksFromCompiler Compiler {..} = do
                              fetch stg_map_ref <*>
                              (fetch cmm_map_ref >>= Stream.collect) <*>
                              (fetch cmm_raw_map_ref >>= Stream.collect)
-                           withHaskellIR mod_summary ir
-                           liftIO $ writeFile obj_output_fn "")
+                           withHaskellIR mod_summary ir obj_output_fn)
                 pure r
               GHC.RealPhase GHC.Cmm -> do
                 void $ GHC.runPhase phase input_fn dflags
@@ -130,9 +129,8 @@ hooksFromCompiler Compiler {..} = do
                   liftIO $
                   CmmIR <$> (takeMVar cmm_ref >>= Stream.collect) <*>
                   (takeMVar cmm_raw_ref >>= Stream.collect)
-                withCmmIR ir
                 obj_output_fn <- GHC.phaseOutputFilename GHC.StopLn
-                liftIO $ writeFile obj_output_fn ""
+                withCmmIR ir obj_output_fn
                 pure (GHC.RealPhase GHC.StopLn, obj_output_fn)
               _ -> GHC.runPhase phase input_fn dflags
       }

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Run.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Run.hs
@@ -53,7 +53,7 @@ runHaskell Config {..} targets cont = do
           (compiler <>
            mempty
              { withHaskellIR =
-                 \ModSummary {..} ir ->
+                 \ModSummary {..} ir _ ->
                    liftIO $
                    atomicModifyIORef' mod_map_ref $ \mod_map ->
                      (M.insert ms_mod ir mod_map, ())
@@ -88,7 +88,8 @@ runCmm Config {..} cmm_fns cont = do
       h <-
         hooksFromCompiler
           (compiler <>
-           mempty {withCmmIR = \ir -> liftIO $ modifyIORef' cmm_irs_ref (ir :)})
+           mempty
+             {withCmmIR = \ir _ -> liftIO $ modifyIORef' cmm_irs_ref (ir :)})
       pure (h, reverse <$> readIORef cmm_irs_ref)
   void $
     setSessionDynFlags


### PR DESCRIPTION
Tracking issue: #53 

We're replacing `.o` host object files generated from gcc assembler with our custom ones. For library targets, they will get bundled by `ar` and copied to the destination pkgdb by Cabal.

After this is implemented, at link time, we can seek to deprecate the global "store" mechanism and use those `.a` archives instead.