### PR TITLE
Correct MOD_SS_Conv/Mod_UU_Conv behaviour for I8/I16

### DIFF
--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -22,6 +22,7 @@ extra-source-files:
   - test/todomvc/**/*.html
   - test/teletype/**/*.hs
   - test/bytearray/**/*.hs
+  - test/bytearraymini/**/*.hs
   - test/bigint/**/*.hs
   - test/cloudflare/**/*.hs
   - test/cloudflare/cloudflare.mjs
@@ -189,6 +190,13 @@ tests:
   bytearray:
     source-dirs: test
     main: bytearray.hs
+    ghc-options: -threaded -rtsopts
+    dependencies:
+      - asterius
+
+  bytearraymini:
+    source-dirs: test
+    main: bytearraymini.hs
     ghc-options: -threaded -rtsopts
     dependencies:
       - asterius

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -70,11 +70,11 @@ rtsAsteriusModule opts =
                 { staticsType = Bytes
                 , asteriusStatics = [Serialized $ encodeStorable invalidAddress]
                 })
-          , ("__asterius_i64_slot"
+          , ( "__asterius_i64_slot"
             , AsteriusStatics
-              { staticsType=Bytes
-              , asteriusStatics = [Serialized $ SBS.pack $ replicate 8 0]
-              })
+                { staticsType = Bytes
+                , asteriusStatics = [Serialized $ SBS.pack $ replicate 8 0]
+                })
           ]
     , functionMap =
         Map.fromList $
@@ -1044,7 +1044,9 @@ assertEqI64Function _ =
   runEDSL [] $ do
     x <- param I64
     y <- param I64
-    callImport "assertEqI64" [convertSInt64ToFloat64 x, convertSInt64ToFloat64 y]
+    callImport
+      "assertEqI64"
+      [convertSInt64ToFloat64 x, convertSInt64ToFloat64 y]
 
 printF32Function _ =
   runEDSL [] $ do
@@ -1070,7 +1072,7 @@ memchrFunction _ =
     p <-
       callImport'
         "__asterius_memchr"
-        (map (convertUInt64ToFloat64) [ptr, val, num])
+        (map convertUInt64ToFloat64 [ptr, val, num])
         F64
     emit $ truncUFloat64ToInt64 p
 
@@ -1078,14 +1080,14 @@ memcpyFunction _ =
   runEDSL [I64] $ do
     setReturnTypes [I64]
     [dst, src, n] <- params [I64, I64, I64]
-    callImport "__asterius_memcpy" $ map (convertUInt64ToFloat64) [dst, src, n]
+    callImport "__asterius_memcpy" $ map convertUInt64ToFloat64 [dst, src, n]
     emit dst
 
 memsetFunction _ =
   runEDSL [I64] $ do
     setReturnTypes [I64]
     [dst, c, n] <- params [I64, I64, I64]
-    callImport "__asterius_memset" $ map (convertUInt64ToFloat64) [dst, c, n]
+    callImport "__asterius_memset" $ map convertUInt64ToFloat64 [dst, c, n]
     emit dst
 
 memcmpFunction _ =
@@ -1095,7 +1097,7 @@ memcmpFunction _ =
     cres <-
       callImport'
         "__asterius_memcmp"
-        (map (convertUInt64ToFloat64) [ptr1, ptr2, n])
+        (map convertUInt64ToFloat64 [ptr1, ptr2, n])
         I32
     emit $ Unary ExtendSInt32 cres
 
@@ -1119,7 +1121,7 @@ toJSArrayBufferFunction _ =
       truncUFloat64ToInt64 <$>
       callImport'
         "__asterius_toJSArrayBuffer_imp"
-        (map (convertUInt64ToFloat64) [addr, len])
+        (map convertUInt64ToFloat64 [addr, len])
         F64
     emit r
 
@@ -1547,19 +1549,18 @@ trapStoreF64Function _ =
 offset_StgTSO_StgStack :: Int
 offset_StgTSO_StgStack = 8 * roundup_bytes_to_words sizeof_StgTSO
 
-
 -- @cheng: there is a trade-off here: Either I emit the low-level
 -- store and load, or I expose a _lot more_ from the EDSL
 -- to create the correct types of stores and loads I want.
 -- I went with the former, but we can discuss trade-offs.
-
 -- | Generate a wrap from the input type to the output type by invoking
 -- | the correct load instruction.
 -- | Since we only generate wrapping from larger types to smaller types,
 -- | our output can only be {32, 16, 8} bits. However, wasm has
 -- | I32 as the smallest type. So, our output is _always_ I32.
 -- | invariant: output type is smaller than input type.
-genWrap :: ValueType -- ^ Input type
+genWrap ::
+     ValueType -- ^ Input type
   -> Int -- ^ number of bytes to load for the output type
   -> Expression
   -> Expression
@@ -1588,9 +1589,11 @@ genWrap ti b x =
     , blockReturnTypes = [I32]
     }
 
-
 -- | Whether when generate a sign extended value
-data ShouldSext = Sext | NoSext deriving(Eq)
+data ShouldSext
+  = Sext
+  | NoSext
+  deriving (Eq)
 
 -- | generate a function to sign extend an input value into an output value.
 -- | We perform the sign extension by storing the old value.
@@ -1598,31 +1601,33 @@ data ShouldSext = Sext | NoSext deriving(Eq)
 -- | ever have to generate sign extension calls from GHC.W8, GHC.W16, GHC.W32,
 -- | all of which are stored as I32, since wasm cannot store smaller types.
 -- | So, our input will _always_ be an I32.
-genExtend :: Int -- ^ number of bytes to load
-    -> ValueType -- ^ output value type
-    -> ShouldSext -- ^ whether the extend should sign-extend or not
-    -> Expression
-    -> Expression
-genExtend b to sext x =
+genExtend ::
+     Int -- ^ number of bytes to load
+  -> ValueType -- ^ output value type
+  -> ShouldSext -- ^ whether the extend should sign-extend or not
+  -> Expression
+  -> Expression
+genExtend b to sext x
         -- we will just use the i64 slot since it's large enough to hold all
         -- the wasm datatypes we have.
-        Block
-          { name = ""
-          , bodys =
-              [ Store
-                  { bytes = 4
-                  , offset = 0
-                  , ptr = symbol "__asterius_i64_slot"
-                  , value = x
-                  , valueType = I32
-                  }
-              , Load
-                  { signed = sext == Sext
-                  , bytes = fromIntegral b
-                  , offset = 0
-                  , valueType = to
-                  , ptr = wrapInt64 (symbol "__asterius_i64_slot")
-                  }
-              ]
-          , blockReturnTypes = [to]
-          }
+ =
+  Block
+    { name = ""
+    , bodys =
+        [ Store
+            { bytes = 4
+            , offset = 0
+            , ptr = symbol "__asterius_i64_slot"
+            , value = x
+            , valueType = I32
+            }
+        , Load
+            { signed = sext == Sext
+            , bytes = fromIntegral b
+            , offset = 0
+            , valueType = to
+            , ptr = wrapInt64 (symbol "__asterius_i64_slot")
+            }
+        ]
+    , blockReturnTypes = [to]
+    }

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -67,6 +67,17 @@ rtsAsteriusModule opts =
                 { staticsType = Bytes
                 , asteriusStatics = [Serialized $ encodeStorable invalidAddress]
                 })
+          , ("__asterius_i32_slot"
+            , AsteriusStatics
+              { staticsType=Bytes
+              , asteriusStatics = [Serialized $ SBS.pack $ replicate (roundup_bytes_to_words 4) 0]
+              })
+
+          , ("__asterius_i64_slot"
+            , AsteriusStatics
+              { staticsType=Bytes
+              , asteriusStatics = [Serialized $ SBS.pack $ replicate (roundup_bytes_to_words 8) 0]
+              })
           ]
     , functionMap =
         Map.fromList $
@@ -184,6 +195,21 @@ rtsAsteriusModule opts =
         , ("print_f32", printF32Function opts)
         , ("print_f64", printF64Function opts)
         , ("assert_eq_i64", assertEqI64Function opts)
+        -- wrap
+        , ("wrapI64ToI8", genWrap I64 1)
+        , ("wrapI32ToI8", genWrap I32 1)
+        , ("wrapI64ToI16", genWrap I64 2)
+        , ("wrapI32ToI16", genWrap I32 2)
+        -- sext
+        , ("extendI8ToI64Sext", genExtend 1 I64 Sext)
+        , ("extendI16ToI64Sext", genExtend 2 I64 Sext)
+        , ("extendI8ToI32Sext", genExtend 1 I32 Sext)
+        , ("extendI16ToI32Sext", genExtend 2 I32 Sext)
+        -- no SEXT
+        , ("extendI8ToI64", genExtend 1 I64 NoSext)
+        , ("extendI16ToI64", genExtend 2 I64 NoSext)
+        , ("extendI8ToI32", genExtend 1 I32 NoSext)
+        , ("extendI16ToI32", genExtend 2 I32 NoSext)
         , ("strlen", strlenFunction opts)
         , ("memchr", memchrFunction opts)
         , ("memcpy", memcpyFunction opts)
@@ -1538,3 +1564,63 @@ trapStoreF64Function _ =
 
 offset_StgTSO_StgStack :: Int
 offset_StgTSO_StgStack = 8 * roundup_bytes_to_words sizeof_StgTSO
+
+
+-- @cheng: there is a trade-off here: Either I emit the low-level
+-- store and load, or I expose a _lot more_ from the EDSL
+-- to create the correct types of stores and loads I want.
+-- I went with the former, but we can discuss trade-offs.
+
+-- | Generate a wrap from the input type to the output type by invoking
+-- | the correct load instruction.
+-- | Since we only generate wrapping from larger types to smaller types,
+-- | our output can only be {32, 16, 8} bits. However, wasm has
+-- | I32 as the smallest type. So, our output is _always_ I32.
+-- | invariant: output type is smaller than input type.
+genWrap :: ValueType -- ^ Input type
+  -> Int -- ^ number of bytes to load for the output type
+  -> Function
+genWrap ti b =
+  runEDSL [I32] $ do
+  setReturnTypes [I32]
+  x <- param ti
+  emit $ Store {
+               bytes=if ti == I32 then 4 else 8
+               , offset=0
+               , ptr = wrapInt64 (symbol "__asterius_i64_slot")
+               , value = x
+               , valueType= ti
+               }
+  emit $ Load { signed=False
+              , bytes=fromIntegral b
+              , offset=0
+              , valueType=I32
+              , ptr = wrapInt64(symbol "__asterius_i64_slot")
+              }
+
+-- | Whether when generate a sign extended value
+data ShouldSext = Sext | NoSext deriving(Eq)
+
+-- | generate a function to sign extend an input value into an output value.
+-- | We perform the sign extension by storing the old value.
+-- | Note that our input type is always I32. This is because we will only
+-- | ever have to generate sign extension calls from GHC.W8, GHC.W16, GHC.W32,
+-- | all of which are stored as I32, since wasm cannot store smaller types.
+-- | So, our input will _always_ be an I32.
+genExtend :: Int -- ^ number of bytes to load
+    -> ValueType -- ^ output value type
+    -> ShouldSext -- ^ whether the extend should sign-extend or not
+    -> Function
+genExtend b to sext =
+    runEDSL [to] $ do
+        setReturnTypes [to]
+        x <- param I32
+        -- we will just use the i64 slot since it's large enough to hold all
+        -- the wasm datatypes we have.
+        storeI32 (symbol "__asterius_i64_slot") 0 x
+        emit $ Load { signed=(sext == Sext)
+                    , bytes=fromIntegral b
+                    , offset=0
+                    , valueType=to
+                    , ptr = wrapInt64(symbol "__asterius_i64_slot")
+                    }

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -70,7 +70,7 @@ rtsAsteriusModule opts =
           , ("__asterius_i64_slot"
             , AsteriusStatics
               { staticsType=Bytes
-              , asteriusStatics = [Serialized $ SBS.pack $ replicate (roundup_bytes_to_words 8) 0]
+              , asteriusStatics = [Serialized $ SBS.pack $ replicate 8 0]
               })
           ]
     , functionMap =

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -67,12 +67,6 @@ rtsAsteriusModule opts =
                 { staticsType = Bytes
                 , asteriusStatics = [Serialized $ encodeStorable invalidAddress]
                 })
-          , ("__asterius_i32_slot"
-            , AsteriusStatics
-              { staticsType=Bytes
-              , asteriusStatics = [Serialized $ SBS.pack $ replicate (roundup_bytes_to_words 4) 0]
-              })
-
           , ("__asterius_i64_slot"
             , AsteriusStatics
               { staticsType=Bytes

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -1617,7 +1617,7 @@ genExtend b to sext x
         [ Store
             { bytes = 4
             , offset = 0
-            , ptr = symbol "__asterius_i64_slot"
+            , ptr = wrapInt64 (symbol "__asterius_i64_slot")
             , value = x
             , valueType = I32
             }

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -302,6 +302,18 @@ marshalCmmBinMachOp o32 tx32 ty32 tr32 o64 tx64 ty64 tr64 w x y =
         ye <- marshalAndCastCmmExpr y ty64
         pure (Binary {binaryOp = o64, operand0 = xe, operand1 = ye}, tr64))
 
+widthToInt :: GHC.Width -> Int
+widthToInt (GHC.W8) = 8
+widthToInt (GHC.W16) = 16
+widthToInt (GHC.W32) = 32
+widthToInt (GHC.W64) = 64
+widthToInt (GHC.W128) = 128
+widthToInt (GHC.W256) = 256
+widthToInt (GHC.W512) = 512
+
+data ShouldSext = Sext | NoSext deriving(Eq)
+
+-- Should this logic be pushed into `marshalAndCastCmmExpr?
 marshalCmmHomoConvMachOp ::
      UnaryOp
   -> UnaryOp
@@ -309,12 +321,39 @@ marshalCmmHomoConvMachOp ::
   -> ValueType
   -> GHC.Width
   -> GHC.Width
+  -> ShouldSext
   -> GHC.CmmExpr
   -> CodeGen (Expression, ValueType)
-marshalCmmHomoConvMachOp o36 o63 t32 t64 _ w1 x = do
-  (o, t, tr) <- dispatchCmmWidth w1 (o63, t64, t32) (o36, t32, t64)
-  xe <- marshalAndCastCmmExpr x t
-  pure (Unary {unaryOp = o, operand0 = xe}, tr)
+marshalCmmHomoConvMachOp o36 o63 t32 t64 w0 w1 sext x =
+  if (w0 == GHC.W8 || w0 == GHC.W16) && (w1 == GHC.W32 || w1 == GHC.W64)
+  then do
+    -- we are extending from {W8, W16} to {W32, W64}. Sign extension
+    -- semantics matters here.
+    let name = AsteriusEntitySymbol $ "extendI" <> showSBS (widthToInt w0) <> "ToI" <> showSBS (widthToInt w1)
+    (xe, _) <- marshalCmmExpr x
+    let c = Call
+              { target = name <> (if sext == Sext then "Sext" else "")
+              , operands = [xe]
+              , callReturnTypes = [if w1 == GHC.W64 then I64 else I32]
+              }
+    pure (c, if w1 == GHC.W64 then I64 else I32)
+  else if (w0 == GHC.W32 || w0 == GHC.W64) && (w1 == GHC.W8 || w1 == GHC.W16)
+  then do
+    -- we are wrapping from {32, 64} to {8, 16}
+    let name = AsteriusEntitySymbol $ "wrapI" <> showSBS (widthToInt w0) <> "ToI" <> showSBS (widthToInt w1)
+    -- traceM $ "$ in marshal: " <> show w0 <> " -> " <> show w1 <> "(" <> show name <> ")"
+    (xe, _) <- marshalCmmExpr x
+    let c = Call
+              { target = name
+              , operands = [xe]
+              , callReturnTypes = [I32]
+              }
+    pure (c, I32)
+  else do
+    -- we are converting from {32, 64} to {32, 64} of floating point / int
+    (o, t, tr) <- dispatchCmmWidth w1 (o63, t64, t32) (o36, t32, t64)
+    xe <- marshalAndCastCmmExpr x t
+    pure (Unary {unaryOp = o, operand0 = xe}, tr)
 
 marshalCmmHeteroConvMachOp ::
      UnaryOp
@@ -478,11 +517,11 @@ marshalCmmMachOp (GHC.MO_FS_Conv w0 w1) [x] =
     w1
     x
 marshalCmmMachOp (GHC.MO_SS_Conv w0 w1) [x] =
-  marshalCmmHomoConvMachOp ExtendSInt32 WrapInt64 I32 I64 w0 w1 x
+  marshalCmmHomoConvMachOp ExtendSInt32 WrapInt64 I32 I64 w0 w1 Sext x
 marshalCmmMachOp (GHC.MO_UU_Conv w0 w1) [x] =
-  marshalCmmHomoConvMachOp ExtendUInt32 WrapInt64 I32 I64 w0 w1 x
+  marshalCmmHomoConvMachOp ExtendUInt32 WrapInt64 I32 I64 w0 w1 NoSext x
 marshalCmmMachOp (GHC.MO_FF_Conv w0 w1) [x] =
-  marshalCmmHomoConvMachOp PromoteFloat32 DemoteFloat64 F32 F64 w0 w1 x
+  marshalCmmHomoConvMachOp PromoteFloat32 DemoteFloat64 F32 F64 w0 w1 Sext x
 marshalCmmMachOp op xs =
   throwError $ UnsupportedCmmExpr $ showSBS $ GHC.CmmMachOp op xs
 

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -302,15 +302,6 @@ marshalCmmBinMachOp o32 tx32 ty32 tr32 o64 tx64 ty64 tr64 w x y =
         ye <- marshalAndCastCmmExpr y ty64
         pure (Binary {binaryOp = o64, operand0 = xe, operand1 = ye}, tr64))
 
-widthToInt :: GHC.Width -> Int
-widthToInt (GHC.W8) = 8
-widthToInt (GHC.W16) = 16
-widthToInt (GHC.W32) = 32
-widthToInt (GHC.W64) = 64
-widthToInt (GHC.W128) = 128
-widthToInt (GHC.W256) = 256
-widthToInt (GHC.W512) = 512
-
 data ShouldSext = Sext | NoSext deriving(Eq)
 
 -- Should this logic be pushed into `marshalAndCastCmmExpr?
@@ -329,7 +320,7 @@ marshalCmmHomoConvMachOp o36 o63 t32 t64 w0 w1 sext x =
   then do
     -- we are extending from {W8, W16} to {W32, W64}. Sign extension
     -- semantics matters here.
-    let name = AsteriusEntitySymbol $ "extendI" <> showSBS (widthToInt w0) <> "ToI" <> showSBS (widthToInt w1)
+    let name = AsteriusEntitySymbol $ "extendI" <> showSBS (GHC.widthInBits w0) <> "ToI" <> showSBS (GHC.widthInBits w1)
     (xe, _) <- marshalCmmExpr x
     let c = Call
               { target = name <> (if sext == Sext then "Sext" else "")
@@ -340,7 +331,7 @@ marshalCmmHomoConvMachOp o36 o63 t32 t64 w0 w1 sext x =
   else if (w0 == GHC.W32 || w0 == GHC.W64) && (w1 == GHC.W8 || w1 == GHC.W16)
   then do
     -- we are wrapping from {32, 64} to {8, 16}
-    let name = AsteriusEntitySymbol $ "wrapI" <> showSBS (widthToInt w0) <> "ToI" <> showSBS (widthToInt w1)
+    let name = AsteriusEntitySymbol $ "wrapI" <> showSBS (GHC.widthInBits w0) <> "ToI" <> showSBS (GHC.widthInBits w1)
     -- traceM $ "$ in marshal: " <> show w0 <> " -> " <> show w1 <> "(" <> show name <> ")"
     (xe, _) <- marshalCmmExpr x
     let c = Call

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -320,7 +320,7 @@ marshalCmmHomoConvMachOp o36 o63 t32 t64 w0 w1 sext x =
     -- we are extending from {W8, W16} to {W32, W64}. Sign extension
     -- semantics matters here.
     (xe, _) <- marshalCmmExpr x
-    pure (genExtend (if w1 == GHC.W32 then 4 else 8) (if w1 == GHC.W32 then I32 else I64) sext xe, if w1 == GHC.W64 then I64 else I32)
+    pure (genExtend (if w0 == GHC.W8 then 1 else 2) (if w1 == GHC.W32 then I32 else I64) sext xe, if w1 == GHC.W64 then I64 else I32)
   else if (w0 == GHC.W32 || w0 == GHC.W64) && (w1 == GHC.W8 || w1 == GHC.W16)
   then do
     -- we are wrapping from {32, 64} to {8, 16}

--- a/asterius/test/bytearray/bytearray.hs
+++ b/asterius/test/bytearray/bytearray.hs
@@ -8,6 +8,18 @@ import Data.Foldable
 import GHC.Exts
 import GHC.Types
 
+{-
+This test case tests the ability of the compiler to handle casts from I8 to
+I64 in a real-world example by using the `ByteArray#` primitives.
+
+Expected output:
+(1,63)
+(1,-1)
+(1,-1)
+(1,-1)
+199990000
+-}
+
 unI# :: Int -> Int#
 unI# (I# x) = x
 

--- a/asterius/test/bytearraymini.hs
+++ b/asterius/test/bytearraymini.hs
@@ -1,0 +1,8 @@
+import System.Environment
+import System.Process
+
+main :: IO ()
+main = do
+  args <- getArgs
+  callProcess "ahc-link" $
+    ["--input-hs", "test/bytearraymini/bytearraymini.hs", "--run"] <> args

--- a/asterius/test/bytearraymini/bytearraymini.hs
+++ b/asterius/test/bytearraymini/bytearraymini.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# OPTIONS_GHC -O2 -fforce-recomp
+  -Wall -ddump-to-file -ddump-simpl -ddump-stg -ddump-cmm-raw -ddump-asm #-}
+
+import GHC.Exts
+import GHC.Types
+
+{-
+This test case tests the ability of the compiler to handle casts from I8/I16 to
+I64 in a hand-written test case.
+
+Expected output:
+-1
+255
+-1
+65535
+-}
+
+mainInt8 :: IO ()
+mainInt8 = do
+  r <-
+    IO $ \s0 ->
+      case newByteArray# 8# s0 of
+        (# s1, mba #) ->
+          case writeInt8Array# mba 0# 255# s1 of
+            s2 ->
+              case unsafeFreezeByteArray# mba s2 of
+                (# s10, ba #) -> (# s10, I# (indexInt8Array# ba 0#) #)
+  print r
+
+mainInt16 :: IO ()
+mainInt16 = do
+  r <-
+    IO $ \s0 ->
+      case newByteArray# 16# s0 of
+        (# s1, mba #) ->
+          case writeInt16Array# mba 0# 65535# s1 of
+            s2 ->
+              case unsafeFreezeByteArray# mba s2 of
+                (# s10, ba #) -> (# s10, I# (indexInt16Array# ba 0#) #)
+  print r
+
+mainWord8 :: IO ()
+mainWord8 = do
+  r <-
+    IO $ \s0 ->
+      case newByteArray# 8# s0 of
+        (# s1, mba #) ->
+          case writeWord8Array# mba 0# 255## s1 of
+            s2 ->
+              case unsafeFreezeByteArray# mba s2 of
+                (# s10, ba #) -> (# s10, W# (indexWord8Array# ba 0#) #)
+  print r
+
+mainWord16 :: IO ()
+mainWord16 = do
+  r <-
+    IO $ \s0 ->
+      case newByteArray# 16# s0 of
+        (# s1, mba #) ->
+          case writeWord16Array# mba 0# 65535## s1 of
+            s2 ->
+              case unsafeFreezeByteArray# mba s2 of
+                (# s10, ba #) -> (# s10, W# (indexWord16Array# ba 0#) #)
+  print r
+
+main :: IO ()
+main = do
+    mainInt8
+    mainWord8
+    mainInt16
+    mainWord16


### PR DESCRIPTION
This PR supersedes #112. This is a cleaned up version of PR #112 with consistent history. 

We add a testcase `bytearraymini` which is a simplified version of `bytearray` which tests `I8/I16 -> I64` upcasting.

Unfortunately, we do not have a testcase for the downcast of `I64/I32 -> I16/I8`, though the code path has been implemented in the same test case. 

