### PR TITLE
Use imported table for asterius instances

### DIFF
--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -22,6 +22,7 @@ export function newAsteriusInstance(req) {
   let __asterius_logger = new EventLogManager(req.symbolTable),
     __asterius_tracer = new Tracer(__asterius_logger, req.symbolTable),
     __asterius_wasm_instance = null,
+    __asterius_wasm_table = new WebAssembly.Table({element: "anyfunc", initial: req.tableSlots}),
     __asterius_wasm_memory = new WebAssembly.Memory({initial: req.staticMBlocks * (settings.mblock_size / 65536)}),
     __asterius_memory = new Memory(),
     __asterius_memory_trap = new MemoryTrap(__asterius_logger, req.symbolTable),
@@ -108,6 +109,9 @@ export function newAsteriusInstance(req) {
         log: x => Math.log(x),
         exp: x => Math.exp(x),
         pow: (x, y) => Math.pow(x, y)
+      },
+      WasmTable: {
+        table: __asterius_wasm_table
       },
       WasmMemory: {
         memory: __asterius_wasm_memory

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -22,7 +22,7 @@ export function newAsteriusInstance(req) {
   let __asterius_logger = new EventLogManager(req.symbolTable),
     __asterius_tracer = new Tracer(__asterius_logger, req.symbolTable),
     __asterius_wasm_instance = null,
-    __asterius_wasm_memory = new WebAssembly.Memory({initial: req.staticMBlocks * (settings.mblock_size / 65536), maximum: 65536}),
+    __asterius_wasm_memory = new WebAssembly.Memory({initial: req.staticMBlocks * (settings.mblock_size / 65536)}),
     __asterius_memory = new Memory(),
     __asterius_memory_trap = new MemoryTrap(__asterius_logger, req.symbolTable),
     __asterius_mblockalloc = new MBlockAlloc(),

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -896,11 +896,7 @@ stgRun init_f = do
   putLVal f init_f
   loop' [] $ \loop_lbl ->
     if' [] (eqZInt64 (getLVal f)) mempty $ do
-      f' <-
-        callIndirect'
-          (getLVal f `subInt64` constI64 1)
-          []
-          (FunctionType [] [I64])
+      f' <- callIndirect' (getLVal f) [] (FunctionType [] [I64])
       putLVal f f'
       break' loop_lbl Nothing
   pure $ getLVal r1

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -330,6 +330,8 @@ genLib Task {..} LinkReport {..} err_msgs =
       staticsSymbolMap
       exportFunctions
       bundledFFIMarshalState
+  , ", tableSlots: "
+  , intDec tableSlots
   , ", staticMBlocks: "
   , intDec staticMBlocks
   , if sync

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -486,6 +486,10 @@ ahcDistMain task@Task {..} (final_m, err_msgs, report) = do
                c_BinaryenSetShrinkLevel 0
                m_ref <-
                  withPool $ \pool -> OldMarshal.marshalModule pool final_m
+               putStrLn "[INFO] Validating binaryen IR"
+               pass_validation <- c_BinaryenModuleValidate m_ref
+               when (pass_validation /= 1) $
+                 fail "[ERROR] binaryen validation failed"
                m_bin <- LBS.fromStrict <$> OldMarshal.serializeModule m_ref
                putStrLn $
                  "[INFO] Writing WebAssembly binary to " <> show out_wasm

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -227,14 +227,8 @@ resolveAsteriusModule debug has_main bundled_ffi_state export_funcs m_globals_re
         , memorySegments = segs
         , memoryImport =
             MemoryImport
-              { internalName = "__asterius_memory"
-              , externalModuleName = "WasmMemory"
-              , externalBaseName = "memory"
-              , shared = False
-              }
-        , memoryExport =
-            MemoryExport
-              {internalName = "__asterius_memory", externalName = "memory"}
+              {externalModuleName = "WasmMemory", externalBaseName = "memory"}
+        , memoryExport = MemoryExport {externalName = "memory"}
         , memoryMBlocks = initial_mblocks
         }
     err_msgs = eventTable all_event_map

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -51,7 +51,7 @@ data LinkReport = LinkReport
   { unavailableSymbols :: S.Set AsteriusEntitySymbol
   , staticsSymbolMap, functionSymbolMap :: LM.Map AsteriusEntitySymbol Int64
   , infoTableSet :: S.Set Int64
-  , staticMBlocks :: Int
+  , tableSlots, staticMBlocks :: Int
   , bundledFFIMarshalState :: FFIMarshalState
   } deriving (Generic, Show)
 
@@ -64,6 +64,7 @@ instance Semigroup LinkReport where
       , staticsSymbolMap = staticsSymbolMap r0 <> staticsSymbolMap r1
       , functionSymbolMap = functionSymbolMap r0 <> functionSymbolMap r1
       , infoTableSet = infoTableSet r0 <> infoTableSet r1
+      , tableSlots = 0
       , staticMBlocks = 0
       , bundledFFIMarshalState =
           bundledFFIMarshalState r0 <> bundledFFIMarshalState r1
@@ -76,6 +77,7 @@ instance Monoid LinkReport where
       , staticsSymbolMap = mempty
       , functionSymbolMap = mempty
       , infoTableSet = mempty
+      , tableSlots = 0
       , staticMBlocks = 0
       , bundledFFIMarshalState = mempty
       }
@@ -177,14 +179,16 @@ resolveAsteriusModule ::
      , LM.Map AsteriusEntitySymbol Int64
      , LM.Map AsteriusEntitySymbol Int64
      , [Event]
+     , Int
      , Int)
 resolveAsteriusModule debug has_main bundled_ffi_state export_funcs m_globals_resolved func_start_addr data_start_addr =
-  (new_mod, ss_sym_map, func_sym_map, err_msgs, initial_mblocks)
+  (new_mod, ss_sym_map, func_sym_map, err_msgs, table_slots, initial_mblocks)
   where
-    (func_sym_map, _) =
+    (func_sym_map, last_func_addr) =
       makeFunctionSymbolTable m_globals_resolved func_start_addr
-    func_table = makeFunctionTable func_sym_map
-    (ss_sym_map, last_addr) =
+    table_slots = fromIntegral $ last_func_addr .&. 0xFFFFFFFF
+    func_table = makeFunctionTable func_sym_map func_start_addr
+    (ss_sym_map, last_data_addr) =
       makeDataSymbolTable m_globals_resolved data_start_addr
     all_sym_map = func_sym_map <> ss_sym_map
     func_imports =
@@ -210,7 +214,8 @@ resolveAsteriusModule debug has_main bundled_ffi_state export_funcs m_globals_re
                   , body = body_locals_resolved
                   }
               , event_map')
-    (initial_pages, segs) = makeMemory m_globals_resolved all_sym_map last_addr
+    (initial_pages, segs) =
+      makeMemory m_globals_resolved all_sym_map last_data_addr
     initial_mblocks =
       fromIntegral initial_pages `quot` (mblock_size `quot` wasmPageSize)
     new_mod =
@@ -224,6 +229,11 @@ resolveAsteriusModule debug has_main bundled_ffi_state export_funcs m_globals_re
             | k <- map entityName export_funcs
             ]
         , functionTable = func_table
+        , tableImport =
+            TableImport
+              {externalModuleName = "WasmTable", externalBaseName = "table"}
+        , tableExport = TableExport {externalName = "table"}
+        , tableSlots = table_slots
         , memorySegments = segs
         , memoryImport =
             MemoryImport
@@ -247,6 +257,7 @@ linkStart debug has_main store root_syms export_funcs =
       { staticsSymbolMap = ss_sym_map
       , functionSymbolMap = func_sym_map
       , infoTableSet = makeInfoTableSet merged_m ss_sym_map
+      , Asterius.Resolve.tableSlots = tbl_slots
       , staticMBlocks = static_mbs
       })
   where
@@ -260,7 +271,7 @@ linkStart debug has_main store root_syms export_funcs =
              {entityName = "__asterius_jsffi_export_" <> entityName k}
            | k <- export_funcs
            ])
-    (result_m, ss_sym_map, func_sym_map, err_msgs, static_mbs) =
+    (result_m, ss_sym_map, func_sym_map, err_msgs, tbl_slots, static_mbs) =
       resolveAsteriusModule
         debug
         has_main

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -28,8 +28,10 @@ module Asterius.Types
   , Expression(..)
   , Function(..)
   , FunctionImport(..)
+  , TableImport(..)
   , MemoryImport(..)
   , FunctionExport(..)
+  , TableExport(..)
   , MemoryExport(..)
   , FunctionTable(..)
   , DataSegment(..)
@@ -425,6 +427,12 @@ data FunctionImport = FunctionImport
 
 instance Binary FunctionImport
 
+data TableImport = TableImport
+  { externalModuleName, externalBaseName :: SBS.ShortByteString
+  } deriving (Eq, Show, Data, Generic)
+
+instance Binary TableImport
+
 data MemoryImport = MemoryImport
   { externalModuleName, externalBaseName :: SBS.ShortByteString
   } deriving (Eq, Show, Data, Generic)
@@ -437,6 +445,12 @@ data FunctionExport = FunctionExport
 
 instance Binary FunctionExport
 
+newtype TableExport = TableExport
+  { externalName :: SBS.ShortByteString
+  } deriving (Eq, Show, Data, Generic)
+
+instance Binary TableExport
+
 newtype MemoryExport = MemoryExport
   { externalName :: SBS.ShortByteString
   } deriving (Eq, Show, Data, Generic)
@@ -444,8 +458,8 @@ newtype MemoryExport = MemoryExport
 instance Binary MemoryExport
 
 data FunctionTable = FunctionTable
-  { functionNames :: [SBS.ShortByteString]
-  , tableExportName :: SBS.ShortByteString
+  { tableFunctionNames :: [SBS.ShortByteString]
+  , tableOffset :: BinaryenIndex
   } deriving (Eq, Show, Data, Generic)
 
 instance Binary FunctionTable
@@ -462,6 +476,9 @@ data Module = Module
   , functionImports :: [FunctionImport]
   , functionExports :: [FunctionExport]
   , functionTable :: FunctionTable
+  , tableImport :: TableImport
+  , tableExport :: TableExport
+  , tableSlots :: Int
   , memorySegments :: [DataSegment]
   , memoryImport :: MemoryImport
   , memoryExport :: MemoryExport

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -426,8 +426,7 @@ data FunctionImport = FunctionImport
 instance Binary FunctionImport
 
 data MemoryImport = MemoryImport
-  { internalName, externalModuleName, externalBaseName :: SBS.ShortByteString
-  , shared :: Bool
+  { externalModuleName, externalBaseName :: SBS.ShortByteString
   } deriving (Eq, Show, Data, Generic)
 
 instance Binary MemoryImport
@@ -438,8 +437,8 @@ data FunctionExport = FunctionExport
 
 instance Binary FunctionExport
 
-data MemoryExport = MemoryExport
-  { internalName, externalName :: SBS.ShortByteString
+newtype MemoryExport = MemoryExport
+  { externalName :: SBS.ShortByteString
   } deriving (Eq, Show, Data, Generic)
 
 instance Binary MemoryExport

--- a/binaryen/binaryen/src/binaryen-c.cpp
+++ b/binaryen/binaryen/src/binaryen-c.cpp
@@ -2423,15 +2423,6 @@ void BinaryenSetMemory(BinaryenModuleRef module, BinaryenIndex initial, Binaryen
   }
 }
 
-void BinaryenAddSegments(BinaryenModuleRef module, const char** segments,
-  BinaryenExpressionRef* segmentOffsets, BinaryenIndex* segmentSizes, BinaryenIndex numSegments) {
-  auto* wasm = (Module*)module;
-  for (BinaryenIndex i = 0; i < numSegments; i++) {
-    wasm->memory.segments.emplace_back(
-      (Expression*)segmentOffsets[i], segments[i], segmentSizes[i]);
-  }
-}
-
 // Start function. One per module
 
 void BinaryenSetStart(BinaryenModuleRef module, BinaryenFunctionRef start) {

--- a/binaryen/binaryen/src/binaryen-c.cpp
+++ b/binaryen/binaryen/src/binaryen-c.cpp
@@ -2342,7 +2342,12 @@ void BinaryenRemoveExport(BinaryenModuleRef module, const char* externalName) {
 
 // Function table. One per module
 
-void BinaryenSetFunctionTable(BinaryenModuleRef module, BinaryenIndex initial, BinaryenIndex maximum, const char** funcNames, BinaryenIndex numFuncNames) {
+void BinaryenSetFunctionTable(BinaryenModuleRef module, BinaryenIndex initial,
+  BinaryenIndex maximum, const char** funcNames, BinaryenIndex numFuncNames) {
+  BinaryenSetFunctionTableWithOffset(module, initial, maximum, 0, funcNames, numFuncNames);
+}
+
+void BinaryenSetFunctionTableWithOffset(BinaryenModuleRef module, BinaryenIndex initial, BinaryenIndex maximum, BinaryenIndex offset, const char** funcNames, BinaryenIndex numFuncNames) {
   if (tracing) {
     std::cout << "  {\n";
     std::cout << "    const char* funcNames[] = { ";
@@ -2356,7 +2361,7 @@ void BinaryenSetFunctionTable(BinaryenModuleRef module, BinaryenIndex initial, B
   }
 
   auto* wasm = (Module*)module;
-  Table::Segment segment(wasm->allocator.alloc<Const>()->set(Literal(int32_t(0))));
+  Table::Segment segment(wasm->allocator.alloc<Const>()->set(Literal(int32_t(offset))));
   for (BinaryenIndex i = 0; i < numFuncNames; i++) {
     segment.data.push_back(funcNames[i]);
   }

--- a/binaryen/binaryen/src/binaryen-c.h
+++ b/binaryen/binaryen/src/binaryen-c.h
@@ -748,6 +748,8 @@ void BinaryenRemoveGlobal(BinaryenModuleRef module, const char* name);
 
 void BinaryenSetFunctionTable(BinaryenModuleRef module, BinaryenIndex initial, BinaryenIndex maximum, const char** funcNames, BinaryenIndex numFuncNames);
 
+void BinaryenSetFunctionTableWithOffset(BinaryenModuleRef module, BinaryenIndex initial, BinaryenIndex maximum, BinaryenIndex offset, const char** funcNames, BinaryenIndex numFuncNames);
+
 // Memory. One per module
 
 // Each segment has data in segments, a start offset in segmentOffsets, and a size in segmentSizes.

--- a/binaryen/binaryen/src/binaryen-c.h
+++ b/binaryen/binaryen/src/binaryen-c.h
@@ -754,8 +754,6 @@ void BinaryenSetFunctionTable(BinaryenModuleRef module, BinaryenIndex initial, B
 // exportName can be NULL
 void BinaryenSetMemory(BinaryenModuleRef module, BinaryenIndex initial, BinaryenIndex maximum, const char* exportName, const char** segments, BinaryenExpressionRef* segmentOffsets, BinaryenIndex* segmentSizes, BinaryenIndex numSegments, uint8_t shared);
 
-void BinaryenAddSegments(BinaryenModuleRef module, const char** segments, BinaryenExpressionRef* segmentOffsets, BinaryenIndex* segmentSizes, BinaryenIndex numSegments);
-
 // Start function. One per module
 
 void BinaryenSetStart(BinaryenModuleRef module, BinaryenFunctionRef start);

--- a/binaryen/src/Bindings/Binaryen/Raw.hs
+++ b/binaryen/src/Bindings/Binaryen/Raw.hs
@@ -1600,6 +1600,12 @@ foreign import ccall unsafe "BinaryenSetFunctionTable" c_BinaryenSetFunctionTabl
   BinaryenIndex ->
     BinaryenIndex -> Ptr (Ptr CChar) -> BinaryenIndex -> IO ()
 
+foreign import ccall unsafe "BinaryenSetFunctionTableWithOffset" c_BinaryenSetFunctionTableWithOffset
+  :: BinaryenModuleRef ->
+  BinaryenIndex ->
+    BinaryenIndex ->
+      BinaryenIndex -> Ptr (Ptr CChar) -> BinaryenIndex -> IO ()
+
 foreign import ccall unsafe "BinaryenSetMemory" c_BinaryenSetMemory
   :: BinaryenModuleRef ->
   BinaryenIndex ->

--- a/binaryen/src/Bindings/Binaryen/Raw.hs
+++ b/binaryen/src/Bindings/Binaryen/Raw.hs
@@ -1609,12 +1609,6 @@ foreign import ccall unsafe "BinaryenSetMemory" c_BinaryenSetMemory
           Ptr BinaryenExpressionRef ->
             Ptr BinaryenIndex -> BinaryenIndex -> Word8 -> IO ()
 
-foreign import ccall unsafe "BinaryenAddSegments" c_BinaryenAddSegments
-  :: BinaryenModuleRef ->
-  Ptr (Ptr CChar) ->
-    Ptr BinaryenExpressionRef ->
-      Ptr BinaryenIndex -> BinaryenIndex -> IO ()
-
 foreign import ccall unsafe "BinaryenSetStart" c_BinaryenSetStart
   :: BinaryenModuleRef -> BinaryenFunctionRef -> IO ()
 


### PR DESCRIPTION
Relevant: #54 

Like #90, but done for tables. Also removed a previous binaryen hack and fixed binaryen validation.

Besides the need of dynamic linking from TH/GHCi, an additional benefit for importing table from js: it's easier to play with wasm's reference types proposal; we only need to set `{element: "anyref"}` when creating a table in js, without changing wasm-toolkit/binaryen logic. This is already supported in recent V8 revisions.