### PR TITLE
Uniform `binaryen` build script for all platforms

### DIFF
--- a/binaryen/Setup.hs
+++ b/binaryen/Setup.hs
@@ -1,22 +1,19 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wall #-}
 
+import Ar
 import Data.Foldable
 import Distribution.Simple
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.Program
 import Distribution.Simple.Setup
+import Distribution.System
 import Distribution.Types.BuildInfo
 import Distribution.Types.GenericPackageDescription
 import Distribution.Types.PackageDescription
 import Distribution.Verbosity
 import System.Directory
 import System.FilePath
-
-#if defined(darwin_HOST_OS)
-import Ar
-#endif
 
 main :: IO ()
 main =
@@ -34,10 +31,11 @@ main =
                   absoluteInstallDirs pkg_descr lbi NoCopyDest
                 binaryen_libdir = libdir binaryen_installdirs
                 binaryen_bindir = bindir binaryen_installdirs
-                run' prog args stdin_s = runProgramInvocation
-                                         normal
-                                         (simpleProgramInvocation prog args)
-                                           {progInvokeInput = Just stdin_s}
+                run' prog args stdin_s =
+                  runProgramInvocation
+                    normal
+                    (simpleProgramInvocation prog args)
+                      {progInvokeInput = Just stdin_s}
                 run prog args stdin_s =
                   let Just conf_prog = lookupProgram prog (withPrograms lbi)
                    in runProgramInvocation
@@ -46,11 +44,7 @@ main =
                            (configVerbosity (configFlags lbi)))
                         (programInvocation conf_prog args)
                           {progInvokeInput = Just stdin_s}
-            for_
-              [ binaryen_builddir
-              , binaryen_libdir
-              , binaryen_bindir
-              ] $
+            for_ [binaryen_builddir, binaryen_libdir, binaryen_bindir] $
               createDirectoryIfMissing True
             withCurrentDirectory binaryen_builddir $
               for_
@@ -63,26 +57,15 @@ main =
                 , ["--build", binaryen_builddir]
                 ] $ \args -> run (simpleProgram "cmake") args ""
             binaryen_libs <- listDirectory $ binaryen_builddir </> "lib"
-#if defined(darwin_HOST_OS)
             let output_fn = binaryen_libdir </> "libHSbinaryen-binaryen.a"
-                archives = [ binaryen_builddir </> "lib" </> l
-                           | l <- binaryen_libs ]
-            ar <- foldl mappend <$> mapM loadAr archives
-            writeBSDAr output_fn $ afilter (not . isBSDSymdef) ar
+                archives =
+                  [binaryen_builddir </> "lib" </> l | l <- binaryen_libs]
+                (write_ar, is_symdef)
+                  | buildOS == OSX = (writeBSDAr, isBSDSymdef)
+                  | otherwise = (writeGNUAr, isGNUSymdef)
+            ar <- foldlM (\acc p -> (<> acc) <$> loadAr p) mempty archives
+            write_ar output_fn $ afilter (not . is_symdef) ar
             run' "ranlib" [output_fn] ""
-#else
-            run arProgram ["-M"] $
-              concat $
-              [ "create " ++
-                binaryen_libdir </> "libHSbinaryen-binaryen.a" ++ "\n"
-              ] ++
-              [ "addlib " ++ binaryen_builddir </> "lib" </> l ++ "\n"
-              | l <- binaryen_libs
-              ] ++
-              [ "save\n"
-              , "end\n"
-              ]
-#endif
             binaryen_bins <- listDirectory $ binaryen_builddir </> "bin"
             for_ binaryen_bins $ \b ->
               copyFile

--- a/binaryen/package.yaml
+++ b/binaryen/package.yaml
@@ -19,11 +19,6 @@ custom-setup:
     - Cabal
     - directory
     - filepath
-    # we need ghc technically only on macOS
-    # to work around the lack of MRI scripts
-    # via -M support of the `ar` that's
-    # shipped with macOS.  We here rely in
-    # GHC's built in Ar.
     - ghc
 
 ghc-options: -Wall


### PR DESCRIPTION
This PR extends #55 to improve `binaryen` build script, uniformly uses `Ar` instead of `ar -M` on all platforms. Also gets rid of CPP usage in `Setup.hs` and solves a Cabal warning on non-macOS platforms.