### PR TITLE
Track JSFFI imports/exports in dependency analyzer

### DIFF
--- a/asterius/app/ahc-ar.hs
+++ b/asterius/app/ahc-ar.hs
@@ -19,7 +19,7 @@ type UnsafeAsteriusModule
      , Map AsteriusEntitySymbol LBS.ByteString
      , Map AsteriusEntitySymbol LBS.ByteString
      , Map AsteriusEntitySymbol LBS.ByteString
-     , Map AsteriusModuleSymbol LBS.ByteString)
+     , Map AsteriusEntitySymbol LBS.ByteString)
 
 appendUnsafeAsteriusModule ::
      UnsafeAsteriusModule -> UnsafeAsteriusModule -> UnsafeAsteriusModule

--- a/asterius/app/ahc-ar.hs
+++ b/asterius/app/ahc-ar.hs
@@ -18,7 +18,7 @@ type UnsafeAsteriusModule
      , Map AsteriusEntitySymbol LBS.ByteString
      , Map AsteriusEntitySymbol LBS.ByteString
      , Map AsteriusEntitySymbol LBS.ByteString
-     , Map AsteriusModuleSymbol LBS.ByteString
+     , Map (AsteriusModuleSymbol, Int) LBS.ByteString
      , Map AsteriusModuleSymbol LBS.ByteString)
 
 appendUnsafeAsteriusModule ::

--- a/asterius/app/ahc-ar.hs
+++ b/asterius/app/ahc-ar.hs
@@ -18,7 +18,7 @@ type UnsafeAsteriusModule
      , Map AsteriusEntitySymbol LBS.ByteString
      , Map AsteriusEntitySymbol LBS.ByteString
      , Map AsteriusEntitySymbol LBS.ByteString
-     , Map (AsteriusModuleSymbol, Int) LBS.ByteString
+     , Map AsteriusEntitySymbol LBS.ByteString
      , Map AsteriusModuleSymbol LBS.ByteString)
 
 appendUnsafeAsteriusModule ::

--- a/asterius/src/Asterius/Ar.hs
+++ b/asterius/src/Asterius/Ar.hs
@@ -16,5 +16,5 @@ import Prelude hiding (IO)
 loadAr :: FilePath -> IO AsteriusModule
 loadAr p = do
   GHC.Archive entries <- GHC.loadAr p
-  let Just mod_entry = find (("MODULE" `isPrefixOf`) . GHC.filename) entries
+  let Just mod_entry = find (("MODULE" ==) . GHC.filename) entries
   pure $ decode $ LBS.fromStrict $ GHC.filedata mod_entry

--- a/asterius/src/Asterius/JSFFI.hs
+++ b/asterius/src/Asterius/JSFFI.hs
@@ -41,6 +41,7 @@ import Text.Parsec (anyChar, char, digit, parse, try)
 import Text.Parsec.String (Parser)
 import Type.Reflection
 import qualified TysPrim as GHC
+import qualified Unique as GHC
 
 parseField :: Parser a -> Parser (Chunk a)
 parseField f = do
@@ -233,10 +234,14 @@ recoverWasmWrapperFunctionName :: AsteriusModuleSymbol -> Int -> String
 recoverWasmWrapperFunctionName mod_sym k =
   recoverWasmImportFunctionName mod_sym k <> "_wrapper"
 
-processFFI :: Data a => AsteriusModuleSymbol -> a -> State FFIMarshalState a
+processFFI ::
+     Data a
+  => AsteriusModuleSymbol
+  -> a
+  -> State (FFIMarshalState, GHC.UniqSupply) a
 processFFI mod_sym = w
   where
-    w :: Data a => a -> State FFIMarshalState a
+    w :: Data a => a -> State (FFIMarshalState, GHC.UniqSupply) a
     w t =
       case eqTypeRep (typeOf t) (typeRep :: TypeRep (GHC.ForeignDecl GHC.GhcPs)) of
         Just HRefl ->
@@ -244,11 +249,14 @@ processFFI mod_sym = w
             GHC.ForeignImport { GHC.fd_fi = GHC.CImport (GHC.unLoc -> GHC.JavaScriptCallConv) _ _ _ loc_src
                               , ..
                               } -> do
-              old_state@FFIMarshalState {..} <- get
+              (old_state@FFIMarshalState {..}, old_us) <- get
               let old_decls = ffiImportDecls ! mod_sym
-                  new_k = maybe 0 (succ . fst) $ IM.lookupMax old_decls
+                  (u, new_us) = GHC.takeUniqFromSupply old_us
+                  new_k = GHC.getKey u
                   new_decls = IM.insert new_k new_decl old_decls
-              put $ old_state {ffiImportDecls = M.singleton mod_sym new_decls}
+              put
+                ( old_state {ffiImportDecls = M.singleton mod_sym new_decls}
+                , new_us)
               pure
                 t
                   { GHC.fd_fi =
@@ -275,7 +283,7 @@ processFFI mod_sym = w
             GHC.ForeignExport { GHC.fd_fe = GHC.CExport (GHC.unLoc -> GHC.CExportStatic src_txt lbl GHC.JavaScriptCallConv) loc_src
                               , ..
                               } -> do
-              old_state@FFIMarshalState {..} <- get
+              (old_state@FFIMarshalState {..}, old_us) <- get
               let old_decls = ffiExportDecls ! mod_sym
                   Just ffi_ftype =
                     marshalToFFIFunctionType $ GHC.hsImplicitBody fd_sig_ty
@@ -286,7 +294,9 @@ processFFI mod_sym = w
                       FFIExportDecl
                         {ffiFunctionType = ffi_ftype, ffiExportClosure = ""}
                       old_decls
-              put $ old_state {ffiExportDecls = M.singleton mod_sym new_decls}
+              put
+                ( old_state {ffiExportDecls = M.singleton mod_sym new_decls}
+                , old_us)
               pure
                 t
                   { GHC.fd_fe =
@@ -302,25 +312,29 @@ collectFFISrc ::
   => AsteriusModuleSymbol
   -> GHC.HsParsedModule
   -> FFIMarshalState
-  -> m (GHC.HsParsedModule, FFIMarshalState)
-collectFFISrc mod_sym m ffi_state = pure (m {GHC.hpm_module = new_m}, st)
+  -> GHC.UniqSupply
+  -> m (GHC.HsParsedModule, FFIMarshalState, GHC.UniqSupply)
+collectFFISrc mod_sym m ffi_state old_us =
+  pure (m {GHC.hpm_module = new_m}, st, new_us)
   where
-    (new_m, st) = runState (processFFI mod_sym (GHC.hpm_module m)) ffi_state
+    (new_m, (st, new_us)) =
+      runState (processFFI mod_sym (GHC.hpm_module m)) (ffi_state, old_us)
 
 addFFIProcessor ::
      Compiler
   -> IO (Compiler, AsteriusModuleSymbol -> Prelude.IO AsteriusModule)
 addFFIProcessor c = do
-  ffi_states_ref <- newIORef mempty
+  us <- GHC.mkSplitUniqSupply 'J'
+  ffi_states_ref <- newIORef (mempty, us)
   pure
     ( c
         { patchParsed =
             \mod_summary parsed_mod -> do
               patched_mod <-
                 liftIO $
-                atomicModifyIORef' ffi_states_ref $ \ffi_states ->
+                atomicModifyIORef' ffi_states_ref $ \(ffi_states, old_us) ->
                   let mod_sym = marshalToModuleSymbol $ GHC.ms_mod mod_summary
-                      (patched_mod, ffi_state) =
+                      (patched_mod, ffi_state, new_us) =
                         runIdentity $
                         collectFFISrc
                           mod_sym
@@ -329,7 +343,9 @@ addFFIProcessor c = do
                             { ffiImportDecls = M.insert mod_sym mempty mempty
                             , ffiExportDecls = M.insert mod_sym mempty mempty
                             }
-                   in (M.insert mod_sym ffi_state ffi_states, patched_mod)
+                          old_us
+                   in ( (M.insert mod_sym ffi_state ffi_states, new_us)
+                      , patched_mod)
               patchParsed c mod_summary patched_mod
         , patchTypechecked =
             \mod_summary tc_mod -> do
@@ -366,23 +382,24 @@ addFFIProcessor c = do
                     where
                       go = mconcat $ gmapQ f t
               liftIO $
-                atomicModifyIORef' ffi_states_ref $ \ffi_state ->
-                  ( M.adjust
-                      (\s ->
-                         s
-                           { ffiExportDecls =
-                               M.adjust
-                                 (appEndo $ f $ GHC.tcg_fords tc_mod)
-                                 mod_sym $
-                               ffiExportDecls s
-                           })
-                      mod_sym
-                      ffi_state
+                atomicModifyIORef' ffi_states_ref $ \(ffi_state, old_us) ->
+                  ( ( M.adjust
+                        (\s ->
+                           s
+                             { ffiExportDecls =
+                                 M.adjust
+                                   (appEndo $ f $ GHC.tcg_fords tc_mod)
+                                   mod_sym $
+                                 ffiExportDecls s
+                             })
+                        mod_sym
+                        ffi_state
+                    , old_us)
                   , tc_mod)
         }
     , \mod_sym ->
-        atomicModifyIORef' ffi_states_ref $ \ffi_states ->
-          ( M.delete mod_sym ffi_states
+        atomicModifyIORef' ffi_states_ref $ \(ffi_states, old_us) ->
+          ( (M.delete mod_sym ffi_states, old_us)
           , generateFFIWrapperModule $ ffi_states ! mod_sym))
 
 generateImplicitCastExpression ::

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -281,18 +281,9 @@ genPinnedStaticClosures ::
 genPinnedStaticClosures sym_map export_funcs FFIMarshalState {..} =
   "new Set(" <>
   string7
-    (show (map ((sym_map !) . ffiExportClosure . (export_decls !)) export_funcs)) <>
+    (show
+       (map ((sym_map !) . ffiExportClosure . (ffiExportDecls !)) export_funcs)) <>
   ")"
-  where
-    export_decls =
-      M.foldl'
-        (M.unionWithKey
-           (\k _ _ ->
-              error $
-              "Asterius.Main.genPinnedStaticClosures: conflicted export function " <>
-              show k))
-        M.empty
-        ffiExportDecls
 
 genWasm :: Task -> LBS.ByteString -> Builder
 genWasm Task {..} _ =

--- a/asterius/src/Asterius/Passes/DataSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/DataSymbolTable.hs
@@ -78,7 +78,15 @@ makeMemory AsteriusModule {..} sym_map last_addr =
                    in case static of
                         SymbolStatic sym o ->
                           flush_static_segs $
-                          encodeStorable $ sym_map ! sym + fromIntegral o
+                          encodeStorable $
+                          case Map.lookup sym sym_map of
+                            Just addr -> addr + fromIntegral o
+                            _ ->
+                              error $
+                              "Asterius.Passes.DataSymbolTable.makeMemory: unfound " <>
+                              show sym <>
+                              " in " <>
+                              show statics_sym
                         Uninitialized l ->
                           (static_segs, static_tail_addr - fromIntegral l)
                         Serialized buf -> flush_static_segs buf)

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -86,70 +86,78 @@ mergeSymbols ::
   -> S.Set AsteriusEntitySymbol
   -> (AsteriusModule, LinkReport)
 mergeSymbols debug store_mod root_syms =
-  (final_m, final_rep {bundledFFIMarshalState = ffiMarshalState store_mod})
+  (final_m, final_rep {bundledFFIMarshalState = ffi_this})
   where
+    ffi_all = ffiMarshalState store_mod
+    ffi_this =
+      ffi_all
+        { ffiImportDecls =
+            flip LM.filterWithKey (ffiImportDecls ffi_all) $ \k _ ->
+              (k <> "_wrapper") `LM.member` functionMap store_mod
+        }
     (_, _, final_rep, final_m) = go (root_syms, S.empty, mempty, mempty)
     go i@(i_staging_syms, _, _, _)
       | S.null i_staging_syms = i
       | otherwise = go $ iter i
     iter (i_staging_syms, i_acc_syms, i_rep, i_m) =
-      let o_acc_syms = i_staging_syms <> i_acc_syms
-          (o_unavailable_syms, i_child_syms, o_m) =
-            S.foldr'
-              (\i_staging_sym (i_unavailable_syms_acc, i_child_syms_acc, o_m_acc) ->
-                 case LM.lookup i_staging_sym (staticsMap store_mod) of
-                   Just ss ->
-                     ( i_unavailable_syms_acc
-                     , collectAsteriusEntitySymbols ss i_child_syms_acc
-                     , o_m_acc
-                         { staticsMap =
-                             LM.insert i_staging_sym ss (staticsMap o_m_acc)
-                         })
-                   _ ->
-                     case LM.lookup i_staging_sym (functionMap store_mod) of
-                       Just func ->
+      (o_staging_syms, o_acc_syms, o_rep, o_m)
+      where
+        o_acc_syms = i_staging_syms <> i_acc_syms
+        (o_unavailable_syms, i_child_syms, o_m) =
+          S.foldr'
+            (\i_staging_sym (i_unavailable_syms_acc, i_child_syms_acc, o_m_acc) ->
+               case LM.lookup i_staging_sym (staticsMap store_mod) of
+                 Just ss ->
+                   ( i_unavailable_syms_acc
+                   , collectAsteriusEntitySymbols ss i_child_syms_acc
+                   , o_m_acc
+                       { staticsMap =
+                           LM.insert i_staging_sym ss (staticsMap o_m_acc)
+                       })
+                 _ ->
+                   case LM.lookup i_staging_sym (functionMap store_mod) of
+                     Just func ->
+                       ( i_unavailable_syms_acc
+                       , collectAsteriusEntitySymbols func i_child_syms_acc
+                       , o_m_acc
+                           { functionMap =
+                               LM.insert
+                                 i_staging_sym
+                                 func
+                                 (functionMap o_m_acc)
+                           })
+                     _
+                       | LM.member i_staging_sym (functionErrorMap store_mod) ->
                          ( i_unavailable_syms_acc
-                         , collectAsteriusEntitySymbols func i_child_syms_acc
+                         , i_child_syms_acc
                          , o_m_acc
                              { functionMap =
                                  LM.insert
                                    i_staging_sym
-                                   func
+                                   AsteriusFunction
+                                     { functionType =
+                                         FunctionType
+                                           { paramTypes = []
+                                           , returnTypes = [I64]
+                                           }
+                                     , body =
+                                         emitErrorMessage [I64] $
+                                         entityName i_staging_sym <>
+                                         " failed: it was marked as broken by code generator, with error message: " <>
+                                         showSBS
+                                           (functionErrorMap store_mod !
+                                            i_staging_sym)
+                                     }
                                    (functionMap o_m_acc)
                              })
-                       _
-                         | LM.member i_staging_sym (functionErrorMap store_mod) ->
-                           ( i_unavailable_syms_acc
-                           , i_child_syms_acc
-                           , o_m_acc
-                               { functionMap =
-                                   LM.insert
-                                     i_staging_sym
-                                     AsteriusFunction
-                                       { functionType =
-                                           FunctionType
-                                             { paramTypes = []
-                                             , returnTypes = [I64]
-                                             }
-                                       , body =
-                                           emitErrorMessage [I64] $
-                                           entityName i_staging_sym <>
-                                           " failed: it was marked as broken by code generator, with error message: " <>
-                                           showSBS
-                                             (functionErrorMap store_mod !
-                                              i_staging_sym)
-                                       }
-                                     (functionMap o_m_acc)
-                               })
-                         | otherwise ->
-                           ( S.insert i_staging_sym i_unavailable_syms_acc
-                           , i_child_syms_acc
-                           , o_m_acc))
-              (unavailableSymbols i_rep, S.empty, i_m)
-              i_staging_syms
-          o_rep = i_rep {unavailableSymbols = o_unavailable_syms}
-          o_staging_syms = i_child_syms `S.difference` o_acc_syms
-       in (o_staging_syms, o_acc_syms, o_rep, o_m)
+                       | otherwise ->
+                         ( S.insert i_staging_sym i_unavailable_syms_acc
+                         , i_child_syms_acc
+                         , o_m_acc))
+            (unavailableSymbols i_rep, S.empty, i_m)
+            i_staging_syms
+        o_rep = i_rep {unavailableSymbols = o_unavailable_syms}
+        o_staging_syms = i_child_syms `S.difference` o_acc_syms
 
 makeInfoTableSet ::
      AsteriusModule -> LM.Map AsteriusEntitySymbol Int64 -> S.Set Int64

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -93,7 +93,7 @@ mergeSymbols debug store_mod root_syms =
       ffi_all
         { ffiImportDecls =
             flip LM.filterWithKey (ffiImportDecls ffi_all) $ \k _ ->
-              (k <> "_wrapper") `LM.member` functionMap store_mod
+              (k <> "_wrapper") `LM.member` functionMap final_m
         }
     (_, _, final_rep, final_m) = go (root_syms, S.empty, mempty, mempty)
     go i@(i_staging_syms, _, _, _)

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -532,7 +532,7 @@ instance Binary FFIExportDecl
 
 data FFIMarshalState = FFIMarshalState
   { ffiImportDecls :: LM.Map AsteriusEntitySymbol FFIImportDecl
-  , ffiExportDecls :: LM.Map AsteriusModuleSymbol (LM.Map AsteriusEntitySymbol FFIExportDecl)
+  , ffiExportDecls :: LM.Map AsteriusEntitySymbol FFIExportDecl
   } deriving (Eq, Show, Data)
 
 instance Semigroup FFIMarshalState where

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -148,7 +148,7 @@ instance Binary AsteriusModuleSymbol
 
 newtype AsteriusEntitySymbol = AsteriusEntitySymbol
   { entityName :: SBS.ShortByteString
-  } deriving (Eq, Ord, IsString, Binary)
+  } deriving (Eq, Ord, IsString, Binary, Semigroup)
 
 deriving newtype instance Show AsteriusEntitySymbol
 
@@ -531,7 +531,7 @@ data FFIExportDecl = FFIExportDecl
 instance Binary FFIExportDecl
 
 data FFIMarshalState = FFIMarshalState
-  { ffiImportDecls :: LM.Map (AsteriusModuleSymbol, Int) FFIImportDecl
+  { ffiImportDecls :: LM.Map AsteriusEntitySymbol FFIImportDecl
   , ffiExportDecls :: LM.Map AsteriusModuleSymbol (LM.Map AsteriusEntitySymbol FFIExportDecl)
   } deriving (Eq, Show, Data)
 

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -51,7 +51,6 @@ import Control.Exception
 import Data.Binary
 import qualified Data.ByteString.Short as SBS
 import Data.Data
-import qualified Data.IntMap.Strict as IM
 import qualified Data.Map.Lazy as LM
 import Data.String
 import Foreign
@@ -532,7 +531,7 @@ data FFIExportDecl = FFIExportDecl
 instance Binary FFIExportDecl
 
 data FFIMarshalState = FFIMarshalState
-  { ffiImportDecls :: LM.Map AsteriusModuleSymbol (IM.IntMap FFIImportDecl)
+  { ffiImportDecls :: LM.Map (AsteriusModuleSymbol, Int) FFIImportDecl
   , ffiExportDecls :: LM.Map AsteriusModuleSymbol (LM.Map AsteriusEntitySymbol FFIExportDecl)
   } deriving (Eq, Show, Data)
 


### PR DESCRIPTION
Besides tracking liveness of data segments and functions, the linker also tracks JSFFI imports/exports. Previously, when chasing dependencies, whenever a module was touched, all its JSFFI declarations are included. This is a simple coarse-grained approach proved to work.

Recently we did quite some improvements in the linker (#84) and as a result, all JSFFI declarations of every single module in boot libs and user code is included, which bloats the import/export sections of wasm code and the companion js module. This PR properly implements the filter to exclude unneeded JSFFI declarations from the linker result.