### PR TITLE
Make fib.hs check for regression by using assert_eq_i64

### DIFF
--- a/asterius/test/fib/fib.hs
+++ b/asterius/test/fib/fib.hs
@@ -58,13 +58,35 @@ foreign import ccall unsafe "print_f64" print_f64 :: Double -> IO ()
 
 main :: IO ()
 main = do
-  assert_eq_i64 (fact 5) 120
+  -- Test that assert_eq works
+  assert_eq_i64 10 10
+
   print_i64 $ fib 10
+  assert_eq_i64 (fib 10) 55
+
   print_i64 $ fact 5
+  assert_eq_i64 (fact 5) 120
+
   print_f64 $ cos 0.5
   print_f64 $ 2 ** 3
-  print_i64 $ sizeofBinTree $ force $ genBinTree 3
-  print_i64 $ sizeofBinTree $ force $ genBinTree 5
+
+  let sizeof3Tree = sizeofBinTree $ force $ genBinTree 3
+  print_i64 $ sizeof3Tree
+  -- 2^4 - 1
+  assert_eq_i64 sizeof3Tree 15
+
+  let sizeof5Tree = sizeofBinTree $ force $ genBinTree 5
+  print_i64 $ sizeof5Tree
+  -- 2^6 - 1
+  assert_eq_i64 sizeof5Tree 63
+
   print_i64 $ facts !! 5
-  print_i64 $ factMap 10 IM.! 5
+  assert_eq_i64 (facts !! 5) 120
+
+  let factmapAt5 = factMap 10 IM.! 5
+  print_i64 $ factmapAt5
+  assert_eq_i64 factmapAt5 120
+
+  -- 0! + 1! + 2! + 3! + 4! + 5!
   print_i64 $ sumFacts 5
+  assert_eq_i64 (sumFacts 5) (154)


### PR DESCRIPTION
First add `assert_eq_i64 10 10` to check that `asseet_eq_i64` succeeds when inputs are equal. We will add another test case to ensure that `assert_eq_i64` fails correctly when its inputs are not
equal.

Beef up the `fib.hs` test case by using `assert_eq_i64` wherever
appropriate to check for regression.