### PR TITLE
Make dead code elimination optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
             stack --no-terminal test asterius:bigint
             stack --no-terminal test asterius:todomvc
             stack --no-terminal test asterius:cloudflare
-            stack --no-terminal test asterius:fib --test-arguments="--binaryen"
+            stack --no-terminal test asterius:fib --test-arguments="--binaryen --no-gc-sections"
             stack --no-terminal test asterius:fib --test-arguments="--sync"
             stack --no-terminal test asterius:fib --test-arguments="--debug" > /dev/null
             stack --no-terminal test asterius:jsffi --test-arguments="--debug" > /dev/null

--- a/asterius/app/ahc-ld.hs
+++ b/asterius/app/ahc-ld.hs
@@ -16,6 +16,7 @@ parseLinkTask args = do
       , linkObjs = link_objs
       , linkLibs = link_libs
       , debug = "--debug" `elem` args
+      , gcSections = "--no-gc-sections" `notElem` args
       , rootSymbols =
           map (AsteriusEntitySymbol . fromString) $
           str_args "--extra-root-symbol="

--- a/asterius/src/Asterius/Internals/MagicNumber.hs
+++ b/asterius/src/Asterius/Internals/MagicNumber.hs
@@ -1,13 +1,14 @@
-{-# OPTIONS_GHC -Wno-overflowed-literals #-}
-
 module Asterius.Internals.MagicNumber
   ( dataTag
   , functionTag
+  , invalidAddress
   ) where
 
 import Data.Int
 
-dataTag, functionTag :: Int64
+dataTag, functionTag, invalidAddress :: Int64
 dataTag = 2097143
 
 functionTag = 2097133
+
+invalidAddress = 0x1fffffffff0000

--- a/asterius/src/Asterius/Ld.hs
+++ b/asterius/src/Asterius/Ld.hs
@@ -23,7 +23,7 @@ import Prelude hiding (IO)
 data LinkTask = LinkTask
   { linkOutput :: FilePath
   , linkObjs, linkLibs :: [FilePath]
-  , debug :: Bool
+  , debug, gcSections :: Bool
   , rootSymbols, exportFunctions :: [AsteriusEntitySymbol]
   } deriving (Show)
 
@@ -65,6 +65,7 @@ linkExe ld_task@LinkTask {..} = do
         linkStart
           debug
           True
+          gcSections
           final_store
           (Set.unions
              [ Set.fromList rootSymbols

--- a/asterius/src/Asterius/Ld.hs
+++ b/asterius/src/Asterius/Ld.hs
@@ -57,7 +57,10 @@ rtsUsedSymbols =
 
 linkExe :: LinkTask -> IO ()
 linkExe ld_task@LinkTask {..} = do
-  final_store <- loadTheWorld defaultBuiltinsOptions ld_task
+  final_store <-
+    loadTheWorld
+      defaultBuiltinsOptions {Asterius.Builtins.debug = debug}
+      ld_task
   let ld_result =
         linkStart
           debug

--- a/asterius/src/Asterius/Passes/DataSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/DataSymbolTable.hs
@@ -8,6 +8,7 @@ module Asterius.Passes.DataSymbolTable
   ) where
 
 import Asterius.Internals
+import Asterius.Internals.MagicNumber
 import Asterius.Types
 import Data.Bits
 import qualified Data.ByteString.Short as SBS
@@ -78,12 +79,7 @@ makeMemory AsteriusModule {..} sym_map last_addr =
                       encodeStorable $
                       case Map.lookup sym sym_map of
                         Just addr -> addr + fromIntegral o
-                        _ ->
-                          error $
-                          "Asterius.Passes.DataSymbolTable.makeMemory: unfound " <>
-                          show sym <>
-                          " in " <>
-                          show statics_sym
+                        _ -> invalidAddress
                     Uninitialized l ->
                       (static_segs, static_tail_addr - fromIntegral l)
                     Serialized buf -> flush_static_segs buf)

--- a/asterius/src/Asterius/Passes/GlobalRegs.hs
+++ b/asterius/src/Asterius/Passes/GlobalRegs.hs
@@ -32,7 +32,7 @@ resolveGlobalRegs t =
               where (b, o, vt) = globalRegInfo unresolvedGlobalReg
         UnresolvedSetGlobal {..} ->
           case unresolvedGlobalReg of
-            BaseReg -> error "Asterius.Passes.GlobalRegs: Assignment to BaseReg"
+            BaseReg -> Nop
             _ ->
               Store
                 { bytes = b

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -84,11 +84,13 @@ instance Monoid LinkReport where
 
 mergeSymbols ::
      Bool
+  -> Bool
   -> AsteriusModule
   -> S.Set AsteriusEntitySymbol
   -> (AsteriusModule, LinkReport)
-mergeSymbols debug store_mod root_syms =
-  (store_mod, final_rep {bundledFFIMarshalState = ffi_all})
+mergeSymbols debug gc_sections store_mod root_syms
+  | not gc_sections = (store_mod, final_rep {bundledFFIMarshalState = ffi_all})
+  | otherwise = (final_m, mempty {bundledFFIMarshalState = ffi_this})
   where
     ffi_all = ffiMarshalState store_mod
     ffi_this =
@@ -222,11 +224,12 @@ resolveAsteriusModule debug has_main bundled_ffi_state export_funcs m_globals_re
 linkStart ::
      Bool
   -> Bool
+  -> Bool
   -> AsteriusModule
   -> S.Set AsteriusEntitySymbol
   -> [AsteriusEntitySymbol]
   -> (Module, [Event], LinkReport)
-linkStart debug has_main store root_syms export_funcs =
+linkStart debug has_main gc_sections store root_syms export_funcs =
   ( result_m
   , err_msgs
   , report
@@ -240,6 +243,7 @@ linkStart debug has_main store root_syms export_funcs =
     (merged_m, report) =
       mergeSymbols
         debug
+        gc_sections
         store
         (root_syms <>
          S.fromList

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -88,7 +88,7 @@ mergeSymbols ::
   -> S.Set AsteriusEntitySymbol
   -> (AsteriusModule, LinkReport)
 mergeSymbols debug store_mod root_syms =
-  (final_m, final_rep {bundledFFIMarshalState = ffi_this})
+  (store_mod, final_rep {bundledFFIMarshalState = ffi_all})
   where
     ffi_all = ffiMarshalState store_mod
     ffi_this =

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -128,34 +128,10 @@ mergeSymbols debug store_mod root_syms =
                                  func
                                  (functionMap o_m_acc)
                            })
-                     _
-                       | LM.member i_staging_sym (functionErrorMap store_mod) ->
-                         ( i_unavailable_syms_acc
-                         , i_child_syms_acc
-                         , o_m_acc
-                             { functionMap =
-                                 LM.insert
-                                   i_staging_sym
-                                   AsteriusFunction
-                                     { functionType =
-                                         FunctionType
-                                           { paramTypes = []
-                                           , returnTypes = [I64]
-                                           }
-                                     , body =
-                                         emitErrorMessage [I64] $
-                                         entityName i_staging_sym <>
-                                         " failed: it was marked as broken by code generator, with error message: " <>
-                                         showSBS
-                                           (functionErrorMap store_mod !
-                                            i_staging_sym)
-                                     }
-                                   (functionMap o_m_acc)
-                             })
-                       | otherwise ->
-                         ( S.insert i_staging_sym i_unavailable_syms_acc
-                         , i_child_syms_acc
-                         , o_m_acc))
+                     _ ->
+                       ( S.insert i_staging_sym i_unavailable_syms_acc
+                       , i_child_syms_acc
+                       , o_m_acc))
             (unavailableSymbols i_rep, S.empty, i_m)
             i_staging_syms
         o_rep = i_rep {unavailableSymbols = o_unavailable_syms}

--- a/docs/ahc-link.md
+++ b/docs/ahc-link.md
@@ -88,6 +88,10 @@ Switch on the debug mode. Emits a ton of event logs suitable for piping to `grep
 
 Contain the full symbol table into `xx.lib.mjs`. Automatically implied by `--debug`.
 
+### `--no-gc-sections`
+
+Do not run dead code elimination.
+
 ## Options affecting the linker
 
 ### `--export-function ARG`


### PR DESCRIPTION
Relevant: #54 

This PR adds a `--no-gc-sections` switch to `ahc-link`/`ahc-ld` which makes it possible to switch off dead code elimination. This is beneficial for our current work in TH.

Also fixes a previous bug which renders the bytestring cbits functions unusable due to conflicting import/wrapper symbol clashes.