### PR TITLE
Update ghc to expose HscMain.doCodeGen in ghc api

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -83,10 +83,10 @@ ghc-build: standard
 setup-info:
   ghc:
     linux64:
-      8.9.20190301:
-        url: https://2813-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.9.20190301-x86_64-unknown-linux.tar.xz
-        sha256: 56a6761ca5b0b7089d7aef169c3f438734462b3d99a3a3ff71e54c02e11a9a5e
+      8.9.20190306:
+        url: https://2915-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.9.20190306-x86_64-unknown-linux.tar.xz
+        sha256: ec0d13278767dee45f26926a9c4eddb3678e921e289dfa5d52c0fcb3f715e8ec
     macosx:
-      8.9.20190301:
-        url: https://2810-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.9.20190301-x86_64-apple-darwin.tar.xz
-        sha256: 37b3fa2d6e700cd68ecd145cfeb674c81c26c78421388b4d0bb3cd089eb9bb1b
+      8.9.20190306:
+        url: https://2912-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.9.20190306-x86_64-apple-darwin.tar.xz
+        sha256: 136164760d1cccc11b6b3fb305f96b95c5bf55b6f9632923173cd2daf5607912


### PR DESCRIPTION
Relevant: #54 

`HscMain.doCodeGen` is not exposed in upstream ghc. This updates the ghc bindists to include the necessary change for implementing the Core -> Wasm hook in TH support.