### PR TITLE
Fix issue with loading wasm file during import

### DIFF
--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -305,16 +305,22 @@ genWasm :: Task -> LBS.ByteString -> Builder
 genWasm Task {..} _ =
   mconcat
     [ case target of
-        Node -> "import fs from \"fs\";\n"
+        Node ->
+            "import fs from \"fs\";\n" <>
+            "import path from \"path\";\n" <>
+            if bundle
+               then mempty
+               else "const __dirname = path.dirname(new URL(import.meta.url).pathname);"
+               
         Browser -> mempty
     , "export const module = "
     , case target of
         Node
           | sync ->
-            "new WebAssembly.Module(fs.readFileSync(" <> out_wasm <> "))"
+            "new WebAssembly.Module(fs.readFileSync(path.join(__dirname," <> out_wasm <> ")))"
           | otherwise ->
-            "new Promise((resolve, reject) => fs.readFile(" <> out_wasm <>
-            ", (err, buf) => err ? reject(err) : resolve(buf))).then(buf => WebAssembly.compile(buf))"
+            "new Promise((resolve, reject) => fs.readFile(path.join(__dirname," <> out_wasm <>
+            "), (err, buf) => err ? reject(err) : resolve(buf))).then(buf => WebAssembly.compile(buf))"
         Browser
           | noStreaming ->
             "fetch (" <> out_wasm <>


### PR DESCRIPTION
When module was imported from other directory than this with all generated files, `wasm` file failed to import due to that it was expected to be on the current working dir.