### PR TITLE
Suppress ticks in debug mode pretty-printed dumps

### DIFF
--- a/asterius/src/Asterius/Boot.hs
+++ b/asterius/src/Asterius/Boot.hs
@@ -45,7 +45,7 @@ defaultBootArgs =
   BootArgs
     { bootDir = dataDir </> ".boot"
     , configureOptions =
-        "--disable-shared --disable-profiling --disable-debug-info --disable-library-for-ghci --disable-split-objs --disable-split-sections --disable-library-stripping -O2 --ghc-option=-v1"
+        "--disable-shared --disable-profiling --disable-debug-info --disable-library-for-ghci --disable-split-objs --disable-split-sections --disable-library-stripping -O2 --ghc-option=-v1 --ghc-option=-dsuppress-ticks"
     , buildOptions = ""
     , installOptions = ""
     , builtinsOptions = defaultBuiltinsOptions
@@ -81,6 +81,9 @@ bootRTSCmm :: BootArgs -> IO ()
 bootRTSCmm BootArgs {..} =
   GHC.defaultErrorHandler GHC.defaultFatalMessager GHC.defaultFlushOut $
   GHC.runGhc (Just obj_topdir) $ do
+    dflags0 <- GHC.getSessionDynFlags
+    _ <-
+      GHC.setSessionDynFlags $ GHC.setGeneralFlag' GHC.Opt_SuppressTicks dflags0
     dflags <- GHC.getSessionDynFlags
     setDynFlagsRef dflags
     is_debug <- isJust <$> liftIO (lookupEnv "ASTERIUS_DEBUG")


### PR DESCRIPTION
This PR removes ticks in pretty-printed IR dumps when `ASTERIUS_DEBUG=1` is set when calling `ahc-boot`, reducing a lot of visual noise. For the raw Cmm AST dump, however, we don't bother to filter out the `CmmTick` instructions yet.