### PR TITLE
Implement `ahc-ar`

### DIFF
--- a/asterius/app/ahc-ar.hs
+++ b/asterius/app/ahc-ar.hs
@@ -1,17 +1,55 @@
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE RankNTypes #-}
 
+import Asterius.Internals hiding (decodeFile, encodeFile)
+import Asterius.Types
+import Control.Exception
+import Control.Monad
+import Data.Binary
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import Data.Traversable
+import Prelude hiding (IO)
 import System.Directory
 import System.Environment.Blank
-import System.IO
+import System.FilePath
+import System.IO hiding (IO)
 import System.Process
+
+objectSymbolMap :: FilePath -> IO (Map AsteriusEntitySymbol FilePath)
+objectSymbolMap obj_path = do
+  r <- decodeFileOrFail obj_path
+  case r of
+    Left _ -> pure Map.empty
+    Right m -> do
+      when (currentModuleSymbol m == noModuleSymbol) $
+        throwIO $ userError $ "ahc-ar: error when decoding " <> obj_path
+      let syms =
+            mconcat
+              [ Map.keys (staticsMap m)
+              , Map.keys (staticsErrorMap m)
+              , Map.keys (functionMap m)
+              , Map.keys (functionErrorMap m)
+              ]
+      pure $ Map.fromList [(sym, takeBaseName obj_path) | sym <- syms]
+
+archiveIndex :: [FilePath] -> IO FilePath
+archiveIndex obj_paths = do
+  symbol_map <- mconcat <$> for obj_paths objectSymbolMap
+  tmpdir <- getTemporaryDirectory
+  let index_path = tmpdir </> "INDEX"
+  encodeFile index_path symbol_map
+  pure index_path
 
 main :: IO ()
 main = do
   (reverse -> (('@':rsp_path):archive_path:_)) <- getArgs
   obj_paths <- lines <$> readFile rsp_path
+  index_path <- archiveIndex obj_paths
   tmpdir <- getTemporaryDirectory
   (new_rsp_path, new_rsp_h) <- openTempFile tmpdir "ar.rsp"
-  hPutStr new_rsp_h $ unlines obj_paths
+  hPutStr new_rsp_h $ unlines (index_path : obj_paths)
   hClose new_rsp_h
   callProcess "ar" ["-r", "-c", archive_path, '@' : new_rsp_path]
+  removeFile index_path
   removeFile new_rsp_path

--- a/asterius/app/ahc-ar.hs
+++ b/asterius/app/ahc-ar.hs
@@ -16,7 +16,8 @@ import System.FilePath
 import System.IO hiding (IO)
 import System.Process
 
-objectSymbolMap :: FilePath -> IO (Map AsteriusEntitySymbol FilePath)
+objectSymbolMap ::
+     FilePath -> IO (Map AsteriusEntitySymbol AsteriusModuleSymbol)
 objectSymbolMap obj_path = do
   r <- decodeFileOrFail obj_path
   case r of
@@ -24,7 +25,7 @@ objectSymbolMap obj_path = do
     Right m -> do
       when (currentModuleSymbol m == noModuleSymbol) $
         throwIO $ userError $ "ahc-ar: error when decoding " <> obj_path
-      let f = Map.map (const $ takeBaseName obj_path)
+      let f = Map.map (const $ currentModuleSymbol m)
           symbol_map =
             mconcat
               [ f (staticsMap m)

--- a/asterius/app/ahc-ar.hs
+++ b/asterius/app/ahc-ar.hs
@@ -24,14 +24,15 @@ objectSymbolMap obj_path = do
     Right m -> do
       when (currentModuleSymbol m == noModuleSymbol) $
         throwIO $ userError $ "ahc-ar: error when decoding " <> obj_path
-      let syms =
+      let f = Map.map (const $ takeBaseName obj_path)
+          symbol_map =
             mconcat
-              [ Map.keys (staticsMap m)
-              , Map.keys (staticsErrorMap m)
-              , Map.keys (functionMap m)
-              , Map.keys (functionErrorMap m)
+              [ f (staticsMap m)
+              , f (staticsErrorMap m)
+              , f (functionMap m)
+              , f (functionErrorMap m)
               ]
-      pure $ Map.fromList [(sym, takeBaseName obj_path) | sym <- syms]
+      pure symbol_map
 
 archiveIndex :: [FilePath] -> IO FilePath
 archiveIndex obj_paths = do

--- a/asterius/app/ahc-ar.hs
+++ b/asterius/app/ahc-ar.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE ViewPatterns #-}
+
+import System.Directory
+import System.Environment.Blank
+import System.IO
+import System.Process
+
+main :: IO ()
+main = do
+  (reverse -> (('@':rsp_path):archive_path:_)) <- getArgs
+  obj_paths <- lines <$> readFile rsp_path
+  tmpdir <- getTemporaryDirectory
+  (new_rsp_path, new_rsp_h) <- openTempFile tmpdir "ar.rsp"
+  hPutStr new_rsp_h $ unlines obj_paths
+  hClose new_rsp_h
+  callProcess "ar" ["-r", "-c", archive_path, '@' : new_rsp_path]
+  removeFile new_rsp_path

--- a/asterius/boot-init.sh
+++ b/asterius/boot-init.sh
@@ -7,3 +7,4 @@ cp -r $ASTERIUS_SANDBOX_GHC_LIBDIR/. $ASTERIUS_LIB_DIR
 mkdir $ASTERIUS_LIB_DIR/package.conf.d
 cp $ASTERIUS_BOOT_LIBS_DIR/rts/rts.conf $ASTERIUS_LIB_DIR/package.conf.d/
 $ASTERIUS_GHCPKG --package-db=$ASTERIUS_LIB_DIR/package.conf.d recache
+mkdir $ASTERIUS_LIB_DIR/rts

--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -110,6 +110,13 @@ executables:
     dependencies:
       - asterius
 
+  ahc-ar:
+    source-dirs: app
+    main: ahc-ar.hs
+    ghc-options: -threaded -feager-blackholing -rtsopts
+    dependencies:
+      - asterius
+
 tests:
   nir-test:
     source-dirs: test

--- a/asterius/src/Asterius/Ar.hs
+++ b/asterius/src/Asterius/Ar.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Asterius.Ar
+  ( loadAr
+  ) where
+
+import qualified Ar as GHC
+import Asterius.Internals
+import Asterius.Types
+import Data.Binary
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Map.Lazy as LMap
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import Prelude hiding (IO)
+
+loadAr :: FilePath -> IO AsteriusStore
+loadAr p = do
+  GHC.Archive entries <- GHC.loadAr p
+  let files_map =
+        Map.fromList [(filename, filedata) | GHC.ArchiveEntry {..} <- entries]
+      (mod_sym_map :: Map AsteriusModuleSymbol FilePath) =
+        Map.foldlWithKey'
+          (\tot obj_path buf ->
+             case decodeOrFail (LBS.fromStrict buf) of
+               Left _ -> tot
+               Right (_, _, mod_sym) -> Map.insert mod_sym obj_path tot)
+          Map.empty
+          files_map
+      (sym_map :: Map AsteriusEntitySymbol AsteriusModuleSymbol) =
+        decode $ LBS.fromStrict $ files_map ! "INDEX"
+      mod_map = LMap.map (decode . LBS.fromStrict . (files_map !)) mod_sym_map
+  pure AsteriusStore {symbolMap = sym_map, moduleMap = mod_map}

--- a/asterius/src/Asterius/Boot.hs
+++ b/asterius/src/Asterius/Boot.hs
@@ -47,7 +47,8 @@ defaultBootArgs =
   BootArgs
     { bootDir = dataDir </> ".boot"
     , configureOptions =
-        "--disable-shared --disable-profiling --disable-debug-info --disable-library-for-ghci --disable-split-objs --disable-split-sections --disable-library-stripping -O2 --ghc-option=-v1"
+        "--disable-shared --disable-profiling --disable-debug-info --disable-library-for-ghci --disable-split-objs --disable-split-sections --disable-library-stripping -O2 --ghc-option=-v1 --with-ar=" <>
+        ahcAr
     , buildOptions = ""
     , installOptions = ""
     , builtinsOptions = defaultBuiltinsOptions

--- a/asterius/src/Asterius/Boot.hs
+++ b/asterius/src/Asterius/Boot.hs
@@ -109,7 +109,7 @@ bootRTSCmm BootArgs {..} =
                   (GHC.Module GHC.rtsUnitId $
                    GHC.mkModuleName $ takeBaseName obj_path)
                 mod_sym = marshalToModuleSymbol ms_mod
-             in case runCodeGen (marshalCmmIR ir) dflags ms_mod of
+             in case runCodeGen (marshalCmmIR ms_mod ir) dflags ms_mod of
                   Left err -> throwIO err
                   Right m -> do
                     encodeAsteriusModule obj_topdir mod_sym m

--- a/asterius/src/Asterius/Boot.hs
+++ b/asterius/src/Asterius/Boot.hs
@@ -34,6 +34,7 @@ import System.Directory
 import System.Environment
 import System.Exit
 import System.FilePath
+import System.IO hiding (IO)
 import System.Process
 
 data BootArgs = BootArgs
@@ -89,6 +90,7 @@ bootRTSCmm BootArgs {..} =
     setDynFlagsRef dflags
     is_debug <- isJust <$> liftIO (lookupEnv "ASTERIUS_DEBUG")
     store_ref <- liftIO $ newIORef mempty
+    obj_paths_ref <- liftIO $ newIORef []
     rts_cmm_mods <-
       map takeBaseName . filter ((== ".cmm") . takeExtension) <$>
       liftIO (listDirectory rts_path)
@@ -112,8 +114,10 @@ bootRTSCmm BootArgs {..} =
              in case runCodeGen (marshalCmmIR ms_mod ir) dflags ms_mod of
                   Left err -> throwIO err
                   Right m -> do
+                    encodeFile obj_path m
                     encodeAsteriusModule obj_topdir mod_sym m
                     modifyIORef' store_ref $ registerModule obj_topdir mod_sym m
+                    modifyIORef' obj_paths_ref (obj_path :)
                     when is_debug $ do
                       let p = (obj_path -<.>)
                       writeFile (p "dump-wasm-ast") $ show m
@@ -124,6 +128,15 @@ bootRTSCmm BootArgs {..} =
     liftIO $ do
       store <- readIORef store_ref
       encodeStore store_path store
+      obj_paths <- readIORef obj_paths_ref
+      tmpdir <- getTemporaryDirectory
+      (rsp_path, rsp_h) <- openTempFile tmpdir "ar.rsp"
+      hPutStr rsp_h $ unlines obj_paths
+      hClose rsp_h
+      callProcess
+        ahcAr
+        ["-r", "-c", obj_topdir </> "rts" </> "libHSrts.a", '@' : rsp_path]
+      removeFile rsp_path
   where
     rts_path = bootLibsPath </> "rts"
     obj_topdir = bootDir </> "asterius_lib"

--- a/asterius/src/Asterius/BuildInfo.hs
+++ b/asterius/src/Asterius/BuildInfo.hs
@@ -3,6 +3,7 @@ module Asterius.BuildInfo
   , ghcPkg
   , ghcLibDir
   , ahc
+  , ahcAr
   , dataDir
   , packageDBStack
   ) where
@@ -11,5 +12,7 @@ import BuildInfo_asterius
 import System.Directory
 import System.FilePath
 
-ahc :: FilePath
+ahc, ahcAr :: FilePath
 ahc = binDir </> "ahc" <.> exeExtension
+
+ahcAr = binDir </> "ahc-ar" <.> exeExtension

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -1032,8 +1032,12 @@ marshalCmmDecl decl =
           Left err -> mempty {functionErrorMap = M.fromList [(sym, err)]}
           Right f -> mempty {functionMap = M.fromList [(sym, f)]}
 
-marshalHaskellIR :: HaskellIR -> CodeGen AsteriusModule
-marshalHaskellIR HaskellIR {..} = mconcat <$> for (concat cmmRaw) marshalCmmDecl
+marshalHaskellIR :: GHC.Module -> HaskellIR -> CodeGen AsteriusModule
+marshalHaskellIR ms_mod HaskellIR {..} = do
+  m <- mconcat <$> for (concat cmmRaw) marshalCmmDecl
+  pure m {currentModuleSymbol = marshalToModuleSymbol ms_mod}
 
-marshalCmmIR :: CmmIR -> CodeGen AsteriusModule
-marshalCmmIR CmmIR {..} = mconcat <$> for (concat cmmRaw) marshalCmmDecl
+marshalCmmIR :: GHC.Module -> CmmIR -> CodeGen AsteriusModule
+marshalCmmIR ms_mod CmmIR {..} = do
+  m <- mconcat <$> for (concat cmmRaw) marshalCmmDecl
+  pure m {currentModuleSymbol = marshalToModuleSymbol ms_mod}

--- a/asterius/src/Asterius/FrontendPlugin.hs
+++ b/asterius/src/Asterius/FrontendPlugin.hs
@@ -47,7 +47,7 @@ frontendPlugin =
                   setDynFlagsRef dflags
                   let mod_sym = marshalToModuleSymbol ms_mod
                   liftIO $
-                    case runCodeGen (marshalHaskellIR ir) dflags ms_mod of
+                    case runCodeGen (marshalHaskellIR ms_mod ir) dflags ms_mod of
                       Left err -> throwIO err
                       Right m' -> do
                         get_ffi_mod <- readIORef get_ffi_mod_ref
@@ -76,7 +76,7 @@ frontendPlugin =
                         GHC.Module GHC.rtsUnitId $
                         GHC.mkModuleName $ takeBaseName obj_path
                   liftIO $
-                    case runCodeGen (marshalCmmIR ir) dflags ms_mod of
+                    case runCodeGen (marshalCmmIR ms_mod ir) dflags ms_mod of
                       Left err -> throwIO err
                       Right m -> do
                         encodeFile obj_path m

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -436,7 +436,7 @@ ahcLinkMain task@Task {..} = do
             }
           [inputHS]
           (\ms_mod obj_path ir ->
-             case runCodeGen (marshalHaskellIR ir) dflags ms_mod of
+             case runCodeGen (marshalHaskellIR ms_mod ir) dflags ms_mod of
                Left err -> throwIO err
                Right m' -> do
                  let mod_sym = marshalToModuleSymbol ms_mod


### PR DESCRIPTION
Tracking issue: #53 

Previously in #63, we made `ahc` generate `.o` wasm object files which are bundled by gnu ar and copied by Cabal. Now we'll implement `ahc-ar` and other necessary utilities to:

* Add symbol indices into `.a` archives
* Reconstruct stores from archives, without losing lazy loading of individual object files
* Get rid of the legacy object storage completely.