### PR TITLE
Add exports and conditional main execution for --sync target

### DIFF
--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -384,12 +384,14 @@ genDefEntry Task {..} =
                    else mempty
                , "try {\n"
                , "i.wasmInstance.exports.hs_init();\n"
+               , "if (i.wasmInstance.exports.main)\n"
                , "i.wasmInstance.exports.main();\n"
                , "} catch (err) {\n"
                , "console.log(i.stdio.stdout());\n"
                , "throw err;\n"
                , "}\n"
                , "console.log(i.stdio.stdout());\n"
+               , exports
                ]
         else mconcat
                [ "module.then(m => "
@@ -411,6 +413,15 @@ genDefEntry Task {..} =
     ]
   where
     out_base = string7 outputBaseName
+    exports = mconcat $ map
+        ( \AsteriusEntitySymbol{..} -> mconcat
+            [ "export const "
+            , shortByteString entityName
+            , " = i.wasmInstance.exports."
+            , shortByteString entityName
+            , "\n"
+            ]
+        ) exportFunctions
 
 genHTML :: Task -> Builder
 genHTML Task {..} =


### PR DESCRIPTION
Example `jsffi.mjs` is now rendered as when `--sync` option is passed.

```
import {module} from "./jsffi.wasm.mjs";
import * as jsffi from "./jsffi.lib.mjs";
process.on("unhandledRejection", err => { throw err; });
let i = jsffi.newInstance(module);
try {
i.wasmInstance.exports.hs_init();
if (i.wasmInstance.exports.main)
i.wasmInstance.exports.main();
} catch (err) {
console.log(i.stdio.stdout());
throw err;
}
console.log(i.stdio.stdout());
export const putchar = i.wasmInstance.exports.putchar
export const mult_hs_double = i.wasmInstance.exports.mult_hs_double
export const mult_hs_int = i.wasmInstance.exports.mult_hs_int
```

It allows test case to be invoked like.
```
import {mult_hs_int, mult_hs_double, putchar} from './jsffi.mjs';

console.log(mult_hs_int(9,9));
console.log(mult_hs_double(9, 9));
putchar("H".codePointAt(0));
```


Partially implements #74