### PR TITLE
Remove NodeFileSystem and unwanted dependency

### DIFF
--- a/asterius/rts/rts.fs.mjs
+++ b/asterius/rts/rts.fs.mjs
@@ -1,5 +1,3 @@
-import fs from "fs";
-
 export class MemoryFileSystem {
   constructor(logger) {
     this.root = new Map([ [ "/dev/stdout", "" ], [ "/dev/stderr", "" ] ]);
@@ -17,21 +15,6 @@ export class MemoryFileSystem {
   writeSync(fd, string) {
     const p = this.fds[fd];
     this.root.set(p, this.root.get(p) + string);
-    this.logger.logEvent([ fd, string ]);
-  }
-}
-
-export class NodeFileSystem {
-  constructor(logger) {
-    this.logger = logger;
-    Object.freeze(this);
-  }
-  stdout() { return process.stdout.fd; }
-  stderr() { return process.stderr.fd; }
-  openSync(path, flags) { return fs.openSync(path, flags); }
-  closeSync(fd) { fs.closeSync(fd); }
-  writeSync(fd, string) {
-    fs.writeSync(fd, string);
     this.logger.logEvent([ fd, string ]);
   }
 }


### PR DESCRIPTION
Closes #59

currently `NodeFileSystem` is not used, so it can be dropped for now instead of breaking `--browser` compatibility.