### PR TITLE
Re-enable the memory trap framework of debug mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,10 @@ jobs:
             stack --no-terminal test asterius:fib --test-arguments="--no-gc-sections"
             stack --no-terminal test asterius:fib --test-arguments="--binaryen --no-gc-sections"
             stack --no-terminal test asterius:fib --test-arguments="--sync"
+
+            cd ~/.local
+            $CIRCLE_WORKING_DIRECTORY/utils/v8-node.py
+            cd $CIRCLE_WORKING_DIRECTORY
             stack --no-terminal test asterius:fib --test-arguments="--debug" > /dev/null
             stack --no-terminal test asterius:jsffi --test-arguments="--debug" > /dev/null
             stack --no-terminal test asterius:array --test-arguments="--debug" > /dev/null
@@ -73,9 +77,6 @@ jobs:
             # stack --no-terminal test asterius:bytearray --test-arguments="--debug" > /dev/null
             stack --no-terminal test asterius:bigint --test-arguments="--debug" > /dev/null
 
-            cd ~/.local
-            $CIRCLE_WORKING_DIRECTORY/utils/v8-node.py
-            cd $CIRCLE_WORKING_DIRECTORY
             stack --no-terminal test asterius:fib --test-arguments="--tail-calls"
             stack --no-terminal test asterius:fib --test-arguments="--tail-calls --no-gc-sections"
 

--- a/asterius/rts/rts.memory.mjs
+++ b/asterius/rts/rts.memory.mjs
@@ -46,6 +46,14 @@ export class Memory {
   f32Store(p, v) { this.dataView.setFloat32(Memory.unTag(p), Number(v), true); }
   f64Load(p) { return this.dataView.getFloat64(Memory.unTag(p), true); }
   f64Store(p, v) { this.dataView.setFloat64(Memory.unTag(p), Number(v), true); }
+  i32LoadS8(p) { return this.dataView.getInt8(Memory.unTag(p)); }
+  i32LoadU8(p) { return this.dataView.getUint8(Memory.unTag(p)); }
+  i32LoadS16(p) { return this.dataView.getInt16(Memory.unTag(p), true); }
+  i32LoadU16(p) { return this.dataView.getUint16(Memory.unTag(p), true); }
+  i64LoadS8(p) { return BigInt(this.dataView.getInt8(Memory.unTag(p))); }
+  i64LoadU8(p) { return BigInt(this.dataView.getUint8(Memory.unTag(p))); }
+  i64LoadS16(p) { return BigInt(this.dataView.getInt16(Memory.unTag(p), true)); }
+  i64LoadU16(p) { return BigInt(this.dataView.getUint16(Memory.unTag(p), true)); }
   heapAlloced(p) { return Memory.unTag(p) >= (this.staticMBlocks << Math.log2(rtsConstants.mblock_size)); }
   strlen(_str) { return this.i8View.subarray(Memory.unTag(_str)).indexOf(0); }
   memchr(_ptr, val, num) {

--- a/asterius/rts/rts.memorytrap.mjs
+++ b/asterius/rts/rts.memorytrap.mjs
@@ -12,8 +12,7 @@ export class MemoryTrap {
 
   showI64(x) { return "0x" + x.toString(16).padStart(8, "0"); }
 
-  trap(_p, o) {
-    const p = _p + o;
+  trap(p) {
     if (Memory.getTag(p) != rtsConstants.dataTag) {
       const err =
           new WebAssembly.RuntimeError("Invalid address " + this.showI64(p));
@@ -23,188 +22,122 @@ export class MemoryTrap {
   }
 
   loadI8(bp, o) {
-    /*
-    this.logger.logInfo([
-      "load", "i8", p, this.symbolLookupTable[p], o, v,
-      this.symbolLookupTable[v]
-    ]);
-    this.trap(p, o);
-    */
     const p = bp + BigInt(o);
+    this.trap(p);
     return this.memory.i8Load(p);
   }
 
   loadI16(bp, o) {
-    /*
-    this.logger.logInfo([
-      "load", "i16", p, this.symbolLookupTable[p], o, v,
-      this.symbolLookupTable[v]
-    ]);
-    this.trap(p, o);
-    */
     const p = bp + BigInt(o);
+    this.trap(p);
     return this.memory.i16Load(p);
   }
 
   loadI32(bp, o) {
-    /*
-    this.logger.logInfo([
-      "load", "i32", p, this.symbolLookupTable[p], o, v,
-      this.symbolLookupTable[v]
-    ]);
-    this.trap(p, o);
-    */
     const p = bp + BigInt(o);
+    this.trap(p);
     return this.memory.i32Load(p);
   }
 
   loadI64(bp, o) {
-    /*
-    const v = (BigInt(v_hi) << BigInt(32)) | BigInt(v_lo);
-    this.logger.logInfo([
-      "load", "i64", p, this.symbolLookupTable[p], o, v,
-      this.symbolLookupTable[v]
-    ]);
-    this.trap(p, o);
-    */
     const p = bp + BigInt(o);
+    this.trap(p);
     return this.memory.i64Load(p);
   }
 
   loadI32S8(bp, o) {
     const p = bp + BigInt(o);
+    this.trap(p);
     return this.memory.i32LoadS8(p);
   }
 
   loadI32U8(bp, o) {
     const p = bp + BigInt(o);
+    this.trap(p);
     return this.memory.i32LoadU8(p);
   }
 
   loadI32S16(bp, o) {
     const p = bp + BigInt(o);
+    this.trap(p);
     return this.memory.i32LoadS16(p);
   }
 
   loadI32U16(bp, o) {
     const p = bp + BigInt(o);
+    this.trap(p);
     return this.memory.i32LoadU16(p);
   }
 
   loadI64S8(bp, o) {
     const p = bp + BigInt(o);
+    this.trap(p);
     return this.memory.i64LoadS8(p);
   }
 
   loadI64U8(bp, o) {
     const p = bp + BigInt(o);
+    this.trap(p);
     return this.memory.i64LoadU8(p);
   }
 
   loadI64S16(bp, o) {
     const p = bp + BigInt(o);
+    this.trap(p);
     return this.memory.i64LoadS16(p);
   }
 
   loadI64U16(bp, o) {
     const p = bp + BigInt(o);
+    this.trap(p);
     return this.memory.i64LoadU16(p);
   }
 
   loadF32(bp, o) {
-    /*
-    this.logger.logInfo([
-      "load", "f32", p, this.symbolLookupTable[p], o, v,
-      this.symbolLookupTable[v]
-    ]);
-    this.trap(p, o);
-    */
     const p = bp + BigInt(o);
+    this.trap(p);
     return this.memory.f32Load(p);
   }
 
   loadF64(bp, o) {
-    /*
-    this.logger.logInfo([
-      "load", "f64", p, this.symbolLookupTable[p], o, v,
-      this.symbolLookupTable[v]
-    ]);
-    this.trap(p, o);
-    */
     const p = bp + BigInt(o);
+    this.trap(p);
     return this.memory.f64Load(p);
   }
 
   storeI8(bp, o, v) {
-    /*
-    this.logger.logInfo([
-      "store", "i8", p, this.symbolLookupTable[p], o, v,
-      this.symbolLookupTable[v]
-    ]);
-    this.trap(p, o);
-    */
     const p = bp + BigInt(o);
+    this.trap(p);
     this.memory.i8Store(p, v);
   }
 
   storeI16(bp, o, v) {
-    /*
-    this.logger.logInfo([
-      "store", "i16", p, this.symbolLookupTable[p], o, v,
-      this.symbolLookupTable[v]
-    ]);
-    this.trap(p, o);
-    */
     const p = bp + BigInt(o);
+    this.trap(p);
     this.memory.i16Store(p, v);
   }
 
   storeI32(bp, o, v) {
-    /*
-    this.logger.logInfo([
-      "store", "i32", p, this.symbolLookupTable[p], o, v,
-      this.symbolLookupTable[v]
-    ]);
-    this.trap(p, o);
-    */
     const p = bp + BigInt(o);
+    this.trap(p);
     this.memory.i32Store(p, v);
   }
 
   storeI64(bp, o, v) {
-    /*
-    const v = (BigInt(v_hi) << BigInt(32)) | BigInt(v_lo);
-    this.logger.logInfo([
-      "store", "i64", p, this.symbolLookupTable[p], o, v,
-      this.symbolLookupTable[v]
-    ]);
-    this.trap(p, o);
-    */
     const p = bp + BigInt(o);
+    this.trap(p);
     this.memory.i64Store(p, v);
   }
 
   storeF32(bp, o, v) {
-    /*
-    this.logger.logInfo([
-      "store", "f32", p, this.symbolLookupTable[p], o, v,
-      this.symbolLookupTable[v]
-    ]);
-    this.trap(p, o);
-    */
     const p = bp + BigInt(o);
+    this.trap(p);
     this.memory.f32Store(p, v);
   }
 
   storeF64(bp, o, v) {
-    /*
-    this.logger.logInfo([
-      "store", "f64", p, this.symbolLookupTable[p], o, v,
-      this.symbolLookupTable[v]
-    ]);
-    this.trap(p, o);
-    */
     const p = bp + BigInt(o);
+    this.trap(p);
     this.memory.f64Store(p, v);
   }
 }

--- a/asterius/rts/rts.memorytrap.mjs
+++ b/asterius/rts/rts.memorytrap.mjs
@@ -2,10 +2,11 @@ import * as rtsConstants from "./rts.constants.mjs";
 import { Memory } from "./rts.memory.mjs";
 
 export class MemoryTrap {
-  constructor(logger, syms) {
+  constructor(logger, syms, memory) {
     this.logger = logger;
     this.symbolLookupTable = {};
     for (const[k, v] of Object.entries(syms)) this.symbolLookupTable[v] = k;
+    this.memory = memory;
     Object.freeze(this);
   }
 
@@ -21,101 +22,149 @@ export class MemoryTrap {
     }
   }
 
-  loadI8(p, o, v) {
+  loadI8(bp, o) {
+    /*
     this.logger.logInfo([
       "load", "i8", p, this.symbolLookupTable[p], o, v,
       this.symbolLookupTable[v]
     ]);
     this.trap(p, o);
+    */
+    const p = bp + BigInt(o);
+    return this.memory.i8Load(p);
   }
 
-  loadI16(p, o, v) {
+  loadI16(bp, o) {
+    /*
     this.logger.logInfo([
       "load", "i16", p, this.symbolLookupTable[p], o, v,
       this.symbolLookupTable[v]
     ]);
     this.trap(p, o);
+    */
+    const p = bp + BigInt(o);
+    return this.memory.i16Load(p);
   }
 
-  loadI32(p, o, v) {
+  loadI32(bp, o) {
+    /*
     this.logger.logInfo([
       "load", "i32", p, this.symbolLookupTable[p], o, v,
       this.symbolLookupTable[v]
     ]);
     this.trap(p, o);
+    */
+    const p = bp + BigInt(o);
+    return this.memory.i32Load(p);
   }
 
-  loadI64(p, o, v_lo, v_hi) {
+  loadI64(bp, o) {
+    /*
     const v = (BigInt(v_hi) << BigInt(32)) | BigInt(v_lo);
     this.logger.logInfo([
       "load", "i64", p, this.symbolLookupTable[p], o, v,
       this.symbolLookupTable[v]
     ]);
     this.trap(p, o);
+    */
+    const p = bp + BigInt(o);
+    return this.memory.i64Load(p);
   }
 
-  loadF32(p, o, v) {
+  loadF32(bp, o) {
+    /*
     this.logger.logInfo([
       "load", "f32", p, this.symbolLookupTable[p], o, v,
       this.symbolLookupTable[v]
     ]);
     this.trap(p, o);
+    */
+    const p = bp + BigInt(o);
+    return this.memory.f32Load(p);
   }
 
-  loadF64(p, o, v) {
+  loadF64(bp, o) {
+    /*
     this.logger.logInfo([
       "load", "f64", p, this.symbolLookupTable[p], o, v,
       this.symbolLookupTable[v]
     ]);
     this.trap(p, o);
+    */
+    const p = bp + BigInt(o);
+    return this.memory.f64Load(p);
   }
 
-  storeI8(p, o, v) {
+  storeI8(bp, o, v) {
+    /*
     this.logger.logInfo([
       "store", "i8", p, this.symbolLookupTable[p], o, v,
       this.symbolLookupTable[v]
     ]);
     this.trap(p, o);
+    */
+    const p = bp + BigInt(o);
+    this.memory.i8Store(p, v);
   }
 
-  storeI16(p, o, v) {
+  storeI16(bp, o, v) {
+    /*
     this.logger.logInfo([
       "store", "i16", p, this.symbolLookupTable[p], o, v,
       this.symbolLookupTable[v]
     ]);
     this.trap(p, o);
+    */
+    const p = bp + BigInt(o);
+    this.memory.i16Store(p, v);
   }
 
-  storeI32(p, o, v) {
+  storeI32(bp, o, v) {
+    /*
     this.logger.logInfo([
       "store", "i32", p, this.symbolLookupTable[p], o, v,
       this.symbolLookupTable[v]
     ]);
     this.trap(p, o);
+    */
+    const p = bp + BigInt(o);
+    this.memory.i32Store(p, v);
   }
 
-  storeI64(p, o, v_lo, v_hi) {
+  storeI64(bp, o, v) {
+    /*
     const v = (BigInt(v_hi) << BigInt(32)) | BigInt(v_lo);
     this.logger.logInfo([
       "store", "i64", p, this.symbolLookupTable[p], o, v,
       this.symbolLookupTable[v]
     ]);
     this.trap(p, o);
+    */
+    const p = bp + BigInt(o);
+    this.memory.i64Store(p, v);
   }
 
-  storeF32(p, o, v) {
+  storeF32(bp, o, v) {
+    /*
     this.logger.logInfo([
       "store", "f32", p, this.symbolLookupTable[p], o, v,
       this.symbolLookupTable[v]
     ]);
     this.trap(p, o);
+    */
+    const p = bp + BigInt(o);
+    this.memory.f32Store(p, v);
   }
 
-  storeF64(p, o, v) {
+  storeF64(bp, o, v) {
+    /*
     this.logger.logInfo([
       "store", "f64", p, this.symbolLookupTable[p], o, v,
       this.symbolLookupTable[v]
     ]);
     this.trap(p, o);
+    */
+    const p = bp + BigInt(o);
+    this.memory.f64Store(p, v);
   }
 }

--- a/asterius/rts/rts.memorytrap.mjs
+++ b/asterius/rts/rts.memorytrap.mjs
@@ -71,6 +71,46 @@ export class MemoryTrap {
     return this.memory.i64Load(p);
   }
 
+  loadI32S8(bp, o) {
+    const p = bp + BigInt(o);
+    return this.memory.i32LoadS8(p);
+  }
+
+  loadI32U8(bp, o) {
+    const p = bp + BigInt(o);
+    return this.memory.i32LoadU8(p);
+  }
+
+  loadI32S16(bp, o) {
+    const p = bp + BigInt(o);
+    return this.memory.i32LoadS16(p);
+  }
+
+  loadI32U16(bp, o) {
+    const p = bp + BigInt(o);
+    return this.memory.i32LoadU16(p);
+  }
+
+  loadI64S8(bp, o) {
+    const p = bp + BigInt(o);
+    return this.memory.i64LoadS8(p);
+  }
+
+  loadI64U8(bp, o) {
+    const p = bp + BigInt(o);
+    return this.memory.i64LoadU8(p);
+  }
+
+  loadI64S16(bp, o) {
+    const p = bp + BigInt(o);
+    return this.memory.i64LoadS16(p);
+  }
+
+  loadI64U16(bp, o) {
+    const p = bp + BigInt(o);
+    return this.memory.i64LoadU16(p);
+  }
+
   loadF32(bp, o) {
     /*
     this.logger.logInfo([

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -25,7 +25,7 @@ export function newAsteriusInstance(req) {
     __asterius_wasm_table = new WebAssembly.Table({element: "anyfunc", initial: req.tableSlots}),
     __asterius_wasm_memory = new WebAssembly.Memory({initial: req.staticMBlocks * (rtsConstants.mblock_size / 65536)}),
     __asterius_memory = new Memory(),
-    __asterius_memory_trap = new MemoryTrap(__asterius_logger, req.symbolTable),
+    __asterius_memory_trap = new MemoryTrap(__asterius_logger, req.symbolTable, __asterius_memory),
     __asterius_mblockalloc = new MBlockAlloc(),
     __asterius_heapalloc = new HeapAlloc(__asterius_memory, __asterius_mblockalloc),
     __asterius_stableptr_manager = new StablePtrManager(),

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -400,7 +400,18 @@ rtsFunctionImports debug =
                 , ("F32", F32)
                 , ("F64", F64)
                 ]
-            ]
+            ] <>
+          [ FunctionImport
+            { internalName = "__asterius_load_" <> k1 <> "_" <> s <> b
+            , externalModuleName = "MemoryTrap"
+            , externalBaseName = "load" <> k1 <> s <> b
+            , functionType =
+                FunctionType {paramTypes = [I64, I32], returnTypes = [t1]}
+            }
+          | (k1, t1) <- [("I32", I32), ("I64", I64)]
+          , s <- ["S", "U"]
+          , b <- ["8", "16"]
+          ]
      else []) <>
   map (fst . snd) byteStringCBits
 

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -78,22 +78,7 @@ rtsAsteriusModule opts =
           ]
     , functionMap =
         Map.fromList $
-        (if debug opts
-        then    [ ("__asterius_trap_load_i8", trapLoadI8Function opts)
-                , ("__asterius_trap_store_i8", trapStoreI8Function opts)
-                , ("__asterius_trap_load_i16", trapLoadI16Function opts)
-                , ("__asterius_trap_store_i16", trapStoreI16Function opts)
-                , ("__asterius_trap_load_i32", trapLoadI32Function opts)
-                , ("__asterius_trap_store_i32", trapStoreI32Function opts)
-                , ("__asterius_trap_load_i64", trapLoadI64Function opts)
-                , ("__asterius_trap_store_i64", trapStoreI64Function opts)
-                , ("__asterius_trap_load_f32", trapLoadF32Function opts)
-                , ("__asterius_trap_store_f32", trapStoreF32Function opts)
-                , ("__asterius_trap_load_f64", trapLoadF64Function opts)
-                , ("__asterius_trap_store_f64", trapStoreF64Function opts)
-                ]
-          else [])
-        <> map (\(func_sym, (_, func)) -> (func_sym, func)) byteStringCBits
+        map (\(func_sym, (_, func)) -> (func_sym, func)) byteStringCBits
     }  <> mainFunction opts
        <> hsInitFunction opts
        <> scheduleWaitThreadFunction opts
@@ -389,22 +374,6 @@ rtsFunctionImports debug =
               , functionType =
                   FunctionType {paramTypes = [F64, I32, F64], returnTypes = []}
               }
-          , FunctionImport
-              { internalName = "__asterius_load_I64"
-              , externalModuleName = "MemoryTrap"
-              , externalBaseName = "loadI64"
-              , functionType =
-                  FunctionType
-                    {paramTypes = [F64, I32, I32, I32], returnTypes = []}
-              }
-          , FunctionImport
-              { internalName = "__asterius_store_I64"
-              , externalModuleName = "MemoryTrap"
-              , externalBaseName = "storeI64"
-              , functionType =
-                  FunctionType
-                    {paramTypes = [F64, I32, I32, I32], returnTypes = []}
-              }
           ] <>
           concat
             [ [ FunctionImport
@@ -412,8 +381,7 @@ rtsFunctionImports debug =
                   , externalModuleName = "MemoryTrap"
                   , externalBaseName = "load" <> k
                   , functionType =
-                      FunctionType
-                        {paramTypes = [F64, I32, t], returnTypes = []}
+                      FunctionType {paramTypes = [I64, I32], returnTypes = [t]}
                   }
               , FunctionImport
                   { internalName = "__asterius_store_" <> k
@@ -421,13 +389,14 @@ rtsFunctionImports debug =
                   , externalBaseName = "store" <> k
                   , functionType =
                       FunctionType
-                        {paramTypes = [F64, I32, t], returnTypes = []}
+                        {paramTypes = [I64, I32, t], returnTypes = []}
                   }
             ]
             | (k, t) <-
                 [ ("I8", I32)
                 , ("I16", I32)
                 , ("I32", I32)
+                , ("I64", I64)
                 , ("F32", F32)
                 , ("F64", F64)
                 ]
@@ -609,12 +578,6 @@ generateWrapperModule mod = mod {
 
 
 mainFunction, hsInitFunction, rtsApplyFunction, rtsEvalFunction, rtsEvalIOFunction, rtsEvalLazyIOFunction, rtsGetSchedStatusFunction, rtsCheckSchedStatusFunction, scheduleWaitThreadFunction, createThreadFunction, createGenThreadFunction, createIOThreadFunction, createStrictIOThreadFunction, allocatePinnedFunction, newCAFFunction, stgReturnFunction, getStablePtrWrapperFunction, deRefStablePtrWrapperFunction, freeStablePtrWrapperFunction, rtsMkBoolFunction, rtsMkDoubleFunction, rtsMkCharFunction, rtsMkIntFunction, rtsMkWordFunction, rtsMkPtrFunction, rtsMkStablePtrFunction, rtsGetBoolFunction, rtsGetDoubleFunction, loadI64Function, printI64Function, assertEqI64Function, printF32Function, printF64Function, strlenFunction, memchrFunction, memcpyFunction, memsetFunction, memcmpFunction, fromJSArrayBufferFunction, toJSArrayBufferFunction, fromJSStringFunction, fromJSArrayFunction, threadPausedFunction, dirtyMutVarFunction :: BuiltinsOptions -> AsteriusModule
-
--- Not migrated to using runEDSL yet.
-trapLoadI8Function, trapStoreI8Function, trapLoadI16Function,
-  trapStoreI16Function, trapLoadI32Function, trapStoreI32Function,
-  trapLoadI64Function, trapStoreI64Function, trapLoadF32Function,
-  trapStoreF32Function, trapLoadF64Function, trapStoreF64Function :: BuiltinsOptions -> Function
 
 mainFunction BuiltinsOptions {} =
   runEDSL  "main" $ do
@@ -1170,392 +1133,6 @@ getF64GlobalRegFunction _ n gr =
   runEDSL n $ do
     setReturnTypes [F64]
     emit $ convertSInt64ToFloat64 $ getLVal $ global gr
-
-trapLoadI8Function _ =
-  Function
-    { functionType = FunctionType {paramTypes = [I64, I32], returnTypes = [I32]}
-    , varTypes = []
-    , body =
-        Block
-          { name = ""
-          , bodys =
-              [ CallImport
-                  { target' = "__asterius_load_I8"
-                  , operands = [fp, o, v]
-                  , callImportReturnTypes = []
-                  }
-              , v
-              ]
-          , blockReturnTypes = [I32]
-          }
-    }
-  where
-    bp = GetLocal {index = 0, valueType = I64}
-    o = GetLocal {index = 1, valueType = I32}
-    p =
-      Binary
-        { binaryOp = AddInt32
-        , operand0 = Unary {unaryOp = WrapInt64, operand0 = bp}
-        , operand1 = o
-        }
-    fp = Unary {unaryOp = ConvertUInt64ToFloat64, operand0 = bp}
-    v = Load {signed = False, bytes = 1, offset = 0, valueType = I32, ptr = p}
-
-trapStoreI8Function _ =
-  Function
-    { functionType =
-        FunctionType {paramTypes = [I64, I32, I32], returnTypes = []}
-    , varTypes = []
-    , body =
-        Block
-          { name = ""
-          , bodys =
-              [ CallImport
-                  { target' = "__asterius_store_I8"
-                  , operands = [fp, o, v]
-                  , callImportReturnTypes = []
-                  }
-              , Store
-                  {bytes = 1, offset = 0, ptr = p, value = v, valueType = I32}
-              ]
-          , blockReturnTypes = []
-          }
-    }
-  where
-    bp = GetLocal {index = 0, valueType = I64}
-    o = GetLocal {index = 1, valueType = I32}
-    p =
-      Binary
-        { binaryOp = AddInt32
-        , operand0 = Unary {unaryOp = WrapInt64, operand0 = bp}
-        , operand1 = o
-        }
-    fp = Unary {unaryOp = ConvertUInt64ToFloat64, operand0 = bp}
-    v = GetLocal {index = 2, valueType = I32}
-
-trapLoadI16Function _ =
-  Function
-    { functionType = FunctionType {paramTypes = [I64, I32], returnTypes = [I32]}
-    , varTypes = []
-    , body =
-        Block
-          { name = ""
-          , bodys =
-              [ CallImport
-                  { target' = "__asterius_load_I16"
-                  , operands = [fp, o, v]
-                  , callImportReturnTypes = []
-                  }
-              , v
-              ]
-          , blockReturnTypes = [I32]
-          }
-    }
-  where
-    bp = GetLocal {index = 0, valueType = I64}
-    o = GetLocal {index = 1, valueType = I32}
-    p =
-      Binary
-        { binaryOp = AddInt32
-        , operand0 = Unary {unaryOp = WrapInt64, operand0 = bp}
-        , operand1 = o
-        }
-    fp = Unary {unaryOp = ConvertUInt64ToFloat64, operand0 = bp}
-    v = Load {signed = False, bytes = 2, offset = 0, valueType = I32, ptr = p}
-
-trapStoreI16Function _ =
-  Function
-    { functionType =
-        FunctionType {paramTypes = [I64, I32, I32], returnTypes = []}
-    , varTypes = []
-    , body =
-        Block
-          { name = ""
-          , bodys =
-              [ CallImport
-                  { target' = "__asterius_store_I16"
-                  , operands = [fp, o, v]
-                  , callImportReturnTypes = []
-                  }
-              , Store
-                  {bytes = 2, offset = 0, ptr = p, value = v, valueType = I32}
-              ]
-          , blockReturnTypes = []
-          }
-    }
-  where
-    bp = GetLocal {index = 0, valueType = I64}
-    o = GetLocal {index = 1, valueType = I32}
-    p =
-      Binary
-        { binaryOp = AddInt32
-        , operand0 = Unary {unaryOp = WrapInt64, operand0 = bp}
-        , operand1 = o
-        }
-    fp = Unary {unaryOp = ConvertUInt64ToFloat64, operand0 = bp}
-    v = GetLocal {index = 2, valueType = I32}
-
-trapLoadI32Function _ =
-  Function
-    { functionType = FunctionType {paramTypes = [I64, I32], returnTypes = [I32]}
-    , varTypes = []
-    , body =
-        Block
-          { name = ""
-          , bodys =
-              [ CallImport
-                  { target' = "__asterius_load_I32"
-                  , operands = [fp, o, v]
-                  , callImportReturnTypes = []
-                  }
-              , v
-              ]
-          , blockReturnTypes = [I32]
-          }
-    }
-  where
-    bp = GetLocal {index = 0, valueType = I64}
-    o = GetLocal {index = 1, valueType = I32}
-    p =
-      Binary
-        { binaryOp = AddInt32
-        , operand0 = Unary {unaryOp = WrapInt64, operand0 = bp}
-        , operand1 = o
-        }
-    fp = Unary {unaryOp = ConvertUInt64ToFloat64, operand0 = bp}
-    v = Load {signed = False, bytes = 4, offset = 0, valueType = I32, ptr = p}
-
-trapStoreI32Function _ =
-  Function
-    { functionType =
-        FunctionType {paramTypes = [I64, I32, I32], returnTypes = []}
-    , varTypes = []
-    , body =
-        Block
-          { name = ""
-          , bodys =
-              [ CallImport
-                  { target' = "__asterius_store_I32"
-                  , operands = [fp, o, v]
-                  , callImportReturnTypes = []
-                  }
-              , Store
-                  {bytes = 4, offset = 0, ptr = p, value = v, valueType = I32}
-              ]
-          , blockReturnTypes = []
-          }
-    }
-  where
-    bp = GetLocal {index = 0, valueType = I64}
-    o = GetLocal {index = 1, valueType = I32}
-    p =
-      Binary
-        { binaryOp = AddInt32
-        , operand0 = Unary {unaryOp = WrapInt64, operand0 = bp}
-        , operand1 = o
-        }
-    fp = Unary {unaryOp = ConvertUInt64ToFloat64, operand0 = bp}
-    v = GetLocal {index = 2, valueType = I32}
-
-trapLoadI64Function _ =
-  Function
-    { functionType = FunctionType {paramTypes = [I64, I32], returnTypes = [I64]}
-    , varTypes = []
-    , body =
-        Block
-          { name = ""
-          , bodys =
-              [ CallImport
-                  { target' = "__asterius_load_I64"
-                  , operands = [fp, o, v_lo, v_hi]
-                  , callImportReturnTypes = []
-                  }
-              , v
-              ]
-          , blockReturnTypes = [I64]
-          }
-    }
-  where
-    bp = GetLocal {index = 0, valueType = I64}
-    o = GetLocal {index = 1, valueType = I32}
-    p =
-      Binary
-        { binaryOp = AddInt32
-        , operand0 = Unary {unaryOp = WrapInt64, operand0 = bp}
-        , operand1 = o
-        }
-    fp = Unary {unaryOp = ConvertUInt64ToFloat64, operand0 = bp}
-    v = Load {signed = False, bytes = 8, offset = 0, valueType = I64, ptr = p}
-    v_lo = Unary {unaryOp = WrapInt64, operand0 = v}
-    v_hi =
-      Unary
-        { unaryOp = WrapInt64
-        , operand0 =
-            Binary {binaryOp = ShrUInt64, operand0 = v, operand1 = ConstI64 32}
-        }
-
-trapStoreI64Function _ =
-  Function
-    { functionType =
-        FunctionType {paramTypes = [I64, I32, I64], returnTypes = []}
-    , varTypes = []
-    , body =
-        Block
-          { name = ""
-          , bodys =
-              [ CallImport
-                  { target' = "__asterius_store_I64"
-                  , operands = [fp, o, v_lo, v_hi]
-                  , callImportReturnTypes = []
-                  }
-              , Store
-                  {bytes = 8, offset = 0, ptr = p, value = v, valueType = I64}
-              ]
-          , blockReturnTypes = []
-          }
-    }
-  where
-    bp = GetLocal {index = 0, valueType = I64}
-    o = GetLocal {index = 1, valueType = I32}
-    p =
-      Binary
-        { binaryOp = AddInt32
-        , operand0 = Unary {unaryOp = WrapInt64, operand0 = bp}
-        , operand1 = o
-        }
-    fp = Unary {unaryOp = ConvertUInt64ToFloat64, operand0 = bp}
-    v = GetLocal {index = 2, valueType = I64}
-    v_lo = Unary {unaryOp = WrapInt64, operand0 = v}
-    v_hi =
-      Unary
-        { unaryOp = WrapInt64
-        , operand0 =
-            Binary {binaryOp = ShrUInt64, operand0 = v, operand1 = ConstI64 32}
-        }
-
-trapLoadF32Function _ =
-  Function
-    { functionType = FunctionType {paramTypes = [I64, I32], returnTypes = [F32]}
-    , varTypes = []
-    , body =
-        Block
-          { name = ""
-          , bodys =
-              [ CallImport
-                  { target' = "__asterius_load_F32"
-                  , operands = [fp, o, v]
-                  , callImportReturnTypes = []
-                  }
-              , v
-              ]
-          , blockReturnTypes = [F32]
-          }
-    }
-  where
-    bp = GetLocal {index = 0, valueType = I64}
-    o = GetLocal {index = 1, valueType = I32}
-    p =
-      Binary
-        { binaryOp = AddInt32
-        , operand0 = Unary {unaryOp = WrapInt64, operand0 = bp}
-        , operand1 = o
-        }
-    fp = Unary {unaryOp = ConvertUInt64ToFloat64, operand0 = bp}
-    v = Load {signed = True, bytes = 4, offset = 0, valueType = F32, ptr = p}
-
-trapStoreF32Function _ =
-  Function
-    { functionType =
-        FunctionType {paramTypes = [I64, I32, F32], returnTypes = []}
-    , varTypes = []
-    , body =
-        Block
-          { name = ""
-          , bodys =
-              [ CallImport
-                  { target' = "__asterius_store_F32"
-                  , operands = [fp, o, v]
-                  , callImportReturnTypes = []
-                  }
-              , Store
-                  {bytes = 4, offset = 0, ptr = p, value = v, valueType = F32}
-              ]
-          , blockReturnTypes = []
-          }
-    }
-  where
-    bp = GetLocal {index = 0, valueType = I64}
-    o = GetLocal {index = 1, valueType = I32}
-    p =
-      Binary
-        { binaryOp = AddInt32
-        , operand0 = Unary {unaryOp = WrapInt64, operand0 = bp}
-        , operand1 = o
-        }
-    fp = Unary {unaryOp = ConvertUInt64ToFloat64, operand0 = bp}
-    v = GetLocal {index = 2, valueType = F32}
-
-trapLoadF64Function _ =
-  Function
-    { functionType = FunctionType {paramTypes = [I64, I32], returnTypes = [F64]}
-    , varTypes = []
-    , body =
-        Block
-          { name = ""
-          , bodys =
-              [ CallImport
-                  { target' = "__asterius_load_F64"
-                  , operands = [fp, o, v]
-                  , callImportReturnTypes = []
-                  }
-              , v
-              ]
-          , blockReturnTypes = [F64]
-          }
-    }
-  where
-    bp = GetLocal {index = 0, valueType = I64}
-    o = GetLocal {index = 1, valueType = I32}
-    p =
-      Binary
-        { binaryOp = AddInt32
-        , operand0 = Unary {unaryOp = WrapInt64, operand0 = bp}
-        , operand1 = o
-        }
-    fp = Unary {unaryOp = ConvertUInt64ToFloat64, operand0 = bp}
-    v = Load {signed = True, bytes = 8, offset = 0, valueType = F64, ptr = p}
-
-trapStoreF64Function _ =
-  Function
-    { functionType =
-        FunctionType {paramTypes = [I64, I32, F64], returnTypes = []}
-    , varTypes = []
-    , body =
-        Block
-          { name = ""
-          , bodys =
-              [ CallImport
-                  { target' = "__asterius_store_F64"
-                  , operands = [fp, o, v]
-                  , callImportReturnTypes = []
-                  }
-              , Store
-                  {bytes = 8, offset = 0, ptr = p, value = v, valueType = F64}
-              ]
-          , blockReturnTypes = []
-          }
-    }
-  where
-    bp = GetLocal {index = 0, valueType = I64}
-    o = GetLocal {index = 1, valueType = I32}
-    p =
-      Binary
-        { binaryOp = AddInt32
-        , operand0 = Unary {unaryOp = WrapInt64, operand0 = bp}
-        , operand1 = o
-        }
-    fp = Unary {unaryOp = ConvertUInt64ToFloat64, operand0 = bp}
-    v = GetLocal {index = 2, valueType = F64}
 
 offset_StgTSO_StgStack :: Int
 offset_StgTSO_StgStack = 8 * roundup_bytes_to_words sizeof_StgTSO

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -459,11 +459,13 @@ ahcDistMain logger task@Task {..} (final_m, err_msgs, report) = do
       then do
         logger $ "[INFO] Running " <> out_js
         callProcess "node" $
+          ["--experimental-wasm-bigint" | debug] <>
           ["--experimental-wasm-return-call" | tailCalls] <>
           [takeFileName out_js]
       else do
         logger $ "[INFO] Running " <> out_entry
         callProcess "node" $
+          ["--experimental-wasm-bigint" | debug] <>
           ["--experimental-wasm-return-call" | tailCalls] <>
           ["--experimental-modules", takeFileName out_entry]
 

--- a/asterius/src/Asterius/MemoryTrap.hs
+++ b/asterius/src/Asterius/MemoryTrap.hs
@@ -2,70 +2,56 @@
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TupleSections #-}
 
 module Asterius.MemoryTrap
   ( addMemoryTrap
-  , addMemoryTrapDeep
   ) where
 
 import Asterius.Types
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Short as SBS
-import Data.Data (Data, gmapM)
+import Data.Data (Data, gmapT)
 import qualified Data.Map.Strict as M
-import Data.Traversable
 import Type.Reflection
 
-addMemoryTrap :: Monad m => AsteriusModule -> m AsteriusModule
-addMemoryTrap m = do
-  new_function_map <-
-    fmap M.fromList $
-    for (M.toList $ functionMap m) $ \(func_sym, func) ->
-      if "__asterius" `BS.isPrefixOf` SBS.fromShort (entityName func_sym)
-        then pure (func_sym, func)
-        else (func_sym, ) <$> addMemoryTrapDeep func
-  pure m {functionMap = new_function_map}
+addMemoryTrap :: AsteriusModule -> AsteriusModule
+addMemoryTrap m =
+  let new_function_map =
+        flip M.mapWithKey (functionMap m) $ \func_sym func ->
+          if "__asterius" `BS.isPrefixOf` SBS.fromShort (entityName func_sym)
+            then func
+            else addMemoryTrapDeep func
+   in m {functionMap = new_function_map}
 
-addMemoryTrapDeep :: (Monad m, Data a) => a -> m a
+addMemoryTrapDeep :: Data a => a -> a
 addMemoryTrapDeep t =
   case eqTypeRep (typeOf t) (typeRep :: TypeRep Expression) of
     Just HRefl ->
       case t of
-        Load {ptr = Unary {unaryOp = WrapInt64, operand0 = i64_ptr}, ..} -> do
-          new_i64_ptr <- addMemoryTrapDeep i64_ptr
-          pure
-            Call
-              { target =
-                  AsteriusEntitySymbol
-                    { entityName =
-                        "__asterius_trap_load_" <> ty_name valueType bytes
-                    }
-              , operands = [new_i64_ptr, ConstI32 $ fromIntegral offset]
-              , callReturnTypes = [valueType]
-              }
-        Store {ptr = Unary {unaryOp = WrapInt64, operand0 = i64_ptr}, ..} -> do
-          new_i64_ptr <- addMemoryTrapDeep i64_ptr
-          new_value <- addMemoryTrapDeep value
-          pure
-            Call
-              { target =
-                  AsteriusEntitySymbol
-                    { entityName =
-                        "__asterius_trap_store_" <> ty_name valueType bytes
-                    }
-              , operands =
-                  [new_i64_ptr, ConstI32 $ fromIntegral offset, new_value]
-              , callReturnTypes = []
-              }
+        Load {ptr = Unary {unaryOp = WrapInt64, operand0 = i64_ptr}, ..} ->
+          let new_i64_ptr = addMemoryTrapDeep i64_ptr
+           in CallImport
+                { target' = "__asterius_load_" <> ty_name valueType bytes
+                , operands = [new_i64_ptr, ConstI32 $ fromIntegral offset]
+                , callImportReturnTypes = [valueType]
+                }
+        Store {ptr = Unary {unaryOp = WrapInt64, operand0 = i64_ptr}, ..} ->
+          let new_i64_ptr = addMemoryTrapDeep i64_ptr
+              new_value = addMemoryTrapDeep value
+           in CallImport
+                { target' = "__asterius_store_" <> ty_name valueType bytes
+                , operands =
+                    [new_i64_ptr, ConstI32 $ fromIntegral offset, new_value]
+                , callImportReturnTypes = []
+                }
         _ -> go
     _ -> go
   where
-    go = gmapM addMemoryTrapDeep t
-    ty_name I32 1 = "i8"
-    ty_name I32 2 = "i16"
-    ty_name I32 4 = "i32"
-    ty_name I64 8 = "i64"
-    ty_name F32 4 = "f32"
-    ty_name F64 8 = "f64"
+    go = gmapT addMemoryTrapDeep t
+    ty_name I32 1 = "I8"
+    ty_name I32 2 = "I16"
+    ty_name I32 4 = "I32"
+    ty_name I64 8 = "I64"
+    ty_name F32 4 = "F32"
+    ty_name F64 8 = "F64"
     ty_name _ _ = error "Asterius.MemoryTrap.addMemoryTrapDeep"

--- a/asterius/src/Asterius/MemoryTrap.hs
+++ b/asterius/src/Asterius/MemoryTrap.hs
@@ -14,38 +14,50 @@ import Type.Reflection
 
 addMemoryTrap :: AsteriusModule -> AsteriusModule
 addMemoryTrap m =
-  let new_function_map = M.map addMemoryTrapDeep (functionMap m)
+  let new_function_map = M.mapWithKey addMemoryTrapDeep (functionMap m)
    in m {functionMap = new_function_map}
 
-addMemoryTrapDeep :: Data a => a -> a
-addMemoryTrapDeep t =
-  case eqTypeRep (typeOf t) (typeRep :: TypeRep Expression) of
-    Just HRefl ->
-      case t of
-        Load {ptr = Unary {unaryOp = WrapInt64, operand0 = i64_ptr}, ..} ->
-          let new_i64_ptr = addMemoryTrapDeep i64_ptr
-           in CallImport
-                { target' = "__asterius_load_" <> ty_name valueType bytes
-                , operands = [new_i64_ptr, ConstI32 $ fromIntegral offset]
-                , callImportReturnTypes = [valueType]
-                }
-        Store {ptr = Unary {unaryOp = WrapInt64, operand0 = i64_ptr}, ..} ->
-          let new_i64_ptr = addMemoryTrapDeep i64_ptr
-              new_value = addMemoryTrapDeep value
-           in CallImport
-                { target' = "__asterius_store_" <> ty_name valueType bytes
-                , operands =
-                    [new_i64_ptr, ConstI32 $ fromIntegral offset, new_value]
-                , callImportReturnTypes = []
-                }
-        _ -> go
-    _ -> go
+addMemoryTrapDeep :: Data a => AsteriusEntitySymbol -> a -> a
+addMemoryTrapDeep func_sym = w
   where
-    go = gmapT addMemoryTrapDeep t
-    ty_name I32 1 = "I8"
-    ty_name I32 2 = "I16"
-    ty_name I32 4 = "I32"
-    ty_name I64 8 = "I64"
-    ty_name F32 4 = "F32"
-    ty_name F64 8 = "F64"
-    ty_name _ _ = error "Asterius.MemoryTrap.addMemoryTrapDeep"
+    w :: Data b => b -> b
+    w t =
+      case eqTypeRep (typeOf t) (typeRep :: TypeRep Expression) of
+        Just HRefl ->
+          case t of
+            Load {ptr = Unary {unaryOp = WrapInt64, operand0 = i64_ptr}, ..} ->
+              let new_i64_ptr = w i64_ptr
+               in CallImport
+                    { target' =
+                        "__asterius_load_" <> ty_name func_sym t valueType bytes
+                    , operands = [new_i64_ptr, ConstI32 $ fromIntegral offset]
+                    , callImportReturnTypes = [valueType]
+                    }
+            Store {ptr = Unary {unaryOp = WrapInt64, operand0 = i64_ptr}, ..} ->
+              let new_i64_ptr = w i64_ptr
+                  new_value = w value
+               in CallImport
+                    { target' =
+                        "__asterius_store_" <>
+                        ty_name func_sym t valueType bytes
+                    , operands =
+                        [new_i64_ptr, ConstI32 $ fromIntegral offset, new_value]
+                    , callImportReturnTypes = []
+                    }
+            _ -> go
+        _ -> go
+      where
+        go = gmapT w t
+    ty_name _ _ I32 1 = "I8"
+    ty_name _ _ I32 2 = "I16"
+    ty_name _ _ I32 4 = "I32"
+    ty_name _ _ I64 8 = "I64"
+    ty_name _ _ F32 4 = "F32"
+    ty_name _ _ F64 8 = "F64"
+    ty_name sym e vt b =
+      error $
+      "Asterius.MemoryTrap.addMemoryTrapDeep: " <> show sym <> " " <> show vt <>
+      " " <>
+      show b <>
+      " " <>
+      show e

--- a/asterius/src/Asterius/MemoryTrap.hs
+++ b/asterius/src/Asterius/MemoryTrap.hs
@@ -8,19 +8,13 @@ module Asterius.MemoryTrap
   ) where
 
 import Asterius.Types
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Short as SBS
 import Data.Data (Data, gmapT)
 import qualified Data.Map.Strict as M
 import Type.Reflection
 
 addMemoryTrap :: AsteriusModule -> AsteriusModule
 addMemoryTrap m =
-  let new_function_map =
-        flip M.mapWithKey (functionMap m) $ \func_sym func ->
-          if "__asterius" `BS.isPrefixOf` SBS.fromShort (entityName func_sym)
-            then func
-            else addMemoryTrapDeep func
+  let new_function_map = M.map addMemoryTrapDeep (functionMap m)
    in m {functionMap = new_function_map}
 
 addMemoryTrapDeep :: Data a => a -> a

--- a/asterius/src/Asterius/MemoryTrap.hs
+++ b/asterius/src/Asterius/MemoryTrap.hs
@@ -14,50 +14,53 @@ import Type.Reflection
 
 addMemoryTrap :: AsteriusModule -> AsteriusModule
 addMemoryTrap m =
-  let new_function_map = M.mapWithKey addMemoryTrapDeep (functionMap m)
+  let new_function_map = M.map addMemoryTrapDeep (functionMap m)
    in m {functionMap = new_function_map}
 
-addMemoryTrapDeep :: Data a => AsteriusEntitySymbol -> a -> a
-addMemoryTrapDeep func_sym = w
-  where
-    w :: Data b => b -> b
-    w t =
-      case eqTypeRep (typeOf t) (typeRep :: TypeRep Expression) of
-        Just HRefl ->
-          case t of
-            Load {ptr = Unary {unaryOp = WrapInt64, operand0 = i64_ptr}, ..} ->
-              let new_i64_ptr = w i64_ptr
-               in CallImport
-                    { target' =
-                        "__asterius_load_" <> ty_name func_sym t valueType bytes
-                    , operands = [new_i64_ptr, ConstI32 $ fromIntegral offset]
-                    , callImportReturnTypes = [valueType]
-                    }
-            Store {ptr = Unary {unaryOp = WrapInt64, operand0 = i64_ptr}, ..} ->
-              let new_i64_ptr = w i64_ptr
-                  new_value = w value
-               in CallImport
-                    { target' =
-                        "__asterius_store_" <>
-                        ty_name func_sym t valueType bytes
-                    , operands =
-                        [new_i64_ptr, ConstI32 $ fromIntegral offset, new_value]
-                    , callImportReturnTypes = []
-                    }
-            _ -> go
+addMemoryTrapDeep :: Data a => a -> a
+addMemoryTrapDeep t =
+  case eqTypeRep (typeOf t) (typeRep :: TypeRep Expression) of
+    Just HRefl ->
+      case t of
+        Load {ptr = Unary {unaryOp = WrapInt64, operand0 = i64_ptr}, ..} ->
+          let new_i64_ptr = addMemoryTrapDeep i64_ptr
+           in CallImport
+                { target' =
+                    "__asterius_load_" <> load_fn_suffix valueType bytes signed
+                , operands = [new_i64_ptr, ConstI32 $ fromIntegral offset]
+                , callImportReturnTypes = [valueType]
+                }
+        Store {ptr = Unary {unaryOp = WrapInt64, operand0 = i64_ptr}, ..} ->
+          let new_i64_ptr = addMemoryTrapDeep i64_ptr
+              new_value = addMemoryTrapDeep value
+           in CallImport
+                { target' =
+                    "__asterius_store_" <> store_fn_suffix valueType bytes
+                , operands =
+                    [new_i64_ptr, ConstI32 $ fromIntegral offset, new_value]
+                , callImportReturnTypes = []
+                }
         _ -> go
-      where
-        go = gmapT w t
-    ty_name _ _ I32 1 = "I8"
-    ty_name _ _ I32 2 = "I16"
-    ty_name _ _ I32 4 = "I32"
-    ty_name _ _ I64 8 = "I64"
-    ty_name _ _ F32 4 = "F32"
-    ty_name _ _ F64 8 = "F64"
-    ty_name sym e vt b =
-      error $
-      "Asterius.MemoryTrap.addMemoryTrapDeep: " <> show sym <> " " <> show vt <>
-      " " <>
-      show b <>
-      " " <>
-      show e
+    _ -> go
+  where
+    go = gmapT addMemoryTrapDeep t
+    load_fn_suffix I32 1 False = "I32_U8"
+    load_fn_suffix I32 1 True = "I32_S8"
+    load_fn_suffix I32 2 False = "I32_U16"
+    load_fn_suffix I32 2 True = "I32_S16"
+    load_fn_suffix I32 4 _ = "I32"
+    load_fn_suffix I64 1 False = "I64_U8"
+    load_fn_suffix I64 1 True = "I64_S8"
+    load_fn_suffix I64 2 False = "I64_U16"
+    load_fn_suffix I64 2 True = "I64_S16"
+    load_fn_suffix I64 8 _ = "I64"
+    load_fn_suffix F32 4 _ = "F32"
+    load_fn_suffix F64 8 _ = "F64"
+    load_fn_suffix _ _ _ = error "Asterius.MemoryTrap.addMemoryTrapDeep"
+    store_fn_suffix I32 1 = "I8"
+    store_fn_suffix I32 2 = "I16"
+    store_fn_suffix I32 4 = "I32"
+    store_fn_suffix I64 8 = "I64"
+    store_fn_suffix F32 4 = "F32"
+    store_fn_suffix F64 8 = "F64"
+    store_fn_suffix _ _ = error "Asterius.MemoryTrap.addMemoryTrapDeep"

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -14,6 +14,7 @@ module Asterius.Resolve
 import Asterius.Builtins
 import Asterius.Internals.MagicNumber
 import Asterius.JSFFI
+import Asterius.MemoryTrap
 import Asterius.Passes.DataSymbolTable
 import Asterius.Passes.FunctionSymbolTable
 import Asterius.Types
@@ -220,7 +221,7 @@ linkStart debug has_main gc_sections binaryen store root_syms export_funcs =
       , staticMBlocks = static_mbs
       })
   where
-    (merged_m, report) =
+    (merged_m', report) =
       mergeSymbols
         debug
         gc_sections
@@ -231,6 +232,9 @@ linkStart debug has_main gc_sections binaryen store root_syms export_funcs =
              {entityName = "__asterius_jsffi_export_" <> entityName k}
            | k <- export_funcs
            ])
+    merged_m
+      | debug = addMemoryTrap merged_m'
+      | otherwise = merged_m'
     (result_m, ss_sym_map, func_sym_map, err_msgs, tbl_slots, static_mbs) =
       resolveAsteriusModule
         debug

--- a/stack.yaml
+++ b/stack.yaml
@@ -38,7 +38,7 @@ extra-deps:
   - hspec-discover-2.7.0
   - hspec-expectations-0.8.2
   - http-date-0.0.8
-  - http-types-0.12.2
+  - http-types-0.12.3
   - http2-1.6.4
   - integer-logarithms-1.0.2.2
   - iproute-1.7.7
@@ -46,7 +46,7 @@ extra-deps:
   - http://head.hackage.haskell.org/package/memory-0.14.18.tar.gz
   - HUnit-1.6.0.0
   - language-javascript-0.6.0.11
-  - mime-types-0.1.0.8
+  - mime-types-0.1.0.9
   - mintty-0.1.2
   - network-2.8.0.0
   - network-byte-order-0.0.0.0
@@ -78,7 +78,7 @@ extra-deps:
   - transformers-compat-0.6.2
   - unbounded-delays-0.1.1.0
   - unix-compat-0.5.1
-  - unordered-containers-0.2.9.0
+  - unordered-containers-0.2.10.0
   - utf8-string-1.0.1.1
   - vault-0.3.1.2
   - unix-time-0.3.8
@@ -86,11 +86,11 @@ extra-deps:
   - unliftio-core-0.1.2.0
   - vector-0.12.0.3
   - void-0.7.2
-  - wai-3.2.1.2
-  - wai-app-static-3.1.6.2
-  - wai-extra-3.0.24.3
+  - wai-3.2.2
+  - wai-app-static-3.1.6.3
+  - wai-extra-3.0.26
   - wai-logger-2.3.2
-  - warp-3.2.25
+  - warp-3.2.27
   - wcwidth-0.0.2
   - word8-0.1.3
   - http://head.hackage.haskell.org/package/zlib-0.6.2.tar.gz


### PR DESCRIPTION
In the previous efforts to make the linker faster, we moved the link-time rewriting passes to compile-time, and unfortunately dropped support for "memory trap" & "tracing" passes.

This PR reimplements the memory trap framework, enabled by the `--debug` flag of `ahc-link`/`ahc-dist`. Compared to the previous implementation, it:

* Relies on the `--experimental-wasm-bigint` V8 feature flag, and requires using V8 team's node integration build to run.
* The read/write barriers are solely implemented in JavaScript. The wasm load/store instructions are mapped 1-to-1 to calls of imported barrier functions. No intermediate wasm trap functions exist anymore.
* The trap is enabled for all wasm functions, even the built-in rts routines, since we don't need to worry about reentrancy issues.
* We also take sign extension into account for 8-bit/16-bit read barriers.
* We don't emit an event log for any load/store yet; will do when we have a more decent event log system.

This PR only enables a very coarse-grained check at the moment: the higher 32-bits of any data address should exactly match a preset magic number, and if not, it's an invalid address. More advanced checks which cooperate with the block allocator will land in subsequent PRs.