### PR TITLE
Update ghc

### DIFF
--- a/ghc-toolkit/boot-libs/base/Control/Monad.hs
+++ b/ghc-toolkit/boot-libs/base/Control/Monad.hs
@@ -191,16 +191,22 @@ forever a   = let a' = a *> a' in a'
 -- data structures or a state monad.
 mapAndUnzipM      :: (Applicative m) => (a -> m (b,c)) -> [a] -> m ([b], [c])
 {-# INLINE mapAndUnzipM #-}
+-- Inline so that fusion with 'unzip' and 'traverse' has a chance to fire.
+-- See Note [Inline @unzipN@ functions] in GHC/OldList.hs.
 mapAndUnzipM f xs =  unzip <$> traverse f xs
 
 -- | The 'zipWithM' function generalizes 'zipWith' to arbitrary applicative functors.
 zipWithM          :: (Applicative m) => (a -> b -> m c) -> [a] -> [b] -> m [c]
 {-# INLINE zipWithM #-}
+-- Inline so that fusion with zipWith and sequenceA have a chance to fire
+-- See Note [Fusion for zipN/zipWithN] in List.hs]
 zipWithM f xs ys  =  sequenceA (zipWith f xs ys)
 
 -- | 'zipWithM_' is the extension of 'zipWithM' which ignores the final result.
 zipWithM_         :: (Applicative m) => (a -> b -> m c) -> [a] -> [b] -> m ()
 {-# INLINE zipWithM_ #-}
+-- Inline so that fusion with zipWith and sequenceA have a chance to fire
+-- See Note [Fusion for zipN/zipWithN] in List.hs]
 zipWithM_ f xs ys =  sequenceA_ (zipWith f xs ys)
 
 {- | The 'foldM' function is analogous to 'Data.Foldable.foldl', except that its result is

--- a/ghc-toolkit/boot-libs/base/Data/Bits.hs
+++ b/ghc-toolkit/boot-libs/base/Data/Bits.hs
@@ -540,8 +540,8 @@ instance Bits Integer where
    testBit x (I# i) = testBitInteger x i
    zeroBits   = 0
 
-   bit (I# i#) = bitInteger i#
-   popCount x  = I# (popCountInteger x)
+   bit (I# i#) = errorWithoutStackTrace "bitInteger"
+   popCount x  = errorWithoutStackTrace "popCountInteger"
 
    rotate x i = shift x i   -- since an Integer never wraps around
 
@@ -563,8 +563,8 @@ instance Bits Natural where
    zeroBits      = wordToNaturalBase 0##
    clearBit x i  = x `xor` (bit i .&. x)
 
-   bit (I# i#) = bitNatural i#
-   popCount x  = popCountNatural x
+   bit (I# i#) = errorWithoutStackTrace "bitNatural"
+   popCount x  = errorWithoutStackTrace "popCountNatural"
 
    rotate x i = shift x i   -- since an Natural never wraps around
 

--- a/ghc-toolkit/boot-libs/base/Data/Bits.hs
+++ b/ghc-toolkit/boot-libs/base/Data/Bits.hs
@@ -540,8 +540,8 @@ instance Bits Integer where
    testBit x (I# i) = testBitInteger x i
    zeroBits   = 0
 
-   bit (I# i#) = errorWithoutStackTrace "bitInteger"
-   popCount x  = errorWithoutStackTrace "popCountInteger"
+   bit (I# i#) = bitInteger i#
+   popCount x  = I# (popCountInteger x)
 
    rotate x i = shift x i   -- since an Integer never wraps around
 
@@ -563,8 +563,8 @@ instance Bits Natural where
    zeroBits      = wordToNaturalBase 0##
    clearBit x i  = x `xor` (bit i .&. x)
 
-   bit (I# i#) = errorWithoutStackTrace "bitNatural"
-   popCount x  = errorWithoutStackTrace "popCountNatural"
+   bit (I# i#) = bitNatural i#
+   popCount x  = popCountNatural x
 
    rotate x i = shift x i   -- since an Natural never wraps around
 

--- a/ghc-toolkit/boot-libs/base/Data/OldList.hs
+++ b/ghc-toolkit/boot-libs/base/Data/OldList.hs
@@ -929,8 +929,27 @@ foldr7_left _  z _ _ _      _      _      _      _      _      = z
 
  #-}
 
+{-
+
+Note [Inline @unzipN@ functions]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The inline principle for @unzip{4,5,6,7}@ is the same as 'unzip'/'unzip3' in
+"GHC.List".
+The 'unzip'/'unzip3' functions are inlined so that the `foldr` with which they
+are defined has an opportunity to fuse.
+
+As such, since there are not any differences between 2/3-ary 'unzip' and its
+n-ary counterparts below aside from the number of arguments, the `INLINE`
+pragma should be replicated in the @unzipN@ functions below as well.
+
+-}
+
 -- | The 'unzip4' function takes a list of quadruples and returns four
 -- lists, analogous to 'unzip'.
+{-# INLINE unzip4 #-}
+-- Inline so that fusion with `foldr` has an opportunity to fire.
+-- See Note [Inline @unzipN@ functions] above.
 unzip4                  :: [(a,b,c,d)] -> ([a],[b],[c],[d])
 unzip4                  =  foldr (\(a,b,c,d) ~(as,bs,cs,ds) ->
                                         (a:as,b:bs,c:cs,d:ds))
@@ -938,6 +957,9 @@ unzip4                  =  foldr (\(a,b,c,d) ~(as,bs,cs,ds) ->
 
 -- | The 'unzip5' function takes a list of five-tuples and returns five
 -- lists, analogous to 'unzip'.
+{-# INLINE unzip5 #-}
+-- Inline so that fusion with `foldr` has an opportunity to fire.
+-- See Note [Inline @unzipN@ functions] above.
 unzip5                  :: [(a,b,c,d,e)] -> ([a],[b],[c],[d],[e])
 unzip5                  =  foldr (\(a,b,c,d,e) ~(as,bs,cs,ds,es) ->
                                         (a:as,b:bs,c:cs,d:ds,e:es))
@@ -945,6 +967,9 @@ unzip5                  =  foldr (\(a,b,c,d,e) ~(as,bs,cs,ds,es) ->
 
 -- | The 'unzip6' function takes a list of six-tuples and returns six
 -- lists, analogous to 'unzip'.
+{-# INLINE unzip6 #-}
+-- Inline so that fusion with `foldr` has an opportunity to fire.
+-- See Note [Inline @unzipN@ functions] above.
 unzip6                  :: [(a,b,c,d,e,f)] -> ([a],[b],[c],[d],[e],[f])
 unzip6                  =  foldr (\(a,b,c,d,e,f) ~(as,bs,cs,ds,es,fs) ->
                                         (a:as,b:bs,c:cs,d:ds,e:es,f:fs))
@@ -952,6 +977,9 @@ unzip6                  =  foldr (\(a,b,c,d,e,f) ~(as,bs,cs,ds,es,fs) ->
 
 -- | The 'unzip7' function takes a list of seven-tuples and returns
 -- seven lists, analogous to 'unzip'.
+{-# INLINE unzip7 #-}
+-- Inline so that fusion with `foldr` has an opportunity to fire.
+-- See Note [Inline @unzipN@ functions] above.
 unzip7          :: [(a,b,c,d,e,f,g)] -> ([a],[b],[c],[d],[e],[f],[g])
 unzip7          =  foldr (\(a,b,c,d,e,f,g) ~(as,bs,cs,ds,es,fs,gs) ->
                                 (a:as,b:bs,c:cs,d:ds,e:es,f:fs,g:gs))

--- a/ghc-toolkit/boot-libs/base/Foreign/C/Error.hs
+++ b/ghc-toolkit/boot-libs/base/Foreign/C/Error.hs
@@ -255,11 +255,15 @@ isValidErrno (Errno errno)  = errno /= -1
 
 -- | Get the current value of @errno@ in the current thread.
 --
+-- On GHC, the runtime will ensure that any Haskell thread will only see "its own"
+-- @errno@, by saving and restoring the value when Haskell threads are scheduled
+-- across OS threads.
 getErrno :: IO Errno
 
 -- We must call a C function to get the value of errno in general.  On
 -- threaded systems, errno is hidden behind a C macro so that each OS
--- thread gets its own copy.
+-- thread gets its own copy (`saved_errno`, which `rts/Schedule.c` restores
+-- back into the thread-local `errno` when a Haskell thread is rescheduled).
 getErrno = do e <- get_errno; return (Errno e)
 foreign import ccall unsafe "HsBase.h __hscore_get_errno" get_errno :: IO CInt
 

--- a/ghc-toolkit/boot-libs/base/GHC/List.hs
+++ b/ghc-toolkit/boot-libs/base/GHC/List.hs
@@ -925,14 +925,14 @@ foldr2 k z = go
         go []    _ys     = z
         go _xs   []      = z
         go (x:xs) (y:ys) = k x y (go xs ys)
-{-# INLINE [0] foldr2 #-}
+{-# INLINE [0] foldr2 #-}  -- See Note [Fusion for foldrN]
 
 foldr2_left :: (a -> b -> c -> d) -> d -> a -> ([b] -> c) -> [b] -> d
 foldr2_left _k  z _x _r []     = z
 foldr2_left  k _z  x  r (y:ys) = k x y (r ys)
 
 -- foldr2 k z xs ys = foldr (foldr2_left k z)  (\_ -> z) xs ys
-{-# RULES
+{-# RULES   -- See Note [Fusion for foldrN]
 "foldr2/left"   forall k z ys (g::forall b.(a->b->b)->b->b) .
                   foldr2 k z (build g) ys = g (foldr2_left  k z) (\_ -> z) ys
  #-}
@@ -944,7 +944,7 @@ foldr3 k z = go
     go  _     []     _      = z
     go  _     _      []     = z
     go (a:as) (b:bs) (c:cs) = k a b c (go as bs cs)
-{-# INLINE [0] foldr3 #-}
+{-# INLINE [0] foldr3 #-}  -- See Note [Fusion for foldrN]
 
 
 foldr3_left :: (a -> b -> c -> d -> e) -> e -> a ->
@@ -953,28 +953,63 @@ foldr3_left k _z a r (b:bs) (c:cs) = k a b c (r bs cs)
 foldr3_left _  z _ _  _      _     = z
 
 -- foldr3 k n xs ys zs = foldr (foldr3_left k n) (\_ _ -> n) xs ys zs
-{-# RULES
+{-# RULES   -- See Note [Fusion for foldrN]
 "foldr3/left"   forall k z (g::forall b.(a->b->b)->b->b).
                   foldr3 k z (build g) = g (foldr3_left k z) (\_ _ -> z)
  #-}
 
--- There used to be a foldr2/right rule, allowing foldr2 to fuse with a build
--- form on the right. However, this causes trouble if the right list ends in
--- a bottom that is only avoided by the left list ending at that spot. That is,
--- foldr2 f z [a,b,c] (d:e:f:_|_), where the right list is produced by a build
--- form, would cause the foldr2/right rule to introduce bottom. Example:
---
--- zip [1,2,3,4] (unfoldr (\s -> if s > 4 then undefined else Just (s,s+1)) 1)
---
--- should produce
---
--- [(1,1),(2,2),(3,3),(4,4)]
---
--- but with the foldr2/right rule it would instead produce
---
--- (1,1):(2,2):(3,3):(4,4):_|_
+{- Note [Fusion for foldrN]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+We arrange that foldr2, foldr3, etc is a good consumer for its first
+(left) list argument. Here's how. See below for the second, third
+etc list arguments
 
--- Zips for larger tuples are in the List module.
+* The rule "foldr2/left" (active only before phase 1) does this:
+     foldr2 k z (build g) ys = g (foldr2_left  k z) (\_ -> z) ys
+  thereby fusing away the 'build' on the left argument
+
+* To ensure this rule has a chance to fire, foldr2 has a NOINLINE[1] pragma
+
+There used to be a "foldr2/right" rule, allowing foldr2 to fuse with a build
+form on the right. However, this causes trouble if the right list ends in
+a bottom that is only avoided by the left list ending at that spot. That is,
+foldr2 f z [a,b,c] (d:e:f:_|_), where the right list is produced by a build
+form, would cause the foldr2/right rule to introduce bottom. Example:
+  zip [1,2,3,4] (unfoldr (\s -> if s > 4 then undefined else Just (s,s+1)) 1)
+should produce
+  [(1,1),(2,2),(3,3),(4,4)]
+but with the foldr2/right rule it would instead produce
+  (1,1):(2,2):(3,3):(4,4):_|_
+
+Note [Fusion for zipN/zipWithN]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+We arrange that zip, zip3, etc, and zipWith, zipWit3 etc, are all
+good consumers for their first (left) argument, and good producers.
+Here's how.  See Note [Fusion for foldr2] for why it can't fuse its
+second (right) list argument.
+
+NB: Zips for larger tuples are in the List module.
+
+* Rule "zip" (active only before phase 1) rewrites
+    zip xs ys = build (\c n -> foldr2 (zipFB c) n xs ys)
+  See also Note [Inline FB functions]
+
+  Ditto rule "zipWith".
+
+* To give this rule a chance to fire, we give zip a NOLINLINE[1]
+  pragma (although since zip is recursive it might not need it)
+
+* Now the rules for foldr2 (see Note [Fusion for foldr2]) may fire,
+  or rules that fuse the build-produced output of zip.
+
+* If none of these fire, rule "zipList" (active only in phase 1)
+  rewrites the foldr2 call back to zip
+     foldr2 (zipFB (:)) []   = zip
+  This rule will only fire when build has inlined, which also
+  happens in phase 1.
+
+  Ditto rule "zipWithList".
+-}
 
 ----------------------------------------------
 -- | /O(min(m,n))/. 'zip' takes two lists and returns a list of corresponding
@@ -995,7 +1030,7 @@ foldr3_left _  z _ _  _      _     = z
 --
 -- 'zip' is capable of list fusion, but it is restricted to its
 -- first list argument and its resulting list.
-{-# NOINLINE [1] zip #-}
+{-# NOINLINE [1] zip #-}  -- See Note [Fusion for zipN/zipWithN]
 zip :: [a] -> [b] -> [(a,b)]
 zip []     _bs    = []
 zip _as    []     = []
@@ -1005,7 +1040,7 @@ zip (a:as) (b:bs) = (a,b) : zip as bs
 zipFB :: ((a, b) -> c -> d) -> a -> b -> c -> d
 zipFB c = \x y r -> (x,y) `c` r
 
-{-# RULES
+{-# RULES  -- See Note [Fusion for zipN/zipWithN]
 "zip"      [~1] forall xs ys. zip xs ys = build (\c n -> foldr2 (zipFB c) n xs ys)
 "zipList"  [1]  foldr2 (zipFB (:)) []   = zip
  #-}
@@ -1026,7 +1061,7 @@ zip3 _      _      _      = []
 zip3FB :: ((a,b,c) -> xs -> xs') -> a -> b -> c -> xs -> xs'
 zip3FB cons = \a b c r -> (a,b,c) `cons` r
 
-{-# RULES
+{-# RULES    -- See Note [Fusion for zipN/zipWithN]
 "zip3"       [~1] forall as bs cs. zip3 as bs cs = build (\c n -> foldr3 (zip3FB c) n as bs cs)
 "zip3List"   [1]          foldr3 (zip3FB (:)) [] = zip3
  #-}
@@ -1049,7 +1084,7 @@ zip3FB cons = \a b c r -> (a,b,c) `cons` r
 --
 -- 'zipWith' is capable of list fusion, but it is restricted to its
 -- first list argument and its resulting list.
-{-# NOINLINE [1] zipWith #-}
+{-# NOINLINE [1] zipWith #-}  -- See Note [Fusion for zipN/zipWithN]
 zipWith :: (a->b->c) -> [a]->[b]->[c]
 zipWith f = go
   where
@@ -1063,7 +1098,7 @@ zipWith f = go
 zipWithFB :: (a -> b -> c) -> (d -> e -> a) -> d -> e -> b -> c
 zipWithFB c f = \x y r -> (x `f` y) `c` r
 
-{-# RULES
+{-# RULES       -- See Note [Fusion for zipN/zipWithN]
 "zipWith"       [~1] forall f xs ys.    zipWith f xs ys = build (\c n -> foldr2 (zipWithFB c f) n xs ys)
 "zipWithList"   [1]  forall f.  foldr2 (zipWithFB (:) f) [] = zipWith f
   #-}
@@ -1093,12 +1128,16 @@ zipWith3FB cons func = \a b c r -> (func a b c) `cons` r
 -- and a list of second components.
 unzip    :: [(a,b)] -> ([a],[b])
 {-# INLINE unzip #-}
+-- Inline so that fusion `foldr` has an opportunity to fire.
+-- See Note [Inline @unzipN@ functions] in GHC/OldList.hs.
 unzip    =  foldr (\(a,b) ~(as,bs) -> (a:as,b:bs)) ([],[])
 
 -- | The 'unzip3' function takes a list of triples and returns three
 -- lists, analogous to 'unzip'.
 unzip3   :: [(a,b,c)] -> ([a],[b],[c])
 {-# INLINE unzip3 #-}
+-- Inline so that fusion `foldr` has an opportunity to fire.
+-- See Note [Inline @unzipN@ functions] in GHC/OldList.hs.
 unzip3   =  foldr (\(a,b,c) ~(as,bs,cs) -> (a:as,b:bs,c:cs))
                   ([],[],[])
 

--- a/ghc-toolkit/boot-libs/base/tests/all.T
+++ b/ghc-toolkit/boot-libs/base/tests/all.T
@@ -203,6 +203,7 @@ test('T8089',
 test('hWaitForInput-accurate-socket', reqlib('unix'), compile_and_run, [''])
 test('T8684', expect_broken(8684), compile_and_run, [''])
 test('hWaitForInput-accurate-stdin', normal, compile_and_run, [''])
+test('hWaitForInput-accurate-pipe', reqlib('unix'), compile_and_run, [''])
 test('T9826',normal, compile_and_run,[''])
 test('T9848',
         [ collect_stats('bytes allocated')

--- a/ghc-toolkit/boot-libs/base/tests/hWaitForInput-accurate-pipe.hs
+++ b/ghc-toolkit/boot-libs/base/tests/hWaitForInput-accurate-pipe.hs
@@ -1,0 +1,23 @@
+import Control.Concurrent
+import Control.Monad
+import GHC.Clock
+import System.IO
+import System.Posix.IO
+import System.Timeout
+
+main :: IO ()
+main = do
+    (readPipe, _) <- createPipe
+    readPipeHandle <- fdToHandle readPipe
+    let nanoSecondsPerSecond = 1000 * 1000 * 1000
+    let milliSecondsPerSecond = 1000
+    let timeToSpend = 1
+    let timeToSpendNano = timeToSpend * nanoSecondsPerSecond
+    let timeToSpendMilli = timeToSpend * milliSecondsPerSecond
+    start <- getMonotonicTimeNSec
+    b <- hWaitForInput readPipeHandle timeToSpendMilli
+    end <- getMonotonicTimeNSec
+    let timeSpentNano = fromIntegral $ end - start
+    let delta = timeSpentNano - timeToSpendNano
+    -- We can never wait for a shorter amount of time than specified
+    putStrLn $ "delta >= 0: " ++ show (delta > 0)

--- a/ghc-toolkit/boot-libs/base/tests/hWaitForInput-accurate-pipe.stdout
+++ b/ghc-toolkit/boot-libs/base/tests/hWaitForInput-accurate-pipe.stdout
@@ -1,0 +1,1 @@
+delta >= 0: True

--- a/ghc-toolkit/boot-libs/ghc-boot-th/ghc-boot-th.cabal
+++ b/ghc-toolkit/boot-libs/ghc-boot-th/ghc-boot-th.cabal
@@ -3,7 +3,7 @@
 -- ghc-boot-th.cabal.in, not ghc-boot-th.cabal.
 
 name:           ghc-boot-th
-version:        8.7
+version:        8.9
 license:        BSD3
 license-file:   LICENSE
 category:       GHC
@@ -29,10 +29,11 @@ source-repository head
 Library
     default-language: Haskell2010
     other-extensions: DeriveGeneric
+    default-extensions: NoImplicitPrelude
 
     exposed-modules:
             GHC.LanguageExtensions.Type
             GHC.ForeignSrcLang.Type
             GHC.Lexeme
 
-    build-depends: base       >= 4.7 && < 4.13
+    build-depends: base       >= 4.7 && < 4.14

--- a/ghc-toolkit/boot-libs/rts/Apply.cmm
+++ b/ghc-toolkit/boot-libs/rts/Apply.cmm
@@ -60,7 +60,7 @@ stg_ap_0_fast ( P_ fun )
 
 again:
     W_  info;
-    W_ untaggedfun;
+    P_ untaggedfun;
     W_ arity;
     untaggedfun = UNTAG(fun);
     info = %INFO_PTR(untaggedfun);
@@ -106,6 +106,11 @@ again:
                 pap = Hp - SIZEOF_StgPAP + WDS(1);
                 SET_HDR(pap, stg_PAP_info, CCCS);
                 StgPAP_arity(pap) = arity;
+                if (arity <= TAG_MASK) {
+                  // TODO: Shouldn't this already be tagged? If not why did we
+                  // untag it at the beginning of this function?
+                  fun = untaggedfun + arity;
+                }
                 StgPAP_fun(pap)   = fun;
                 StgPAP_n_args(pap) = 0;
                 return (pap);
@@ -117,9 +122,8 @@ again:
                 return (fun);
             } else {
                 // We're going to copy this PAP, and put the new CCS in it
-                fun = untaggedfun;
                 W_ size;
-                size = SIZEOF_StgPAP + WDS(TO_W_(StgPAP_n_args(fun)));
+                size = SIZEOF_StgPAP + WDS(TO_W_(StgPAP_n_args(untaggedfun)));
                 HP_CHK_GEN(size);
                 TICK_ALLOC_PAP(size, 0);
                 // attribute this allocation to the "overhead of profiling"
@@ -127,13 +131,13 @@ again:
                 P_ pap;
                 pap = Hp - size + WDS(1);
                 // We'll lose the original PAP, so we should enter its CCS
-                ccall enterFunCCS(BaseReg "ptr", StgHeader_ccs(fun) "ptr");
+                ccall enterFunCCS(BaseReg "ptr", StgHeader_ccs(untaggedfun) "ptr");
                 SET_HDR(pap, stg_PAP_info, CCCS);
-                StgPAP_arity(pap) = StgPAP_arity(fun);
-                StgPAP_n_args(pap) = StgPAP_n_args(fun);
+                StgPAP_arity(pap) = StgPAP_arity(untaggedfun);
+                StgPAP_n_args(pap) = StgPAP_n_args(untaggedfun);
                 StgPAP_fun(pap)   = StgPAP_fun(fun);
                 W_ i;
-                i = TO_W_(StgPAP_n_args(fun));
+                i = TO_W_(StgPAP_n_args(untaggedfun));
             loop:
                 if (i == 0) {
                     return (pap);

--- a/ghc-toolkit/boot-libs/template-haskell/Language/Haskell/TH/Lib.hs
+++ b/ghc-toolkit/boot-libs/template-haskell/Language/Haskell/TH/Lib.hs
@@ -52,10 +52,10 @@ module Language.Haskell.TH.Lib (
     bindS, letS, noBindS, parS, recS,
 
     -- *** Types
-        forallT, varT, conT, appT, appKindT, arrowT, infixT, uInfixT, parensT,
-        equalityT, listT, tupleT, unboxedTupleT, unboxedSumT, sigT, litT,
-        wildCardT, promotedT, promotedTupleT, promotedNilT, promotedConsT,
-        implicitParamT,
+        forallT, forallVisT, varT, conT, appT, appKindT, arrowT, infixT,
+        uInfixT, parensT, equalityT, listT, tupleT, unboxedTupleT, unboxedSumT,
+        sigT, litT, wildCardT, promotedT, promotedTupleT, promotedNilT,
+        promotedConsT, implicitParamT,
     -- **** Type literals
     numTyLit, strTyLit,
     -- **** Strictness

--- a/ghc-toolkit/boot-libs/template-haskell/Language/Haskell/TH/Lib/Internal.hs
+++ b/ghc-toolkit/boot-libs/template-haskell/Language/Haskell/TH/Lib/Internal.hs
@@ -646,6 +646,9 @@ forallT tvars ctxt ty = do
     ty1    <- ty
     return $ ForallT tvars1 ctxt1 ty1
 
+forallVisT :: [TyVarBndrQ] -> TypeQ -> TypeQ
+forallVisT tvars ty = ForallVisT <$> sequenceA tvars <*> ty
+
 varT :: Name -> TypeQ
 varT = return . VarT
 

--- a/ghc-toolkit/boot-libs/template-haskell/Language/Haskell/TH/Syntax.hs
+++ b/ghc-toolkit/boot-libs/template-haskell/Language/Haskell/TH/Syntax.hs
@@ -2099,6 +2099,7 @@ data PatSynArgs
   deriving( Show, Eq, Ord, Data, Generic )
 
 data Type = ForallT [TyVarBndr] Cxt Type  -- ^ @forall \<vars\>. \<ctxt\> => \<type\>@
+          | ForallVisT [TyVarBndr] Type   -- ^ @forall \<vars\> -> \<type\>@
           | AppT Type Type                -- ^ @T a b@
           | AppKindT Type Kind            -- ^ @T \@k t@
           | SigT Type Kind                -- ^ @t :: k@

--- a/ghc-toolkit/boot-libs/template-haskell/changelog.md
+++ b/ghc-toolkit/boot-libs/template-haskell/changelog.md
@@ -5,6 +5,9 @@
   * Introduce a `liftTyped` method to the `Lift` class and set the default
     implementations of `lift`/`liftTyped` to be in terms of each other.
 
+  * Add a `ForallVisT` constructor to `Type` to represent visible, dependent
+    quantification.
+
 ## 2.15.0.0 *TBA*
 
   * In `Language.Haskell.TH.Syntax`, `DataInstD`, `NewTypeInstD`, `TySynEqn`,

--- a/ghc-toolkit/boot-libs/template-haskell/template-haskell.cabal
+++ b/ghc-toolkit/boot-libs/template-haskell/template-haskell.cabal
@@ -1,3 +1,7 @@
+-- WARNING: template-haskell.cabal is automatically generated from template-haskell.cabal.in by
+-- ../../configure.  Make sure you are editing template-haskell.cabal.in, not
+-- template-haskell.cabal.
+
 name:           template-haskell
 version:        2.15.0.0
 -- NOTE: Don't forget to update ./changelog.md
@@ -52,7 +56,7 @@ Library
 
     build-depends:
         base        >= 4.11 && < 4.14,
-        ghc-boot-th == 8.7.*,
+        ghc-boot-th == 8.9,
         pretty      == 1.1.*
 
     ghc-options: -Wall

--- a/ghc-toolkit/ghc-libdir/include/ghcversion.h
+++ b/ghc-toolkit/ghc-libdir/include/ghcversion.h
@@ -1,9 +1,9 @@
 #ifndef __GHCVERSION_H__
 #define __GHCVERSION_H__
 
-#define __GLASGOW_HASKELL__ 807
+#define __GLASGOW_HASKELL__ 809
 
-#define __GLASGOW_HASKELL_PATCHLEVEL1__ 20190217
+#define __GLASGOW_HASKELL_PATCHLEVEL1__ 20190301
 
 #define MIN_VERSION_GLASGOW_HASKELL(ma,mi,pl1,pl2) (\
    ((ma)*100+(mi)) <  __GLASGOW_HASKELL__ || \

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Orphans/Show.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Orphans/Show.hs
@@ -113,6 +113,8 @@ deriving instance Show Coercion
 
 deriving instance Show TyCoVarBinder
 
+deriving instance Show AnonArgFlag
+
 deriving instance Show Type
 
 deriving instance Show LitNumType

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: ghc-8.7
+resolver: ghc-8.9
 allow-newer: true
 extra-deps:
   - aeson-1.4.2.0
@@ -83,10 +83,10 @@ ghc-build: standard
 setup-info:
   ghc:
     linux64:
-      8.7.20190217:
-        url: https://2679-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.7.20190217-x86_64-unknown-linux.tar.xz
-        sha256: 6749b2b25eb2aeef6c9c5764b53290a3492bd8bead02539903e10fef11321ba9
+      8.9.20190301:
+        url: https://2813-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.9.20190301-x86_64-unknown-linux.tar.xz
+        sha256: 56a6761ca5b0b7089d7aef169c3f438734462b3d99a3a3ff71e54c02e11a9a5e
     macosx:
-      8.7.20190217:
-        url: https://2678-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.7.20190217-x86_64-apple-darwin.tar.xz
-        sha256: 84fad16342ab0a8577fd87d9891598ff77f20549e8c713c725b6e6baf21f5ece
+      8.9.20190301:
+        url: https://2810-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.9.20190301-x86_64-apple-darwin.tar.xz
+        sha256: 37b3fa2d6e700cd68ecd145cfeb674c81c26c78421388b4d0bb3cd089eb9bb1b


### PR DESCRIPTION
Relevant: #54 

Updates ghc and boot libs to a recent revision. The new ghc version contains @angerman's work on improving iserv & adding remote-iserv (see https://gitlab.haskell.org/ghc/ghc/merge_requests/250)