### PR TITLE
Add new intrinsic assertEqI64 to check if two I64s are equal.

### DIFF
--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -118,6 +118,7 @@ export function newAsteriusInstance(req) {
       },
       rts: {
         printI64: x => __asterius_fs.writeSync(__asterius_fs.stdout(), __asterius_show_I64(x) + "\n"),
+        assertEqI64: function(x, y) { if(x != y) {   throw new WebAssembly.RuntimeError("unequal I64: " + x + ", " + y); } },
         print: x => __asterius_fs.writeSync(__asterius_fs.stdout(), x + "\n"),
         emitEvent: ev => __asterius_logger.logEvent(req.events[ev])
       },

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -183,6 +183,7 @@ rtsAsteriusModule opts =
         , ("print_i64", printI64Function opts)
         , ("print_f32", printF32Function opts)
         , ("print_f64", printF64Function opts)
+        , ("assert_eq_i64", assertEqI64Function opts)
         , ("strlen", strlenFunction opts)
         , ("memchr", memchrFunction opts)
         , ("memcpy", memcpyFunction opts)
@@ -253,6 +254,12 @@ rtsFunctionImports debug =
       , externalModuleName = "rts"
       , externalBaseName = "printI64"
       , functionType = FunctionType {paramTypes = [F64], returnTypes = []}
+      }
+  , FunctionImport
+      { internalName = "assertEqI64"
+      , externalModuleName = "rts"
+      , externalBaseName = "assertEqI64"
+      , functionType = FunctionType {paramTypes = [F64, F64], returnTypes = []}
       }
   , FunctionImport
       { internalName = "printF32"
@@ -624,7 +631,7 @@ generateWrapperFunction func_sym Function {functionType = FunctionType {..}} =
         [I64] -> ([F64], convertSInt64ToFloat64)
         _ -> (returnTypes, id)
 
-mainFunction, hsInitFunction, rtsApplyFunction, rtsEvalFunction, rtsEvalIOFunction, rtsEvalLazyIOFunction, rtsGetSchedStatusFunction, rtsCheckSchedStatusFunction, scheduleWaitThreadFunction, createThreadFunction, createGenThreadFunction, createIOThreadFunction, createStrictIOThreadFunction, allocateFunction, allocatePinnedFunction, newCAFFunction, stgReturnFunction, getStablePtrWrapperFunction, deRefStablePtrWrapperFunction, freeStablePtrWrapperFunction, rtsMkBoolFunction, rtsMkDoubleFunction, rtsMkCharFunction, rtsMkIntFunction, rtsMkWordFunction, rtsMkPtrFunction, rtsMkStablePtrFunction, rtsGetBoolFunction, rtsGetDoubleFunction, rtsGetCharFunction, rtsGetIntFunction, loadI64Function, printI64Function, printF32Function, printF64Function, strlenFunction, memchrFunction, memcpyFunction, memsetFunction, memcmpFunction, fromJSArrayBufferFunction, toJSArrayBufferFunction, fromJSStringFunction, fromJSArrayFunction, threadPausedFunction, dirtyMutVarFunction, trapLoadI8Function, trapStoreI8Function, trapLoadI16Function, trapStoreI16Function, trapLoadI32Function, trapStoreI32Function, trapLoadI64Function, trapStoreI64Function, trapLoadF32Function, trapStoreF32Function, trapLoadF64Function, trapStoreF64Function ::
+mainFunction, hsInitFunction, rtsApplyFunction, rtsEvalFunction, rtsEvalIOFunction, rtsEvalLazyIOFunction, rtsGetSchedStatusFunction, rtsCheckSchedStatusFunction, scheduleWaitThreadFunction, createThreadFunction, createGenThreadFunction, createIOThreadFunction, createStrictIOThreadFunction, allocateFunction, allocatePinnedFunction, newCAFFunction, stgReturnFunction, getStablePtrWrapperFunction, deRefStablePtrWrapperFunction, freeStablePtrWrapperFunction, rtsMkBoolFunction, rtsMkDoubleFunction, rtsMkCharFunction, rtsMkIntFunction, rtsMkWordFunction, rtsMkPtrFunction, rtsMkStablePtrFunction, rtsGetBoolFunction, rtsGetDoubleFunction, rtsGetCharFunction, rtsGetIntFunction, loadI64Function, printI64Function, assertEqI64Function, printF32Function, printF64Function, strlenFunction, memchrFunction, memcpyFunction, memsetFunction, memcmpFunction, fromJSArrayBufferFunction, toJSArrayBufferFunction, fromJSStringFunction, fromJSArrayFunction, threadPausedFunction, dirtyMutVarFunction, trapLoadI8Function, trapStoreI8Function, trapLoadI16Function, trapStoreI16Function, trapLoadI32Function, trapStoreI32Function, trapLoadI64Function, trapStoreI64Function, trapLoadF32Function, trapStoreF32Function, trapLoadF64Function, trapStoreF64Function ::
      BuiltinsOptions -> Function
 mainFunction BuiltinsOptions {} =
   runEDSL [] $ do
@@ -1024,6 +1031,12 @@ printI64Function _ =
   runEDSL [] $ do
     x <- param I64
     callImport "printI64" [convertSInt64ToFloat64 x]
+
+assertEqI64Function _ =
+  runEDSL [] $ do
+    x <- param I64
+    y <- param I64
+    callImport "assertEqI64" [convertSInt64ToFloat64 x, convertSInt64ToFloat64 y]
 
 printF32Function _ =
   runEDSL [] $ do

--- a/asterius/test/fib/fib.hs
+++ b/asterius/test/fib/fib.hs
@@ -52,11 +52,13 @@ sizeofBinTree Tip = 1
 sizeofBinTree (Branch x y) = 1 + sizeofBinTree x + sizeofBinTree y
 
 foreign import ccall unsafe "print_i64" print_i64 :: Int -> IO ()
+foreign import ccall unsafe "assert_eq_i64" assert_eq_i64 :: Int -> Int -> IO ()
 
 foreign import ccall unsafe "print_f64" print_f64 :: Double -> IO ()
 
 main :: IO ()
 main = do
+  assert_eq_i64 (fact 5) 120
   print_i64 $ fib 10
   print_i64 $ fact 5
   print_f64 $ cos 0.5


### PR DESCRIPTION
This was more to understand the codebase. But if this is useful, we can use this to add checking
for equality / inequality quite easily.