### PR TITLE
Change Cmm function sigs to `[] -> []` and implement tail call opcodes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
             stack --no-terminal test asterius:bigint
             stack --no-terminal test asterius:todomvc
             stack --no-terminal test asterius:cloudflare
+            stack --no-terminal test asterius:fib --test-arguments="--tail-calls"
             stack --no-terminal test asterius:fib --test-arguments="--binaryen --no-gc-sections"
             stack --no-terminal test asterius:fib --test-arguments="--sync"
             stack --no-terminal test asterius:fib --test-arguments="--debug" > /dev/null

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ jobs:
             stack --no-terminal test asterius:bigint
             stack --no-terminal test asterius:todomvc
             stack --no-terminal test asterius:cloudflare
-            stack --no-terminal test asterius:fib --test-arguments="--tail-calls"
             stack --no-terminal test asterius:fib --test-arguments="--binaryen --no-gc-sections"
             stack --no-terminal test asterius:fib --test-arguments="--sync"
             stack --no-terminal test asterius:fib --test-arguments="--debug" > /dev/null
@@ -72,6 +71,11 @@ jobs:
             stack --no-terminal test asterius:teletype --test-arguments="--debug" > /dev/null
             # stack --no-terminal test asterius:bytearray --test-arguments="--debug" > /dev/null
             stack --no-terminal test asterius:bigint --test-arguments="--debug" > /dev/null
+
+            cd ~/.local
+            $CIRCLE_WORKING_DIRECTORY/utils/v8-node.py
+            cd $CIRCLE_WORKING_DIRECTORY
+            stack --no-terminal test asterius:fib --test-arguments="--tail-calls"
 
   asterius-build-docker:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
             stack --no-terminal test asterius:bigint
             stack --no-terminal test asterius:todomvc
             stack --no-terminal test asterius:cloudflare
+            stack --no-terminal test asterius:fib --test-arguments="--no-gc-sections"
             stack --no-terminal test asterius:fib --test-arguments="--binaryen --no-gc-sections"
             stack --no-terminal test asterius:fib --test-arguments="--sync"
             stack --no-terminal test asterius:fib --test-arguments="--debug" > /dev/null
@@ -76,6 +77,7 @@ jobs:
             $CIRCLE_WORKING_DIRECTORY/utils/v8-node.py
             cd $CIRCLE_WORKING_DIRECTORY
             stack --no-terminal test asterius:fib --test-arguments="--tail-calls"
+            stack --no-terminal test asterius:fib --test-arguments="--tail-calls --no-gc-sections"
 
   asterius-build-docker:
     docker:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ What works currently:
 * Complete [`binaryen`](https://github.com/WebAssembly/binaryen)/[`wabt`](https://github.com/WebAssembly/wabt) raw bindings, plus a monadic EDSL to construct WebAssembly code directly in Haskell.
 * A Haskell library to handle WebAssembly code, which already powers binary code generation.
 * Unit tests implementing stochastic fuzzer/shrinker for WebAssembly, in order to produce minimal repro in case something goes wrong in generated code.
-* Besides WebAssembly MVP and `BigInt`, no special requirements on the underlying JavaScript engine at the moment.
+* Besides WebAssembly MVP and `BigInt`, no special requirements on the underlying JavaScript engine at the moment. Optionally, we emit binaries using the experimental tail call opcodes; see the `ahc-link` documentation page for details.
 
 Better check the [`fib`](asterius/test/fib/fib.hs), [`jsffi`](asterius/test/jsffi/jsffi.hs), [`array`](asterius/test/array/array.hs), [`rtsapi`](asterius/test/rtsapi.hs) and [`teletype`](asterius/test/teletype/teletype.hs) test suites first to get some idea on current capabilities of `asterius`.
 

--- a/asterius/app/ahc-ld.hs
+++ b/asterius/app/ahc-ld.hs
@@ -17,6 +17,7 @@ parseLinkTask args = do
       , linkLibs = link_libs
       , debug = "--debug" `elem` args
       , gcSections = "--no-gc-sections" `notElem` args
+      , binaryen = "--binaryen" `elem` args
       , rootSymbols =
           map (AsteriusEntitySymbol . fromString) $
           str_args "--extra-root-symbol="

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -901,11 +901,13 @@ newCAFFunction _ =
 
 stgRun :: Expression -> EDSL Expression
 stgRun init_f = do
-  let f = pointerI64 (symbol "__asterius_pc") 0
-  putLVal f init_f
-  loop' [] $ \loop_lbl ->
-    if' [] (eqZInt64 (getLVal f)) mempty $ do
-      callIndirect (getLVal f)
+  let pc = pointerI64 (symbol "__asterius_pc") 0
+  pc_reg <- i64MutLocal
+  putLVal pc init_f
+  loop' [] $ \loop_lbl -> do
+    putLVal pc_reg $ getLVal pc
+    if' [] (eqZInt64 (getLVal pc_reg)) mempty $ do
+      callIndirect (getLVal pc_reg)
       break' loop_lbl Nothing
   pure $ getLVal r1
 

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -17,6 +17,7 @@ module Asterius.Builtins
 
 import Asterius.EDSL
 import Asterius.Internals
+import Asterius.Internals.MagicNumber
 import Asterius.Types
 import qualified Data.ByteString.Short as SBS
 import Data.Foldable
@@ -60,6 +61,11 @@ rtsAsteriusModule opts =
                       SBS.pack $
                       replicate (8 * roundup_bytes_to_words sizeof_Capability) 0
                     ]
+                })
+          , ( "__asterius_pc"
+            , AsteriusStatics
+                { staticsType = Bytes
+                , asteriusStatics = [Serialized $ encodeStorable invalidAddress]
                 })
           ]
     , functionMap =
@@ -895,19 +901,16 @@ newCAFFunction _ =
 
 stgRun :: Expression -> EDSL Expression
 stgRun init_f = do
-  f <- i64MutLocal
+  let f = pointerI64 (symbol "__asterius_pc") 0
   putLVal f init_f
   loop' [] $ \loop_lbl ->
     if' [] (eqZInt64 (getLVal f)) mempty $ do
-      f' <- callIndirect' (getLVal f) [] (FunctionType [] [I64])
-      putLVal f f'
+      callIndirect (getLVal f)
       break' loop_lbl Nothing
   pure $ getLVal r1
 
 stgReturnFunction _ =
-  runEDSL [I64] $ do
-    setReturnTypes [I64]
-    emit $ constI64 0
+  runEDSL [] $ storeI64 (symbol "__asterius_pc") 0 $ constI64 0
 
 getStablePtrWrapperFunction _ =
   runEDSL [I64] $ do

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -920,7 +920,27 @@ marshalCmmBlockBranch instr =
           [AddBranch {to = dest_def, addBranchCondition = Nothing}])
     GHC.CmmCall {..} -> do
       t <- marshalAndCastCmmExpr cml_target I64
-      pure ([SetLocal {index = 2, value = t}], Nothing, [])
+      pure
+        ( [ Store
+              { bytes = 8
+              , offset = 0
+              , ptr =
+                  Unary
+                    { unaryOp = WrapInt64
+                    , operand0 =
+                        Symbol
+                          { unresolvedSymbol = "__asterius_pc"
+                          , symbolOffset = 0
+                          , resolvedSymbol = Nothing
+                          }
+                    }
+              , value = t
+              , valueType = I64
+              }
+          , Return
+          ]
+        , Nothing
+        , [])
     _ -> throwError $ UnsupportedCmmBranch $ showSBS instr
 
 marshalCmmBlock ::
@@ -997,21 +1017,14 @@ marshalCmmProc GHC.CmmGraph {g_graph = GHC.GMany _ body _, ..} = do
         ]
   pure
     AsteriusFunction
-      { functionType = FunctionType {paramTypes = [], returnTypes = [I64]}
+      { functionType = FunctionType {paramTypes = [], returnTypes = []}
       , body =
-          Block
-            { name = ""
-            , bodys =
-                [ CFG
-                    RelooperRun
-                      { entry = blocks_key_subst entry_k
-                      , blockMap = M.fromList blocks_resolved
-                      , labelHelper = 0
-                      }
-                , GetLocal {index = 2, valueType = I64}
-                ]
-            , blockReturnTypes = [I64]
-            }
+          CFG
+            RelooperRun
+              { entry = blocks_key_subst entry_k
+              , blockMap = M.fromList blocks_resolved
+              , labelHelper = 0
+              }
       }
 
 marshalCmmDecl ::

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -921,23 +921,9 @@ marshalCmmBlockBranch instr =
     GHC.CmmCall {..} -> do
       t <- marshalAndCastCmmExpr cml_target I64
       pure
-        ( [ Store
-              { bytes = 8
-              , offset = 0
-              , ptr =
-                  Unary
-                    { unaryOp = WrapInt64
-                    , operand0 =
-                        Symbol
-                          { unresolvedSymbol = "__asterius_pc"
-                          , symbolOffset = 0
-                          , resolvedSymbol = Nothing
-                          }
-                    }
-              , value = t
-              , valueType = I64
-              }
-          , Return
+        ( [ case t of
+              Symbol {..} -> ReturnCall {returnCallTarget64 = unresolvedSymbol}
+              _ -> ReturnCallIndirect {returnCallIndirectTarget64 = t}
           ]
         , Nothing
         , [])

--- a/asterius/src/Asterius/EDSL.hs
+++ b/asterius/src/Asterius/EDSL.hs
@@ -45,7 +45,7 @@ module Asterius.EDSL
   , call'
   , callImport
   , callImport'
-  , callIndirect'
+  , callIndirect
   , Label
   , block'
   , loop'
@@ -318,17 +318,14 @@ callImport' f xs vt = do
     CallImport {target' = f, operands = xs, callImportReturnTypes = [vt]}
   pure $ getLVal lr
 
-callIndirect' :: Expression -> [Expression] -> FunctionType -> EDSL Expression
-callIndirect' f xs ft@FunctionType {returnTypes = [rt]} = do
-  lr <- mutLocal rt
-  putLVal
-    lr
+callIndirect :: Expression -> EDSL ()
+callIndirect f =
+  emit
     CallIndirect
-      {indirectTarget = wrapInt64 f, operands = xs, functionType = ft}
-  pure $ getLVal lr
-callIndirect' _ _ ft =
-  Control.Monad.Fail.fail $
-  "callIndirect': unsupported function type: " <> show ft
+      { indirectTarget = wrapInt64 f
+      , operands = []
+      , functionType = FunctionType {paramTypes = [], returnTypes = []}
+      }
 
 newtype Label = Label
   { unLabel :: SBS.ShortByteString

--- a/asterius/src/Asterius/EDSL.hs
+++ b/asterius/src/Asterius/EDSL.hs
@@ -20,7 +20,6 @@ module Asterius.EDSL
   , i64Local
   , i32Local
   , i64MutLocal
-  , i32MutLocal
   , global
   , pointer
   , pointerI64
@@ -218,10 +217,8 @@ i64Local = local I64
 
 i32Local = local I32
 
-i64MutLocal, i32MutLocal :: EDSL LVal
+i64MutLocal :: EDSL LVal
 i64MutLocal = mutLocal I64
-
-i32MutLocal = mutLocal I32
 
 global :: UnresolvedGlobalReg -> LVal
 global gr =

--- a/asterius/src/Asterius/Internals.hs
+++ b/asterius/src/Asterius/Internals.hs
@@ -15,8 +15,10 @@ module Asterius.Internals
   , showSBS
   , c8SBS
   , (!)
+  , (!?)
   ) where
 
+import Asterius.Internals.MagicNumber
 import Control.Exception
 import qualified Data.Binary as Binary
 import qualified Data.ByteString.Char8 as CBS
@@ -117,3 +119,7 @@ c8SBS = CBS.unpack . SBS.fromShort
   case LM.lookup k m of
     Just v -> v
     _ -> error $ show k <> " not found"
+
+{-# INLINE (!?) #-}
+(!?) :: Ord k => LM.Map k Int64 -> k -> Int64
+(!?) = flip $ LM.findWithDefault invalidAddress

--- a/asterius/src/Asterius/Ld.hs
+++ b/asterius/src/Asterius/Ld.hs
@@ -23,7 +23,7 @@ import Prelude hiding (IO)
 data LinkTask = LinkTask
   { linkOutput :: FilePath
   , linkObjs, linkLibs :: [FilePath]
-  , debug, gcSections :: Bool
+  , debug, gcSections, binaryen :: Bool
   , rootSymbols, exportFunctions :: [AsteriusEntitySymbol]
   } deriving (Show)
 
@@ -66,6 +66,7 @@ linkExe ld_task@LinkTask {..} = do
           debug
           True
           gcSections
+          binaryen
           final_store
           (Set.unions
              [ Set.fromList rootSymbols

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -64,7 +64,7 @@ data Task = Task
   , inputEntryMJS :: Maybe FilePath
   , outputDirectory :: FilePath
   , outputBaseName :: String
-  , gcSections, fullSymTable, bundle, noStreaming, sync, binaryen, debug, outputLinkReport, outputIR, run :: Bool
+  , tailCalls, gcSections, fullSymTable, bundle, noStreaming, sync, binaryen, debug, outputLinkReport, outputIR, run :: Bool
   , extraGHCFlags :: [String]
   , exportFunctions, extraRootSymbols :: [AsteriusEntitySymbol]
   } deriving (Show)
@@ -96,6 +96,7 @@ parseTask args =
         , str_opt "input-mjs" $ \s t -> t {inputEntryMJS = Just s}
         , str_opt "output-directory" $ \s t -> t {outputDirectory = s}
         , str_opt "output-prefix" $ \s t -> t {outputBaseName = s}
+        , bool_opt "tail-calls" $ \t -> t {tailCalls = True}
         , bool_opt "no-gc-sections" $ \t -> t {gcSections = False}
         , bool_opt "full-sym-table" $ \t -> t {fullSymTable = True}
         , bool_opt "bundle" $ \t -> t {bundle = True}
@@ -126,6 +127,7 @@ parseTask args =
           , outputBaseName =
               error "Asterius.Main.parseTask: missing outputBaseName"
           , inputEntryMJS = Nothing
+          , tailCalls = False
           , gcSections = True
           , fullSymTable = False
           , bundle = False
@@ -495,7 +497,11 @@ ahcDistMain task@Task {..} (final_m, err_msgs, report) = do
                c_BinaryenSetOptimizeLevel 0
                c_BinaryenSetShrinkLevel 0
                m_ref <-
-                 withPool $ \pool -> OldMarshal.marshalModule pool final_m
+                 withPool $ \pool ->
+                   OldMarshal.marshalModule
+                     pool
+                     (staticsSymbolMap report <> functionSymbolMap report)
+                     final_m
                putStrLn "[INFO] Validating binaryen IR"
                pass_validation <- c_BinaryenModuleValidate m_ref
                when (pass_validation /= 1) $
@@ -515,7 +521,12 @@ ahcDistMain task@Task {..} (final_m, err_msgs, report) = do
                    _ -> fail "[ERROR] Re-parsing failed"
                pure m_bin)
       else (do putStrLn "[INFO] Converting linked IR to wasm-toolkit IR"
-               let conv_result = runExcept $ NewMarshal.makeModule final_m
+               let conv_result =
+                     runExcept $
+                     NewMarshal.makeModule
+                       tailCalls
+                       (staticsSymbolMap report <> functionSymbolMap report)
+                       final_m
                r <-
                  case conv_result of
                    Left err ->
@@ -580,10 +591,14 @@ ahcDistMain task@Task {..} (final_m, err_msgs, report) = do
     if bundle
       then do
         putStrLn $ "[INFO] Running " <> out_js
-        callProcess "node" [takeFileName out_js]
+        callProcess "node" $
+          ["--experimental-wasm-return-call" | tailCalls] <>
+          [takeFileName out_js]
       else do
         putStrLn $ "[INFO] Running " <> out_entry
-        callProcess "node" ["--experimental-modules", takeFileName out_entry]
+        callProcess "node" $
+          ["--experimental-wasm-return-call" | tailCalls] <>
+          ["--experimental-modules", takeFileName out_entry]
 
 ahcLinkMain :: Task -> IO ()
 ahcLinkMain task = do

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -463,6 +463,7 @@ ahcLink Task {..} = do
     | export_func <- exportFunctions
     ] <>
     ["-optl--no-gc-sections" | not gcSections] <>
+    ["-optl--binaryen" | binaryen] <>
     extraGHCFlags <>
     ["-o", ld_output, inputHS]
   r <- decodeFile ld_output

--- a/asterius/src/Asterius/Marshal.hs
+++ b/asterius/src/Asterius/Marshal.hs
@@ -283,6 +283,7 @@ marshalExpression pool m e =
       x <- marshalExpression pool m operand0
       y <- marshalExpression pool m operand1
       c_BinaryenBinary m (marshalBinaryOp binaryOp) x y
+    Return -> c_BinaryenReturn m nullPtr
     Host {..} -> do
       xs <- forM operands $ marshalExpression pool m
       (es, en) <- marshalV pool xs

--- a/asterius/src/Asterius/Marshal.hs
+++ b/asterius/src/Asterius/Marshal.hs
@@ -299,7 +299,7 @@ marshalExpression pool sym_map m e =
             , ptr =
                 ConstI32 $
                 fromIntegral $ (sym_map ! "__asterius_pc") .&. 0xFFFFFFFF
-            , value = ConstI64 $ sym_map ! returnCallTarget64
+            , value = ConstI64 $ sym_map !? returnCallTarget64
             , valueType = I64
             }
       r <- c_BinaryenReturn m nullPtr

--- a/asterius/src/Asterius/Marshal.hs
+++ b/asterius/src/Asterius/Marshal.hs
@@ -208,58 +208,62 @@ marshalFunctionType pool m k FunctionType {..} = do
   c_BinaryenAddFunctionType m np rts pts ptl
 
 marshalExpression ::
-     Pool -> BinaryenModuleRef -> Expression -> IO BinaryenExpressionRef
-marshalExpression pool m e =
+     Pool
+  -> M.Map AsteriusEntitySymbol Int64
+  -> BinaryenModuleRef
+  -> Expression
+  -> IO BinaryenExpressionRef
+marshalExpression pool sym_map m e =
   case e of
     Block {..} -> do
-      bs <- forM bodys $ marshalExpression pool m
+      bs <- forM bodys $ marshalExpression pool sym_map m
       (bsp, bl) <- marshalV pool bs
       np <- marshalSBS pool name
       rts <- marshalReturnTypes blockReturnTypes
       c_BinaryenBlock m np bsp bl rts
     If {..} -> do
-      c <- marshalExpression pool m condition
-      t <- marshalExpression pool m ifTrue
-      f <- marshalMaybeExpression pool m ifFalse
+      c <- marshalExpression pool sym_map m condition
+      t <- marshalExpression pool sym_map m ifTrue
+      f <- marshalMaybeExpression pool sym_map m ifFalse
       c_BinaryenIf m c t f
     Loop {..} -> do
-      b <- marshalExpression pool m body
+      b <- marshalExpression pool sym_map m body
       np <- marshalSBS pool name
       c_BinaryenLoop m np b
     Break {..} -> do
-      c <- marshalMaybeExpression pool m breakCondition
+      c <- marshalMaybeExpression pool sym_map m breakCondition
       np <- marshalSBS pool name
       c_BinaryenBreak m np c nullPtr
     Switch {..} -> do
-      c <- marshalExpression pool m condition
+      c <- marshalExpression pool sym_map m condition
       ns <- forM names $ marshalSBS pool
       (nsp, nl) <- marshalV pool ns
       dn <- marshalSBS pool defaultName
       c_BinaryenSwitch m nsp nl dn c nullPtr
     Call {..} -> do
-      os <- forM operands $ marshalExpression pool m
+      os <- forM operands $ marshalExpression pool sym_map m
       (ops, osl) <- marshalV pool os
       tp <- marshalSBS pool (entityName target)
       rts <- marshalReturnTypes callReturnTypes
       c_BinaryenCall m tp ops osl rts
     CallImport {..} -> do
-      os <- forM operands $ marshalExpression pool m
+      os <- forM operands $ marshalExpression pool sym_map m
       (ops, osl) <- marshalV pool os
       tp <- marshalSBS pool target'
       rts <- marshalReturnTypes callImportReturnTypes
       c_BinaryenCall m tp ops osl rts
     CallIndirect {..} -> do
-      t <- marshalExpression pool m indirectTarget
-      os <- forM operands $ marshalExpression pool m
+      t <- marshalExpression pool sym_map m indirectTarget
+      os <- forM operands $ marshalExpression pool sym_map m
       (ops, osl) <- marshalV pool os
       tp <- marshalSBS pool $ showSBS functionType
       c_BinaryenCallIndirect m t ops osl tp
     GetLocal {..} -> c_BinaryenGetLocal m index $ marshalValueType valueType
     SetLocal {..} -> do
-      v <- marshalExpression pool m value
+      v <- marshalExpression pool sym_map m value
       c_BinaryenSetLocal m index v
     Load {..} -> do
-      p <- marshalExpression pool m ptr
+      p <- marshalExpression pool sym_map m ptr
       c_BinaryenLoad
         m
         bytes
@@ -269,48 +273,88 @@ marshalExpression pool m e =
         (marshalValueType valueType)
         p
     Store {..} -> do
-      p <- marshalExpression pool m ptr
-      v <- marshalExpression pool m value
+      p <- marshalExpression pool sym_map m ptr
+      v <- marshalExpression pool sym_map m value
       c_BinaryenStore m bytes offset 1 p v (marshalValueType valueType)
     ConstI32 x -> c_BinaryenConstInt32 m x
     ConstI64 x -> c_BinaryenConstInt64 m x
     ConstF32 x -> c_BinaryenConstFloat32 m x
     ConstF64 x -> c_BinaryenConstFloat64 m x
     Unary {..} -> do
-      x <- marshalExpression pool m operand0
+      x <- marshalExpression pool sym_map m operand0
       c_BinaryenUnary m (marshalUnaryOp unaryOp) x
     Binary {..} -> do
-      x <- marshalExpression pool m operand0
-      y <- marshalExpression pool m operand1
+      x <- marshalExpression pool sym_map m operand0
+      y <- marshalExpression pool sym_map m operand1
       c_BinaryenBinary m (marshalBinaryOp binaryOp) x y
-    Return -> c_BinaryenReturn m nullPtr
+    ReturnCall {..} -> do
+      s <-
+        marshalExpression
+          pool
+          sym_map
+          m
+          Store
+            { bytes = 8
+            , offset = 0
+            , ptr =
+                ConstI32 $
+                fromIntegral $ (sym_map ! "__asterius_pc") .&. 0xFFFFFFFF
+            , value = ConstI64 $ sym_map ! returnCallTarget64
+            , valueType = I64
+            }
+      r <- c_BinaryenReturn m nullPtr
+      arr <- pooledNewArray pool [s, r]
+      c_BinaryenBlock m nullPtr arr 2 c_BinaryenTypeNone
+    ReturnCallIndirect {..} -> do
+      s <-
+        marshalExpression
+          pool
+          sym_map
+          m
+          Store
+            { bytes = 8
+            , offset = 0
+            , ptr =
+                ConstI32 $
+                fromIntegral $ (sym_map ! "__asterius_pc") .&. 0xFFFFFFFF
+            , value = returnCallIndirectTarget64
+            , valueType = I64
+            }
+      r <- c_BinaryenReturn m nullPtr
+      arr <- pooledNewArray pool [s, r]
+      c_BinaryenBlock m nullPtr arr 2 c_BinaryenTypeNone
     Host {..} -> do
-      xs <- forM operands $ marshalExpression pool m
+      xs <- forM operands $ marshalExpression pool sym_map m
       (es, en) <- marshalV pool xs
       c_BinaryenHost m (marshalHostOp hostOp) nullPtr es en
     Nop -> c_BinaryenNop m
     Unreachable -> c_BinaryenUnreachable m
-    CFG {..} -> relooperRun pool m graph
+    CFG {..} -> relooperRun pool sym_map m graph
     Symbol {resolvedSymbol = Just x, ..} ->
       c_BinaryenConstInt64 m (x + fromIntegral symbolOffset)
     _ -> throwIO $ UnsupportedExpression e
 
 marshalMaybeExpression ::
-     Pool -> BinaryenModuleRef -> Maybe Expression -> IO BinaryenExpressionRef
-marshalMaybeExpression pool m x =
+     Pool
+  -> M.Map AsteriusEntitySymbol Int64
+  -> BinaryenModuleRef
+  -> Maybe Expression
+  -> IO BinaryenExpressionRef
+marshalMaybeExpression pool sym_map m x =
   case x of
-    Just e -> marshalExpression pool m e
+    Just e -> marshalExpression pool sym_map m e
     _ -> pure nullPtr
 
 marshalFunction ::
      Pool
+  -> M.Map AsteriusEntitySymbol Int64
   -> BinaryenModuleRef
   -> SBS.ShortByteString
   -> BinaryenFunctionTypeRef
   -> Function
   -> IO BinaryenFunctionRef
-marshalFunction pool m k ft Function {..} = do
-  b <- marshalExpression pool m body
+marshalFunction pool sym_map m k ft Function {..} = do
+  b <- marshalExpression pool sym_map m body
   (vtp, vtl) <- marshalV pool $ map marshalValueType varTypes
   np <- marshalSBS pool k
   c_BinaryenAddFunction m np ft vtp vtl b
@@ -348,12 +392,19 @@ marshalFunctionTable pool m tbl_slots FunctionTable {..} = do
     fnl
 
 marshalMemorySegments ::
-     Pool -> BinaryenModuleRef -> Int -> [DataSegment] -> IO ()
-marshalMemorySegments pool m mbs segs = do
+     Pool
+  -> M.Map AsteriusEntitySymbol Int64
+  -> BinaryenModuleRef
+  -> Int
+  -> [DataSegment]
+  -> IO ()
+marshalMemorySegments pool sym_map m mbs segs = do
   (seg_bufs, _ :: Int) <- marshalV pool =<< for segs (marshalSBS pool . content)
   (seg_offsets, _ :: Int) <-
     marshalV pool =<<
-    for segs (\DataSegment {..} -> marshalExpression pool m $ ConstI32 offset)
+    for
+      segs
+      (\DataSegment {..} -> marshalExpression pool sym_map m $ ConstI32 offset)
   (seg_sizes, _ :: Int) <-
     marshalV pool $ map (fromIntegral . SBS.length . content) segs
   c_BinaryenSetMemory
@@ -395,8 +446,9 @@ marshalMemoryExport pool m MemoryExport {..} = do
   enp <- marshalSBS pool externalName
   c_BinaryenAddMemoryExport m inp enp
 
-marshalModule :: Pool -> Module -> IO BinaryenModuleRef
-marshalModule pool hs_mod@Module {..} = do
+marshalModule ::
+     Pool -> M.Map AsteriusEntitySymbol Int64 -> Module -> IO BinaryenModuleRef
+marshalModule pool sym_map hs_mod@Module {..} = do
   let fts = generateWasmFunctionTypeSet hs_mod
   m <- c_BinaryenModuleCreate
   ftps <-
@@ -405,61 +457,67 @@ marshalModule pool hs_mod@Module {..} = do
       ftp <- marshalFunctionType pool m (showSBS ft) ft
       pure (ft, ftp)
   for_ (M.toList functionMap') $ \(k, f@Function {..}) ->
-    marshalFunction pool m k (ftps ! functionType) f
+    marshalFunction pool sym_map m k (ftps ! functionType) f
   forM_ functionImports $ \fi@FunctionImport {..} ->
     marshalFunctionImport pool m (ftps ! functionType) fi
   forM_ functionExports $ marshalFunctionExport pool m
   marshalFunctionTable pool m tableSlots functionTable
   marshalTableImport pool m tableImport
   void $ marshalTableExport pool m tableExport
-  marshalMemorySegments pool m memoryMBlocks memorySegments
+  marshalMemorySegments pool sym_map m memoryMBlocks memorySegments
   marshalMemoryImport pool m memoryImport
   void $ marshalMemoryExport pool m memoryExport
   pure m
 
 relooperAddBlock ::
      Pool
+  -> M.Map AsteriusEntitySymbol Int64
   -> BinaryenModuleRef
   -> RelooperRef
   -> RelooperAddBlock
   -> IO RelooperBlockRef
-relooperAddBlock pool m r ab =
+relooperAddBlock pool sym_map m r ab =
   case ab of
     AddBlock {..} -> do
-      c <- marshalExpression pool m code
+      c <- marshalExpression pool sym_map m code
       c_RelooperAddBlock r c
     AddBlockWithSwitch {..} -> do
-      _code <- marshalExpression pool m code
-      _cond <- marshalExpression pool m condition
+      _code <- marshalExpression pool sym_map m code
+      _cond <- marshalExpression pool sym_map m condition
       c_RelooperAddBlockWithSwitch r _code _cond
 
 relooperAddBranch ::
      Pool
+  -> M.Map AsteriusEntitySymbol Int64
   -> BinaryenModuleRef
   -> M.Map SBS.ShortByteString RelooperBlockRef
   -> SBS.ShortByteString
   -> RelooperAddBranch
   -> IO ()
-relooperAddBranch pool m bm k ab =
+relooperAddBranch pool sym_map m bm k ab =
   case ab of
     AddBranch {..} -> do
-      _cond <- marshalMaybeExpression pool m addBranchCondition
+      _cond <- marshalMaybeExpression pool sym_map m addBranchCondition
       c_RelooperAddBranch (bm ! k) (bm ! to) _cond nullPtr
     AddBranchForSwitch {..} -> do
       (idp, idn) <- marshalV pool indexes
       c_RelooperAddBranchForSwitch (bm ! k) (bm ! to) idp idn nullPtr
 
 relooperRun ::
-     Pool -> BinaryenModuleRef -> RelooperRun -> IO BinaryenExpressionRef
-relooperRun pool m RelooperRun {..} = do
+     Pool
+  -> M.Map AsteriusEntitySymbol Int64
+  -> BinaryenModuleRef
+  -> RelooperRun
+  -> IO BinaryenExpressionRef
+relooperRun pool sym_map m RelooperRun {..} = do
   r <- c_RelooperCreate m
   bpm <-
     fmap fromList $
     for (M.toList blockMap) $ \(k, RelooperBlock {..}) -> do
-      bp <- relooperAddBlock pool m r addBlock
+      bp <- relooperAddBlock pool sym_map m r addBlock
       pure (k, bp)
   for_ (M.toList blockMap) $ \(k, RelooperBlock {..}) ->
-    forM_ addBranches $ relooperAddBranch pool m bpm k
+    forM_ addBranches $ relooperAddBranch pool sym_map m bpm k
   c_RelooperRenderAndDispose r (bpm ! entry) labelHelper
 
 serializeModule :: BinaryenModuleRef -> IO BS.ByteString

--- a/asterius/src/Asterius/NewMarshal.hs
+++ b/asterius/src/Asterius/NewMarshal.hs
@@ -543,6 +543,7 @@ makeInstructions _module_symtable@ModuleSymbolTable {..} _de_bruijn_ctx _local_c
           GtFloat64 -> pure Wasm.F64Gt
           GeFloat64 -> pure Wasm.F64Ge
       pure $ x <> y <> op
+    Return -> pure $ DList.singleton Wasm.Return
     Host {..} -> do
       let op =
             DList.singleton $

--- a/asterius/src/Asterius/NewMarshal.hs
+++ b/asterius/src/Asterius/NewMarshal.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StrictData #-}
 
@@ -15,8 +16,10 @@ import Asterius.Types
 import Asterius.TypesConv
 import Control.Exception
 import Control.Monad.Except
+import Data.Bits
 import qualified Data.ByteString.Short as SBS
 import Data.Coerce
+import Data.Int
 import Data.List
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -250,22 +253,35 @@ lookupLocalContext LocalContext {..} i =
 -- TODO: reduce infer usage
 makeInstructions ::
      MonadError MarshalError m
-  => ModuleSymbolTable
+  => Bool
+  -> Map.Map AsteriusEntitySymbol Int64
+  -> ModuleSymbolTable
   -> DeBruijnContext
   -> LocalContext
   -> Expression
   -> m (DList.DList Wasm.Instruction)
-makeInstructions _module_symtable@ModuleSymbolTable {..} _de_bruijn_ctx _local_ctx expr =
+makeInstructions tail_calls sym_map _module_symtable@ModuleSymbolTable {..} _de_bruijn_ctx _local_ctx expr =
   case expr of
     Block {..}
       | SBS.null name ->
         fmap mconcat $
-        for bodys $ makeInstructions _module_symtable _de_bruijn_ctx _local_ctx
+        for bodys $
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
       | otherwise -> do
         let _new_de_bruijn_ctx = bindLabel name _de_bruijn_ctx
         bs <-
           for bodys $
-          makeInstructions _module_symtable _new_de_bruijn_ctx _local_ctx
+          makeInstructions
+            tail_calls
+            sym_map
+            _module_symtable
+            _new_de_bruijn_ctx
+            _local_ctx
         pure $
           DList.singleton
             Wasm.Block
@@ -274,13 +290,28 @@ makeInstructions _module_symtable@ModuleSymbolTable {..} _de_bruijn_ctx _local_c
               }
     If {..} -> do
       let _new_de_bruijn_ctx = bindLabel mempty _de_bruijn_ctx
-      c <- makeInstructions _module_symtable _de_bruijn_ctx _local_ctx condition
+      c <-
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
+          condition
       t <-
         DList.toList <$>
-        makeInstructions _module_symtable _new_de_bruijn_ctx _local_ctx ifTrue
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _new_de_bruijn_ctx
+          _local_ctx
+          ifTrue
       f <-
         DList.toList <$>
         makeInstructionsMaybe
+          tail_calls
+          sym_map
           _module_symtable
           _new_de_bruijn_ctx
           _local_ctx
@@ -298,7 +329,14 @@ makeInstructions _module_symtable@ModuleSymbolTable {..} _de_bruijn_ctx _local_c
             }
     Loop {..} -> do
       let _new_de_bruijn_ctx = bindLabel name _de_bruijn_ctx
-      b <- makeInstructions _module_symtable _new_de_bruijn_ctx _local_ctx body
+      b <-
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _new_de_bruijn_ctx
+          _local_ctx
+          body
       pure $
         DList.singleton
           Wasm.Loop {loopResultType = [], loopInstructions = DList.toList b}
@@ -306,11 +344,25 @@ makeInstructions _module_symtable@ModuleSymbolTable {..} _de_bruijn_ctx _local_c
       let _lbl = extractLabel _de_bruijn_ctx name
       case breakCondition of
         Just cond -> do
-          c <- makeInstructions _module_symtable _de_bruijn_ctx _local_ctx cond
+          c <-
+            makeInstructions
+              tail_calls
+              sym_map
+              _module_symtable
+              _de_bruijn_ctx
+              _local_ctx
+              cond
           pure $ c <> DList.singleton Wasm.BranchIf {branchIfLabel = _lbl}
         _ -> pure $ DList.singleton Wasm.Branch {branchLabel = _lbl}
     Switch {..} -> do
-      c <- makeInstructions _module_symtable _de_bruijn_ctx _local_ctx condition
+      c <-
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
+          condition
       pure $
         c <>
         DList.singleton
@@ -321,7 +373,12 @@ makeInstructions _module_symtable@ModuleSymbolTable {..} _de_bruijn_ctx _local_c
     Call {..} -> do
       xs <-
         for operands $
-        makeInstructions _module_symtable _de_bruijn_ctx _local_ctx
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
       pure $
         mconcat xs <>
         DList.singleton
@@ -329,7 +386,12 @@ makeInstructions _module_symtable@ModuleSymbolTable {..} _de_bruijn_ctx _local_c
     CallImport {..} -> do
       xs <-
         for operands $
-        makeInstructions _module_symtable _de_bruijn_ctx _local_ctx
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
       pure $
         mconcat xs <>
         DList.singleton
@@ -337,13 +399,20 @@ makeInstructions _module_symtable@ModuleSymbolTable {..} _de_bruijn_ctx _local_c
     CallIndirect {..} -> do
       f <-
         makeInstructions
+          tail_calls
+          sym_map
           _module_symtable
           _de_bruijn_ctx
           _local_ctx
           indirectTarget
       xs <-
         for operands $
-        makeInstructions _module_symtable _de_bruijn_ctx _local_ctx
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
       pure $
         mconcat xs <> f <>
         DList.singleton
@@ -354,7 +423,14 @@ makeInstructions _module_symtable@ModuleSymbolTable {..} _de_bruijn_ctx _local_c
       DList.singleton
         Wasm.GetLocal {getLocalIndex = lookupLocalContext _local_ctx index}
     SetLocal {..} -> do
-      v <- makeInstructions _module_symtable _de_bruijn_ctx _local_ctx value
+      v <-
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
+          value
       pure $
         v <>
         DList.singleton
@@ -381,7 +457,14 @@ makeInstructions _module_symtable@ModuleSymbolTable {..} _de_bruijn_ctx _local_c
           (True, 4, I64) -> pure $ Wasm.I64Load32Signed _mem_arg
           (False, 4, I64) -> pure $ Wasm.I64Load32Unsigned _mem_arg
           _ -> throwError $ UnsupportedExpression expr
-      p <- makeInstructions _module_symtable _de_bruijn_ctx _local_ctx ptr
+      p <-
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
+          ptr
       pure $ p <> op
     Store {..} -> do
       let _mem_arg =
@@ -400,15 +483,36 @@ makeInstructions _module_symtable@ModuleSymbolTable {..} _de_bruijn_ctx _local_c
           (2, I64) -> pure $ Wasm.I64Store16 _mem_arg
           (4, I64) -> pure $ Wasm.I64Store32 _mem_arg
           _ -> throwError $ UnsupportedExpression expr
-      p <- makeInstructions _module_symtable _de_bruijn_ctx _local_ctx ptr
-      v <- makeInstructions _module_symtable _de_bruijn_ctx _local_ctx value
+      p <-
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
+          ptr
+      v <-
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
+          value
       pure $ p <> v <> op
     ConstI32 v -> pure $ DList.singleton Wasm.I32Const {i32ConstValue = v}
     ConstI64 v -> pure $ DList.singleton Wasm.I64Const {i64ConstValue = v}
     ConstF32 v -> pure $ DList.singleton Wasm.F32Const {f32ConstValue = v}
     ConstF64 v -> pure $ DList.singleton Wasm.F64Const {f64ConstValue = v}
     Unary {..} -> do
-      x <- makeInstructions _module_symtable _de_bruijn_ctx _local_ctx operand0
+      x <-
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
+          operand0
       op <-
         DList.singleton <$>
         case unaryOp of
@@ -461,8 +565,22 @@ makeInstructions _module_symtable@ModuleSymbolTable {..} _de_bruijn_ctx _local_c
           ReinterpretInt64 -> pure Wasm.F64ReinterpretFromI64
       pure $ x <> op
     Binary {..} -> do
-      x <- makeInstructions _module_symtable _de_bruijn_ctx _local_ctx operand0
-      y <- makeInstructions _module_symtable _de_bruijn_ctx _local_ctx operand1
+      x <-
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
+          operand0
+      y <-
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
+          operand1
       op <-
         DList.singleton <$>
         case binaryOp of
@@ -543,7 +661,64 @@ makeInstructions _module_symtable@ModuleSymbolTable {..} _de_bruijn_ctx _local_c
           GtFloat64 -> pure Wasm.F64Gt
           GeFloat64 -> pure Wasm.F64Ge
       pure $ x <> y <> op
-    Return -> pure $ DList.singleton Wasm.Return
+    ReturnCall {..}
+      | tail_calls ->
+        pure $
+        DList.singleton
+          Wasm.ReturnCall
+            { returnCallFunctionIndex =
+                functionSymbols ! coerce returnCallTarget64
+            }
+      | otherwise ->
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
+          Store
+            { bytes = 8
+            , offset = 0
+            , ptr =
+                ConstI32 $
+                fromIntegral $ (sym_map ! "__asterius_pc") .&. 0xFFFFFFFF
+            , value = ConstI64 $ sym_map ! returnCallTarget64
+            , valueType = I64
+            }
+    ReturnCallIndirect {..}
+      | tail_calls -> do
+        x <-
+          makeInstructions
+            tail_calls
+            sym_map
+            _module_symtable
+            _de_bruijn_ctx
+            _local_ctx $
+          Unary {unaryOp = WrapInt64, operand0 = returnCallIndirectTarget64}
+        pure $
+          x <>
+          DList.singleton
+            Wasm.ReturnCallIndirect
+              { returnCallIndirectFunctionTypeIndex =
+                  functionTypeSymbols !
+                  FunctionType {paramTypes = [], returnTypes = []}
+              }
+      | otherwise ->
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
+          Store
+            { bytes = 8
+            , offset = 0
+            , ptr =
+                ConstI32 $
+                fromIntegral $ (sym_map ! "__asterius_pc") .&. 0xFFFFFFFF
+            , value = returnCallIndirectTarget64
+            , valueType = I64
+            }
     Host {..} -> do
       let op =
             DList.singleton $
@@ -552,7 +727,12 @@ makeInstructions _module_symtable@ModuleSymbolTable {..} _de_bruijn_ctx _local_c
               GrowMemory -> Wasm.MemoryGrow
       xs <-
         for operands $
-        makeInstructions _module_symtable _de_bruijn_ctx _local_ctx
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
       pure $ mconcat xs <> op
     Nop -> pure $ DList.singleton Wasm.Nop
     Unreachable -> pure $ DList.singleton Wasm.Unreachable
@@ -564,20 +744,33 @@ makeInstructions _module_symtable@ModuleSymbolTable {..} _de_bruijn_ctx _local_c
 
 makeInstructionsMaybe ::
      MonadError MarshalError m
-  => ModuleSymbolTable
+  => Bool
+  -> Map.Map AsteriusEntitySymbol Int64
+  -> ModuleSymbolTable
   -> DeBruijnContext
   -> LocalContext
   -> Maybe Expression
   -> m (DList.DList Wasm.Instruction)
-makeInstructionsMaybe _module_symtable _de_bruijn_ctx _local_ctx m_expr =
+makeInstructionsMaybe tail_calls sym_map _module_symtable _de_bruijn_ctx _local_ctx m_expr =
   case m_expr of
     Just expr ->
-      makeInstructions _module_symtable _de_bruijn_ctx _local_ctx expr
+      makeInstructions
+        tail_calls
+        sym_map
+        _module_symtable
+        _de_bruijn_ctx
+        _local_ctx
+        expr
     _ -> pure mempty
 
 makeCodeSection ::
-     MonadError MarshalError m => Module -> ModuleSymbolTable -> m Wasm.Section
-makeCodeSection _mod@Module {..} _module_symtable =
+     MonadError MarshalError m
+  => Bool
+  -> Map.Map AsteriusEntitySymbol Int64
+  -> Module
+  -> ModuleSymbolTable
+  -> m Wasm.Section
+makeCodeSection tail_calls sym_map _mod@Module {..} _module_symtable =
   fmap Wasm.CodeSection $
   for (Map.elems functionMap') $ \_func@Function {..} -> do
     let _local_ctx@LocalContext {..} = makeLocalContext _mod _func
@@ -588,7 +781,13 @@ makeCodeSection _mod@Module {..} _module_symtable =
             (F32, c) -> (Wasm.F32, c)
             (F64, c) -> (Wasm.F64, c)
     _body <-
-      makeInstructions _module_symtable emptyDeBruijnContext _local_ctx body
+      makeInstructions
+        tail_calls
+        sym_map
+        _module_symtable
+        emptyDeBruijnContext
+        _local_ctx
+        body
     pure
       Wasm.Function
         { functionLocals =
@@ -612,15 +811,20 @@ makeDataSection Module {..} _module_symtable = do
           }
   pure Wasm.DataSection {dataSegments = segs}
 
-makeModule :: MonadError MarshalError m => Module -> m Wasm.Module
-makeModule m = do
+makeModule ::
+     MonadError MarshalError m
+  => Bool
+  -> Map.Map AsteriusEntitySymbol Int64
+  -> Module
+  -> m Wasm.Module
+makeModule tail_calls sym_map m = do
   _module_symtable <- makeModuleSymbolTable m
   _type_sec <- makeTypeSection m _module_symtable
   _import_sec <- makeImportSection m _module_symtable
   _func_sec <- makeFunctionSection m _module_symtable
   _export_sec <- makeExportSection m _module_symtable
   _elem_sec <- makeElementSection m _module_symtable
-  _code_sec <- makeCodeSection m _module_symtable
+  _code_sec <- makeCodeSection tail_calls sym_map m _module_symtable
   _data_sec <- makeDataSection m _module_symtable
   pure $
     Wasm.Module

--- a/asterius/src/Asterius/Passes/LocalRegs.hs
+++ b/asterius/src/Asterius/Passes/LocalRegs.hs
@@ -47,7 +47,7 @@ resolveLocalRegs FunctionType {..} t =
         _ -> pure t
     _ -> pure t
   where
-    base_idx = 3 + length paramTypes
+    base_idx = 2 + length paramTypes
     idx :: UnresolvedLocalReg -> m BinaryenIndex
     idx reg =
       state $ \ps@PassesState {..} ->
@@ -59,5 +59,4 @@ resolveLocalRegs FunctionType {..} t =
 {-# INLINABLE localRegTable #-}
 localRegTable :: PassesState -> [ValueType]
 localRegTable PassesState {..} =
-  I32 :
-  I32 : I64 : map unresolvedLocalRegValueType (sortKeysByIntValue localRegMap)
+  I32 : I32 : map unresolvedLocalRegValueType (sortKeysByIntValue localRegMap)

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -148,6 +148,7 @@ makeInfoTableSet AsteriusModule {..} sym_map =
 resolveAsteriusModule ::
      Bool
   -> Bool
+  -> Bool
   -> FFIMarshalState
   -> [AsteriusEntitySymbol]
   -> AsteriusModule
@@ -159,7 +160,7 @@ resolveAsteriusModule ::
      , [Event]
      , Int
      , Int)
-resolveAsteriusModule debug has_main bundled_ffi_state export_funcs m_globals_resolved func_start_addr data_start_addr =
+resolveAsteriusModule debug has_main binaryen bundled_ffi_state export_funcs m_globals_resolved func_start_addr data_start_addr =
   (new_mod, ss_sym_map, func_sym_map, err_msgs, table_slots, initial_mblocks)
   where
     (func_sym_map, last_func_addr) =
@@ -180,6 +181,7 @@ resolveAsteriusModule debug has_main bundled_ffi_state export_funcs m_globals_re
           let (body_locals_resolved, local_reg_table, event_map') =
                 allPasses
                   debug
+                  binaryen
                   all_sym_map
                   export_func_set
                   sym
@@ -225,11 +227,12 @@ linkStart ::
      Bool
   -> Bool
   -> Bool
+  -> Bool
   -> AsteriusModule
   -> S.Set AsteriusEntitySymbol
   -> [AsteriusEntitySymbol]
   -> (Module, [Event], LinkReport)
-linkStart debug has_main gc_sections store root_syms export_funcs =
+linkStart debug has_main gc_sections binaryen store root_syms export_funcs =
   ( result_m
   , err_msgs
   , report
@@ -255,6 +258,7 @@ linkStart debug has_main gc_sections store root_syms export_funcs =
       resolveAsteriusModule
         debug
         has_main
+        binaryen
         (bundledFFIMarshalState report)
         export_funcs
         merged_m

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -393,7 +393,8 @@ data Expression
           , operand0 :: Expression }
   | Binary { binaryOp :: BinaryOp
            , operand0, operand1 :: Expression }
-  | Return
+  | ReturnCall { returnCallTarget64 :: AsteriusEntitySymbol }
+  | ReturnCallIndirect { returnCallIndirectTarget64 :: Expression }
   | Host { hostOp :: HostOp
          , operands :: [Expression] }
   | Nop

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -393,6 +393,7 @@ data Expression
           , operand0 :: Expression }
   | Binary { binaryOp :: BinaryOp
            , operand0, operand1 :: Expression }
+  | Return
   | Host { hostOp :: HostOp
          , operands :: [Expression] }
   | Nop

--- a/docs/ahc-link.md
+++ b/docs/ahc-link.md
@@ -43,6 +43,12 @@ Specifies the prefix of the output files. Defaults to the base filename of `--in
 
 ## Common options for controlling outputs
 
+### `--tail-calls`
+
+Enable the WebAssembly tail call opcodes in output binary. This requires Node.js/Chromium to be built with a fairly recent revision of V8, and called with the `--experimental-wasm-return-call` flag. Doesn't work with the binaryen backend yet.
+
+See the "Using experimental WebAssembly features" section for more details.
+
 ### `--ghc-option ARG`
 
 Specify additional ghc options. The `{-# OPTIONS_GHC #-}` pragma also works.
@@ -78,7 +84,9 @@ Runs the output code using `node`. Ignored for browser targets.
 
 ### `--binaryen`
 
-Use the binaryen backend for generating `.wasm` files. If you observe any different behavior of output code when this option is on, it's a bug!
+Use the binaryen backend for generating `.wasm` files. Also note that with the binaryen backend, we use the binaryen relooper instead of our own relooper, which at the moment may give better runtime performance.
+
+If you observe any different runtime behavior of output code when this option is on, it's a bug!
 
 ### `--debug`
 

--- a/utils/v8-node.py
+++ b/utils/v8-node.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 from io import BytesIO
-from os import getcwd
 from html.parser import HTMLParser
+import os
 from urllib.request import urlopen
 from zipfile import ZipFile
 
@@ -50,8 +50,10 @@ def get_node_zip_url():
 
 def extract_node_zip(node_zip_bytes, path):
     with ZipFile(BytesIO(node_zip_bytes)) as z:
-        z.extractall(path)
+        for i in z.infolist():
+            z.extract(i.filename, path)
+            os.chmod(os.path.join(path, i.filename), i.external_attr >> 16)
 
 
 if __name__ == "__main__":
-    extract_node_zip(get_bytes(get_node_zip_url()), getcwd())
+    extract_node_zip(get_bytes(get_node_zip_url()), os.getcwd())

--- a/wasm-toolkit/src/Language/WebAssembly/WireFormat.hs
+++ b/wasm-toolkit/src/Language/WebAssembly/WireFormat.hs
@@ -269,6 +269,8 @@ data Instruction
   | Return
   | Call { callFunctionIndex :: FunctionIndex }
   | CallIndirect { callIndirectFuctionTypeIndex :: FunctionTypeIndex }
+  | ReturnCall { returnCallFunctionIndex :: FunctionIndex }
+  | ReturnCallIndirect { returnCallIndirectFunctionTypeIndex :: FunctionTypeIndex }
   | Drop
   | Select
   | GetLocal { getLocalIndex :: LocalIndex }
@@ -450,6 +452,8 @@ getInstruction = do
     0x0F -> pure Return
     0x10 -> Call <$> getFunctionIndex
     0x11 -> CallIndirect <$> getFunctionTypeIndex <* expectWord8 0x00
+    0x12 -> ReturnCall <$> getFunctionIndex
+    0x13 -> ReturnCallIndirect <$> getFunctionTypeIndex <* expectWord8 0x00
     0x1A -> pure Drop
     0x1B -> pure Select
     0x20 -> GetLocal <$> getLocalIndex'
@@ -776,6 +780,13 @@ putInstruction instr =
     CallIndirect {..} -> do
       putWord8 0x11
       putFunctionTypeIndex callIndirectFuctionTypeIndex
+      putWord8 0x00
+    ReturnCall {..} -> do
+      putWord8 0x12
+      putFunctionIndex returnCallFunctionIndex
+    ReturnCallIndirect {..} -> do
+      putWord8 0x13
+      putFunctionTypeIndex returnCallIndirectFunctionTypeIndex
       putWord8 0x00
     Drop -> putWord8 0x1A
     Select -> putWord8 0x1B


### PR DESCRIPTION
We used to have `[] -> [i64]` sigs for wasm functions translated from a cmm graph. When tinkering on the linker and moving passes back to the codegen, I realized we can change them to `[] -> []`, and the return address can be passed via a global state instead. Benefits compared to the old way:

* We used to reserve a write-once local reg in every cmm function just for the return address. Which was a legacy hack and a waste (see below)
* We used to use the `binaryen` relooper, which easily breaks validation when the graph needs to return anything in an exit block. To workaround that we added a return address reg, make the graph write to that reg and return its content as function output, which (due to misdocumentation) triggered undefined behavior in `binaryen` and led to a long term debugging session. We "solved" that by rolling our own relooper, but this PR proves we can still live with the `binaryen` relooper when that backend is used, thus improving output binary code quality.
* This PR makes it trivial to later add "no-trampolining" mode using tail call opcodes.
