### PR TITLE
Wip merge symbol offset

### DIFF
--- a/asterius/src/Asterius/Passes/All.hs
+++ b/asterius/src/Asterius/Passes/All.hs
@@ -10,6 +10,7 @@ import Asterius.Passes.Common
 import Asterius.Passes.Events
 import Asterius.Passes.GlobalRegs
 import Asterius.Passes.LocalRegs
+import Asterius.Passes.MergeSymbolOffset
 import Asterius.Passes.Relooper
 import Asterius.Passes.ResolveSymbols
 import Asterius.Types
@@ -41,4 +42,5 @@ allPasses debug sym_map export_funcs whoami ft event_map t =
       relooperShallow <=<
       resolveLocalRegs ft <=<
       resolveSymbols sym_map <=<
+      mergeSymbolOffset <=<
       maskUnknownCCallTargets whoami export_funcs <=< resolveGlobalRegs

--- a/asterius/src/Asterius/Passes/MergeSymbolOffset.hs
+++ b/asterius/src/Asterius/Passes/MergeSymbolOffset.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Asterius.Passes.MergeSymbolOffset
+  ( mergeSymbolOffset
+  ) where
+
+import Asterius.Internals.SYB
+import Asterius.Types
+import Type.Reflection
+
+{-# INLINEABLE mergeSymbolOffset #-}
+mergeSymbolOffset :: Monad m => GenericM m
+mergeSymbolOffset t =
+  pure $
+  case eqTypeRep (typeOf t) (typeRep :: TypeRep Expression) of
+    Just HRefl ->
+      case t of
+        Load {ptr = sym@Symbol {..}, ..} ->
+          Load
+            { signed = signed
+            , bytes = bytes
+            , offset = fromIntegral $ symbolOffset + fromIntegral offset
+            , valueType = valueType
+            , ptr = sym {symbolOffset = 0}
+            }
+        Store {ptr = sym@Symbol {..}, ..} ->
+          Store
+            { bytes = bytes
+            , offset = fromIntegral $ symbolOffset + fromIntegral offset
+            , ptr = sym {symbolOffset = 0}
+            , value = value
+            , valueType = valueType
+            }
+        _ -> t
+    _ -> t


### PR DESCRIPTION
This PR adds a rewriting pass for load/store instructions: when the address is a symbol (with offset), we set the symbol offset to 0 and merge it into the outer load/store offset. This improves debug logs since more symbols can be re-discovered when looking up a base address in the symbol table.