### PR TITLE
Faster dependency analysis

### DIFF
--- a/asterius/src/Asterius/Internals.hs
+++ b/asterius/src/Asterius/Internals.hs
@@ -1,8 +1,6 @@
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE UnboxedTuples #-}
 
 module Asterius.Internals
@@ -11,7 +9,6 @@ module Asterius.Internals
   , marshalV
   , encodeStorable
   , reinterpretCast
-  , collect
   , encodeFile
   , decodeFile
   , tryDecodeFile
@@ -24,16 +21,13 @@ import Control.Exception
 import qualified Data.Binary as Binary
 import qualified Data.ByteString.Char8 as CBS
 import qualified Data.ByteString.Short.Internal as SBS
-import Data.Data (Data, gmapQl)
 import qualified Data.Map.Lazy as LM
-import qualified Data.Set as S
 import Foreign
 import Foreign.C
 import GHC.Exts
 import GHC.Stack
 import qualified GHC.Types
 import Prelude hiding (IO)
-import Type.Reflection
 
 type IO a
    = HasCallStack =>
@@ -90,15 +84,6 @@ reinterpretCast a =
                         case unIO (poke (Ptr addr) a) s2 of
                           (# s3, _ #) -> unIO (peek (Ptr addr)) s3) of
     (# _, r #) -> r
-
-collect ::
-     forall a k. (Data a, Typeable k, Ord k)
-  => a
-  -> S.Set k
-collect t =
-  case eqTypeRep (typeOf t) (typeRep :: TypeRep k) of
-    Just HRefl -> [t]
-    _ -> gmapQl (<>) mempty collect t
 
 {-# INLINE encodeFile #-}
 encodeFile :: Binary.Binary a => FilePath -> a -> IO ()

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -65,7 +65,7 @@ data Task = Task
   , inputEntryMJS :: Maybe FilePath
   , outputDirectory :: FilePath
   , outputBaseName :: String
-  , fullSymTable, bundle, noStreaming, sync, binaryen, debug, outputLinkReport, outputGraphViz, outputIR, run :: Bool
+  , fullSymTable, bundle, noStreaming, sync, binaryen, debug, outputLinkReport, outputIR, run :: Bool
   , extraGHCFlags :: [String]
   , exportFunctions, extraRootSymbols :: [AsteriusEntitySymbol]
   } deriving (Show)
@@ -103,14 +103,8 @@ parseTask args =
         , bool_opt "sync" $ \t -> t {sync = True}
         , bool_opt "binaryen" $ \t -> t {binaryen = True}
         , bool_opt "debug" $ \t ->
-            t
-              { debug = True
-              , outputLinkReport = True
-              , outputGraphViz = True
-              , outputIR = True
-              }
+            t {debug = True, outputLinkReport = True, outputIR = True}
         , bool_opt "output-link-report" $ \t -> t {outputLinkReport = True}
-        , bool_opt "output-graphviz" $ \t -> t {outputGraphViz = True}
         , bool_opt "output-ir" $ \t -> t {outputIR = True}
         , bool_opt "run" $ \t -> t {run = True}
         , str_opt "ghc-option" $ \s t ->
@@ -134,7 +128,6 @@ parseTask args =
           , binaryen = False
           , debug = False
           , outputLinkReport = False
-          , outputGraphViz = False
           , outputIR = False
           , run = False
           , extraGHCFlags = []
@@ -489,14 +482,9 @@ ahcDistMain task@Task {..} (final_m, err_msgs, report) = do
       out_js = outputDirectory </> outputBaseName <.> "js"
       out_html = outputDirectory </> outputBaseName <.> "html"
       out_link = outputDirectory </> outputBaseName <.> "link.txt"
-      out_dot = outputDirectory </> outputBaseName <.> "dot"
   when outputLinkReport $ do
     putStrLn $ "[INFO] Writing linking report to " <> show out_link
     writeFile out_link $ show report
-  when outputGraphViz $ do
-    putStrLn $
-      "[INFO] Writing GraphViz file of symbol dependencies to " <> show out_dot
-    writeDot out_dot report
   when outputIR $ do
     let p = out_wasm -<.> "bin"
     putStrLn $ "[INFO] Serializing linked IR to " <> show p

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -87,7 +87,8 @@ mergeSymbols ::
   -> AsteriusModule
   -> S.Set AsteriusEntitySymbol
   -> (AsteriusModule, LinkReport)
-mergeSymbols debug AsteriusModule {..} root_syms = (final_m, final_rep)
+mergeSymbols debug AsteriusModule {..} root_syms =
+  (final_m, final_rep {bundledFFIMarshalState = ffiMarshalState})
   where
     (_, final_rep, final_m) = go (root_syms, mempty, mempty)
     go i@(i_staging_syms, _, _) =
@@ -146,7 +147,6 @@ mergeSymbols debug AsteriusModule {..} root_syms = (final_m, final_rep)
             mempty
               { childSymbols = i_child_map
               , unavailableSymbols = S.fromList i_unavailable_syms
-              , bundledFFIMarshalState = ffiMarshalState
               } <>
             i_rep
           o_m = mconcat (map snd i_sym_modlets) <> i_m

--- a/docs/ahc-link.md
+++ b/docs/ahc-link.md
@@ -104,10 +104,6 @@ Use this to specify a symbol to be added to the "root symbol set". Works similar
 
 Output a "link report" text file containing internal linker stats.
 
-### `--output-graphviz`
-
-Output a `.dot` GraphViz file containing a symbol dependency graph file.
-
 ### `--output-ir`
 
 Output wasm IRs of compiled Haskell modules and the resulting module. The IRs aren't intended to be consumed by external tools like binaryen/wabt.


### PR DESCRIPTION
Relevant: #51

This PR speeds up `mergeSymbols`, where we perform dependency analysis and discover live code.

Note that we also removed the ability to output symbol dependency graph as a GraphViz file. Use cases are extremely rare anyway.