### PR TITLE
Implement ahc-cabal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,13 +43,11 @@ jobs:
             apt install -y nodejs
             mkdir -p /root/.local/bin
             curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C /root/.local/bin '*/stack'
+            curl https://downloads.haskell.org/~cabal/cabal-install-latest/cabal-install-2.4.1.0-x86_64-unknown-linux.tar.xz | tar xJ -C /root/.local/bin 'cabal'
       - checkout
       - run:
           name: Test asterius
           command: |
-            node --version
-            npm --version
-
             git submodule update --init --recursive
             stack --no-terminal -j8 build --test --no-run-tests
             stack --no-terminal exec ahc-boot

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN \
   apt install -y nodejs && \
   mkdir -p /root/.local/bin && \
   curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C /root/.local/bin '*/stack' && \
+  curl https://downloads.haskell.org/~cabal/cabal-install-latest/cabal-install-2.4.1.0-x86_64-unknown-linux.tar.xz | tar xJ -C /root/.local/bin 'cabal' && \
   export HS_WABT_PREFIX=/root/.local && \
   stack --no-terminal install asterius wabt && \
   stack --no-terminal exec ahc-boot && \

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We provide pre-built Docker images. Put the input `.hs` program in a directory a
 ```
 terrorjack@ubuntu:~$ docker run -it -v ~/mirror:/mirror terrorjack/asterius
 root@76bcb511663d:~# cd /mirror
-root@76bcb511663d:/mirror# ahc-link --help
+root@76bcb511663d:/mirror# ahc-link --input-hs xxx.hs
 ...
 ```
 
@@ -32,6 +32,7 @@ What works currently:
 * Non-IO parts in `ghc-prim`/`integer-simple`/`base`/`array`/`deepseq`/`containers`/`transformers`/`mtl`/`pretty`/`bytestring`/`binary`/`xhtml`. IO is achieved via rts primitives like `print_i64` or JavaScript FFI.
 * Fast arbitrary-precision `Integer` operations backed by `BigInt`s.
 * Preliminary copying GC, managing both Haskell heap objects and JavaScript references.
+* Preliminary Cabal support.
 * Persistent "vault"s which are KV stores transferrable across asterius instances.
 * Importing JavaScript expressions via the `foreign import javascript` syntax. First-class `JSVal` type in Haskell land.
 * Fast conversion between Haskell/JavaScript types (strings, arrays and ArrayBuffers at the moment)

--- a/asterius/app/ahc-cabal.hs
+++ b/asterius/app/ahc-cabal.hs
@@ -1,0 +1,50 @@
+import Asterius.BuildInfo
+import Data.List
+import System.Environment.Blank
+import System.Process
+
+main :: IO ()
+main = do
+  args <- getArgs
+  let extra_prog_args =
+        [ "--with-ghc=" <> ahc
+        , "--with-ghc-pkg=" <> ahcPkg
+        , "--with-ar=" <> ahcAr
+        , "--ghc-option=-pgml" <> ahcLd
+        ]
+      extra_args =
+        [ "--disable-shared"
+        , "--disable-executable-dynamic"
+        , "--disable-profiling"
+        , "--disable-debug-info"
+        , "--disable-library-for-ghci"
+        , "--disable-split-sections"
+        , "--disable-split-objs"
+        , "--disable-executable-stripping"
+        , "--disable-library-stripping"
+        , "--disable-tests"
+        , "--disable-coverage"
+        , "--disable-benchmarks"
+        , "--disable-relocatable"
+        ] <>
+        extra_prog_args
+      (global_flags, command_flags) = span ("-" `isPrefixOf`) args
+      new_command_flags =
+        case command_flags of
+          command:flags
+            | command `elem`
+                [ "new-build"
+                , "new-configure"
+                , "v2-build"
+                , "v2-configure"
+                , "v1-configure"
+                , "v1-install"
+                ] -> command : (extra_args <> flags)
+            | command `elem` ["v1-build"] ->
+              command : (extra_prog_args <> flags)
+            | command `elem` ["new-update", "v2-update", "v1-sandbox"] ->
+              command_flags
+            | otherwise -> error $ "ahc-cabal: Unsupported command " <> command
+          _ -> command_flags
+      new_args = global_flags <> new_command_flags
+  callProcess "cabal" new_args

--- a/asterius/app/ahc-cabal.hs
+++ b/asterius/app/ahc-cabal.hs
@@ -38,12 +38,25 @@ main = do
                 , "v2-build"
                 , "v2-configure"
                 , "v1-configure"
+                , "v1-reconfigure"
                 , "v1-install"
                 ] -> command : (extra_args <> flags)
             | command `elem` ["v1-build"] ->
               command : (extra_prog_args <> flags)
-            | command `elem` ["new-update", "v2-update", "v1-sandbox"] ->
-              command_flags
+            | command `elem`
+                [ "update"
+                , "help"
+                , "info"
+                , "list"
+                , "fetch"
+                , "user-config"
+                , "get"
+                , "init"
+                , "sandbox"
+                , "new-update"
+                , "v2-update"
+                , "v1-sandbox"
+                ] -> command_flags
             | otherwise -> error $ "ahc-cabal: Unsupported command " <> command
           _ -> command_flags
       new_args = global_flags <> new_command_flags

--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -137,6 +137,13 @@ executables:
     dependencies:
       - asterius
 
+  ahc-cabal:
+    source-dirs: app
+    main: ahc-cabal.hs
+    ghc-options: -threaded -feager-blackholing -rtsopts
+    dependencies:
+      - asterius
+
 tests:
   nir-test:
     source-dirs: test

--- a/docs/ahc-link.md
+++ b/docs/ahc-link.md
@@ -1,6 +1,8 @@
-# Using `ahc-link`
+# Using `ahc-dist`/`ahc-link`
 
 `ahc-link` is the frontend program of Asterius. It taks a Haskell `Main` module and optionally an ES6 "entry" module as input, then emits a `.wasm` WebAssembly binary module and companion JavaScript, which can be run in Node.js or browser environments.
+
+`ahc-dist` works similarly, except it takes the "executable" file generated from `ahc` (either directly by calling `ahc`, or indirectly by using `cabal`) as input. Most command-line arguments are the same as `ahc-link`, except `ahc-link` takes `--input-hs`, while `ahc-dist` takes `--input-exe`.
 
 The options are described in full details here.
 
@@ -8,7 +10,11 @@ The options are described in full details here.
 
 ### `--input-hs ARG`
 
-The Haskell `Main` module's file path. This option doesn't have a default and is mandatory; all others are optional.
+The Haskell `Main` module's file path. This option doesn't have a default and is mandatory; all others are optional. This works only for `ahc-link`.
+
+### `--input-exe ARG`
+
+The "executable" file path. This works only for `ahc-dist`, and is also mandatory.
 
 ### `--input-mjs ARG`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,8 @@ repo_url: https://github.com/tweag/asterius
 pages:
   - 'Home': 'index.md'
   - 'Building guide': 'building.md'
-  - 'Using ahc-link': 'ahc-link.md'
+  - 'Cabal support': 'cabal.md'
+  - 'Using ahc-dist/ahc-link': 'ahc-link.md'
   - 'JavaScript FFI': 'jsffi.md'
   - 'The Vault': 'vault.md'
   - 'Invoking RTS API in JavaScript': 'rts-api.md'


### PR DESCRIPTION
Tracking issue: #53 

So, finally here we are. `ahc-cabal` is the wrapper executable for `cabal`, so users won't need to pass a bunch of specific configure flags in order to make `ahc` and its friends work out of the box.