### PR TITLE
Report unresolved symbols in runtime error messages

### DIFF
--- a/asterius/rts/rts.exception.mjs
+++ b/asterius/rts/rts.exception.mjs
@@ -1,12 +1,14 @@
 import * as ClosureTypes from "./rts.closuretypes.mjs";
 import * as rtsConstants from "./rts.constants.mjs";
+import { Memory } from "./rts.memory.mjs";
 
-export class RaiseExceptionHelper {
+export class ExceptionHelper {
   constructor(memory, heapalloc, info_tables, symbol_table) {
     this.memory = memory;
     this.heapAlloc = heapalloc;
     this.infoTables = info_tables;
     this.symbolTable = symbol_table;
+    this.decoder = new TextDecoder("utf-8", { fatal: true });
     Object.freeze(this);
   }
   raiseExceptionHelper(reg, tso, exception) {
@@ -81,6 +83,17 @@ export class RaiseExceptionHelper {
             "raiseExceptionHelper: unsupported stack frame"
           );
       }
+    }
+  }
+  barf(s) {
+    if (s) {
+      const v0 = this.memory.i8View.subarray(Memory.unTag(s)),
+        len = v0.indexOf(0),
+        v1 = v0.subarray(0, len),
+        r = this.decoder.decode(v1);
+      throw new WebAssembly.RuntimeError(`barf: ${r}`);
+    } else {
+      throw new WebAssembly.RuntimeError("barf");
     }
   }
 }

--- a/asterius/rts/rts.exception.mjs
+++ b/asterius/rts/rts.exception.mjs
@@ -2,6 +2,9 @@ import * as ClosureTypes from "./rts.closuretypes.mjs";
 import * as rtsConstants from "./rts.constants.mjs";
 import { Memory } from "./rts.memory.mjs";
 
+/*
+  The methods of this class are related to exception handling in Haskell.
+ */
 export class ExceptionHelper {
   constructor(memory, heapalloc, info_tables, symbol_table) {
     this.memory = memory;
@@ -11,6 +14,19 @@ export class ExceptionHelper {
     this.decoder = new TextDecoder("utf-8", { fatal: true });
     Object.freeze(this);
   }
+
+  /*
+    This implements a subset of `raiseExceptionHelper` in `rts/Schedule.c` of
+    ghc rts. The function is called by `stg_raisezh` in `Exception.cmm` in rts.
+
+    When a Haskell exception is raised, `stg_raisezh` is entered, and it calls
+    `raiseExceptionHelper` to traverse the stack from the top. For each update
+    frame, the thunk is updated with the "exception closure" (which throws when
+    entered). It exits when a catch frame or stop frame is encountered.
+
+    The stack pointer is rewritten to the head of last encountered frame, and
+    the frame type is returned to `stg_raisezh` for further processing.
+  */
   raiseExceptionHelper(reg, tso, exception) {
     const raise_closure = this.heapAlloc.allocate(
       Math.ceil(rtsConstants.sizeof_StgThunk / 8) + 1
@@ -85,6 +101,39 @@ export class ExceptionHelper {
       }
     }
   }
+
+  /*
+    This implements `barf` in `rts/RtsMessages.c` of ghc rts. The function is
+    used to signal a fatal runtime error.
+
+    The original `barf` is a varargs C function which takes a format string.
+    Unfortunately, we don't implement handling for varargs yet, so we restrict
+    our `barf` to take exactly 1 argument: a pointer to a NUL-terminated string
+    which is the error message itself.
+
+    There exist special `barf`-related logic in various parts of the asterius
+    compiler:
+
+    * In the rts builtins (`Asterius.Builtins`) module, we import `barf` as
+      `__asterius_barf`, and make a `barf` function wrapper which handles the
+      i64/f64 conversion workaround.
+
+    * In the linker (`Asterius.Resolve`), when we encounter an unresolved
+      symbol, we dynamically generate a small data segment which is the
+      NUL-terminated error message containing the symbol itself. The data
+      segment's own symbol is prefixed with `__asterius_barf_`.
+
+    * In the backends (`Asterius.Backends.*`), when we encounter an unresolved
+      symbol `sym`, we try to find `__asterius_barf_sym`, and if found, we
+      insert a `barf` call there. So if an execution path leads to the
+      unresolved symbol, we're likely to get the symbol name from the js error
+      message.
+
+    * The rts cmm files call `barf` with either 0, 1, 2 arguments. In the
+      backends we remove extra arguments, and if there isn't any, we use a
+      `NULL` pointer as argument, which is interpreted as empty error message in
+      our implementation.
+   */
   barf(s) {
     if (s) {
       const v0 = this.memory.i8View.subarray(Memory.unTag(s)),

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -16,7 +16,7 @@ import { IntegerManager } from "./rts.integer.mjs";
 import { MemoryFileSystem } from "./rts.fs.mjs";
 import { ByteStringCBits } from "./rts.bytestring.mjs";
 import { GC } from "./rts.gc.mjs";
-import { RaiseExceptionHelper } from "./rts.exception.mjs";
+import { ExceptionHelper } from "./rts.exception.mjs";
 import * as rtsConstants from "./rts.constants.mjs";
 
 export function newAsteriusInstance(req) {
@@ -37,7 +37,7 @@ export function newAsteriusInstance(req) {
     __asterius_vault = req.vault ? req.vault : new Map(),
     __asterius_bytestring_cbits = new ByteStringCBits(null),
     __asterius_gc = new GC(__asterius_memory, __asterius_mblockalloc, __asterius_heapalloc, __asterius_stableptr_manager, __asterius_tso_manager, req.infoTables, req.pinnedStaticClosures, req.symbolTable),
-    __asterius_raise_exception_helper = new RaiseExceptionHelper(__asterius_memory, __asterius_heapalloc, req.infoTables, req.symbolTable);
+    __asterius_exception_helper = new ExceptionHelper(__asterius_memory, __asterius_heapalloc, req.infoTables, req.symbolTable);
   function __asterius_show_I64(x) {
     return "0x" + x.toString(16).padStart(8, "0");
   }
@@ -126,7 +126,7 @@ export function newAsteriusInstance(req) {
       },
       bytestring: modulify(__asterius_bytestring_cbits),
       GC: modulify(__asterius_gc),
-      RaiseExceptionHelper: modulify(__asterius_raise_exception_helper),
+      ExceptionHelper: modulify(__asterius_exception_helper),
       HeapAlloc: modulify(__asterius_heapalloc),
       HeapBuilder: modulify(__asterius_heap_builder),
       MBlockAlloc: modulify(__asterius_mblockalloc),

--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -331,7 +331,10 @@ marshalExpression sym_map m e =
           r <- lift $ c_BinaryenReturn m nullPtr
           (arr, _) <- marshalV [s, r]
           lift $ c_BinaryenBlock m nullPtr arr 2 c_BinaryenTypeNone
-        _ -> lift $ marshalExpression sym_map m $ barf returnCallTarget64 []
+        _
+          | M.member returnCallTarget64 sym_map ->
+            lift $ marshalExpression sym_map m $ barf returnCallTarget64 []
+          | otherwise -> lift $ c_BinaryenUnreachable m
     ReturnCallIndirect {..} -> do
       s <-
         lift $

--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -11,6 +11,7 @@ module Asterius.Backends.Binaryen
   ) where
 
 import Asterius.Internals
+import Asterius.Internals.Barf
 import Asterius.Internals.MagicNumber
 import Asterius.Internals.Marshal
 import Asterius.Types
@@ -246,11 +247,22 @@ marshalExpression sym_map m e =
       lift $ c_BinaryenSwitch m nsp (fromIntegral nl) dn c nullPtr
     Call {..}
       | M.member target sym_map -> do
-        os <- lift $ forM operands $ marshalExpression sym_map m
+        os <-
+          lift $
+          forM
+            (if target == "barf"
+               then [ case operands of
+                        [] -> ConstI64 0
+                        x:_ -> x
+                    ]
+               else operands) $
+          marshalExpression sym_map m
         (ops, osl) <- marshalV os
         tp <- marshalSBS (entityName target)
         rts <- lift $ marshalReturnTypes callReturnTypes
         lift $ c_BinaryenCall m tp ops (fromIntegral osl) rts
+      | M.member ("__asterius_barf_" <> target) sym_map ->
+        lift $ marshalExpression sym_map m $ barf target callReturnTypes
       | otherwise -> lift $ c_BinaryenUnreachable m
     CallImport {..} -> do
       os <- lift $ forM operands $ marshalExpression sym_map m
@@ -299,24 +311,27 @@ marshalExpression sym_map m e =
         x <- marshalExpression sym_map m operand0
         y <- marshalExpression sym_map m operand1
         c_BinaryenBinary m (marshalBinaryOp binaryOp) x y
-    ReturnCall {..} -> do
-      s <-
-        lift $
-        marshalExpression
-          sym_map
-          m
-          Store
-            { bytes = 8
-            , offset = 0
-            , ptr =
-                ConstI32 $
-                fromIntegral $ (sym_map ! "__asterius_pc") .&. 0xFFFFFFFF
-            , value = ConstI64 $ sym_map !? returnCallTarget64
-            , valueType = I64
-            }
-      r <- lift $ c_BinaryenReturn m nullPtr
-      (arr, _) <- marshalV [s, r]
-      lift $ c_BinaryenBlock m nullPtr arr 2 c_BinaryenTypeNone
+    ReturnCall {..} ->
+      case M.lookup returnCallTarget64 sym_map of
+        Just t -> do
+          s <-
+            lift $
+            marshalExpression
+              sym_map
+              m
+              Store
+                { bytes = 8
+                , offset = 0
+                , ptr =
+                    ConstI32 $
+                    fromIntegral $ (sym_map ! "__asterius_pc") .&. 0xFFFFFFFF
+                , value = ConstI64 t
+                , valueType = I64
+                }
+          r <- lift $ c_BinaryenReturn m nullPtr
+          (arr, _) <- marshalV [s, r]
+          lift $ c_BinaryenBlock m nullPtr arr 2 c_BinaryenTypeNone
+        _ -> lift $ marshalExpression sym_map m $ barf returnCallTarget64 []
     ReturnCallIndirect {..} -> do
       s <-
         lift $
@@ -345,10 +360,12 @@ marshalExpression sym_map m e =
     CFG {..} -> lift $ relooperRun sym_map m graph
     Symbol {..} ->
       lift $
-      c_BinaryenConstInt64 m $
       case M.lookup unresolvedSymbol sym_map of
-        Just x -> x + fromIntegral symbolOffset
-        _ -> invalidAddress
+        Just x -> c_BinaryenConstInt64 m $ x + fromIntegral symbolOffset
+        _
+          | M.member ("__asterius_barf_" <> unresolvedSymbol) sym_map ->
+            marshalExpression sym_map m $ barf unresolvedSymbol [I64]
+          | otherwise -> c_BinaryenConstInt64 m invalidAddress
     _ -> lift $ throwIO $ UnsupportedExpression e
 
 marshalMaybeExpression ::

--- a/asterius/src/Asterius/Backends/WasmToolkit.hs
+++ b/asterius/src/Asterius/Backends/WasmToolkit.hs
@@ -693,16 +693,7 @@ makeInstructions tail_calls sym_map _module_symtable@ModuleSymbolTable {..} _de_
                 _de_bruijn_ctx
                 _local_ctx $
               barf returnCallTarget64 []
-            | otherwise ->
-              pure $
-              DList.singleton
-                (Wasm.I32Const (fromIntegral $ invalidAddress .&. 0xFFFFFFFF)) <>
-              DList.singleton
-                Wasm.ReturnCallIndirect
-                  { returnCallIndirectFunctionTypeIndex =
-                      functionTypeSymbols !
-                      FunctionType {paramTypes = [], returnTypes = []}
-                  }
+            | otherwise -> pure $ DList.singleton Wasm.Unreachable
       | otherwise ->
         case Map.lookup returnCallTarget64 sym_map of
           Just t ->
@@ -730,22 +721,7 @@ makeInstructions tail_calls sym_map _module_symtable@ModuleSymbolTable {..} _de_
                 _de_bruijn_ctx
                 _local_ctx $
               barf returnCallTarget64 []
-            | otherwise ->
-              makeInstructions
-                tail_calls
-                sym_map
-                _module_symtable
-                _de_bruijn_ctx
-                _local_ctx
-                Store
-                  { bytes = 8
-                  , offset = 0
-                  , ptr =
-                      ConstI32 $
-                      fromIntegral $ (sym_map ! "__asterius_pc") .&. 0xFFFFFFFF
-                  , value = ConstI64 invalidAddress
-                  , valueType = I64
-                  }
+            | otherwise -> pure $ DList.singleton Wasm.Unreachable
     ReturnCallIndirect {..}
       | tail_calls -> do
         x <-

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -113,6 +113,7 @@ rtsAsteriusModule opts =
        <> threadPausedFunction opts
        <> dirtyMutVarFunction opts
        <> raiseExceptionHelperFunction opts
+       <> barfFunction opts
        <> (if debug opts then generateRtsAsteriusDebugModule opts else mempty)
        -- | Add in the module that contain functions which need to be
        -- | exposed to the outside world. So add in the module, and
@@ -360,10 +361,16 @@ rtsFunctionImports debug =
       }
   , FunctionImport
       { internalName = "__asterius_raiseExceptionHelper"
-      , externalModuleName = "RaiseExceptionHelper"
+      , externalModuleName = "ExceptionHelper"
       , externalBaseName = "raiseExceptionHelper"
       , functionType =
           FunctionType {paramTypes = [F64, F64, F64], returnTypes = [F64]}
+      }
+  , FunctionImport
+      { internalName = "__asterius_barf"
+      , externalModuleName = "ExceptionHelper"
+      , externalBaseName = "barf"
+      , functionType = FunctionType {paramTypes = [F64], returnTypes = []}
       }
   ] <>
   (if debug
@@ -603,7 +610,7 @@ generateWrapperModule mod = mod {
 
 
 
-mainFunction, hsInitFunction, rtsApplyFunction, rtsEvalFunction, rtsEvalIOFunction, rtsEvalLazyIOFunction, rtsGetSchedStatusFunction, rtsCheckSchedStatusFunction, scheduleWaitThreadFunction, createThreadFunction, createGenThreadFunction, createIOThreadFunction, createStrictIOThreadFunction, allocatePinnedFunction, newCAFFunction, stgReturnFunction, getStablePtrWrapperFunction, deRefStablePtrWrapperFunction, freeStablePtrWrapperFunction, rtsMkBoolFunction, rtsMkDoubleFunction, rtsMkCharFunction, rtsMkIntFunction, rtsMkWordFunction, rtsMkPtrFunction, rtsMkStablePtrFunction, rtsGetBoolFunction, rtsGetDoubleFunction, loadI64Function, printI64Function, assertEqI64Function, printF32Function, printF64Function, strlenFunction, memchrFunction, memcpyFunction, memsetFunction, memcmpFunction, fromJSArrayBufferFunction, toJSArrayBufferFunction, fromJSStringFunction, fromJSArrayFunction, threadPausedFunction, dirtyMutVarFunction, raiseExceptionHelperFunction ::
+mainFunction, hsInitFunction, rtsApplyFunction, rtsEvalFunction, rtsEvalIOFunction, rtsEvalLazyIOFunction, rtsGetSchedStatusFunction, rtsCheckSchedStatusFunction, scheduleWaitThreadFunction, createThreadFunction, createGenThreadFunction, createIOThreadFunction, createStrictIOThreadFunction, allocatePinnedFunction, newCAFFunction, stgReturnFunction, getStablePtrWrapperFunction, deRefStablePtrWrapperFunction, freeStablePtrWrapperFunction, rtsMkBoolFunction, rtsMkDoubleFunction, rtsMkCharFunction, rtsMkIntFunction, rtsMkWordFunction, rtsMkPtrFunction, rtsMkStablePtrFunction, rtsGetBoolFunction, rtsGetDoubleFunction, loadI64Function, printI64Function, assertEqI64Function, printF32Function, printF64Function, strlenFunction, memchrFunction, memcpyFunction, memsetFunction, memcmpFunction, fromJSArrayBufferFunction, toJSArrayBufferFunction, fromJSStringFunction, fromJSArrayFunction, threadPausedFunction, dirtyMutVarFunction, raiseExceptionHelperFunction, barfFunction ::
      BuiltinsOptions -> AsteriusModule
 mainFunction BuiltinsOptions {} =
   runEDSL  "main" $ do
@@ -1163,6 +1170,11 @@ raiseExceptionHelperFunction _ =
         (map convertUInt64ToFloat64 args)
         F64
     emit frame_type
+
+barfFunction _ =
+  runEDSL "barf" $ do
+    s <- param I64
+    callImport "__asterius_barf" [convertUInt64ToFloat64 s]
 
 getF64GlobalRegFunction ::
   BuiltinsOptions

--- a/asterius/src/Asterius/Internals.hs
+++ b/asterius/src/Asterius/Internals.hs
@@ -13,10 +13,8 @@ module Asterius.Internals
   , showSBS
   , c8SBS
   , (!)
-  , (!?)
   ) where
 
-import Asterius.Internals.MagicNumber
 import Control.Exception
 import qualified Data.Binary as Binary
 import qualified Data.ByteString.Char8 as CBS
@@ -102,7 +100,3 @@ c8SBS = CBS.unpack . SBS.fromShort
   case LM.lookup k m of
     Just v -> v
     _ -> error $ show k <> " not found"
-
-{-# INLINE (!?) #-}
-(!?) :: Ord k => LM.Map k Int64 -> k -> Int64
-(!?) = flip $ LM.findWithDefault invalidAddress

--- a/asterius/src/Asterius/Internals/Barf.hs
+++ b/asterius/src/Asterius/Internals/Barf.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Asterius.Internals.Barf
+  ( barf
+  ) where
+
+import Asterius.Types
+
+barf :: AsteriusEntitySymbol -> [ValueType] -> Expression
+barf sym [] =
+  Call
+    { target = "barf"
+    , operands =
+        [ Symbol
+            {unresolvedSymbol = "__asterius_barf_" <> sym, symbolOffset = 0}
+        ]
+    , callReturnTypes = []
+    }
+barf sym vts =
+  Block {name = "", bodys = [barf sym [], Unreachable], blockReturnTypes = vts}

--- a/asterius/src/Asterius/Ld.hs
+++ b/asterius/src/Asterius/Ld.hs
@@ -39,7 +39,8 @@ loadTheWorld LinkTask {..} = do
 rtsUsedSymbols :: Set AsteriusEntitySymbol
 rtsUsedSymbols =
   Set.fromList
-    [ "base_GHCziPtr_Ptr_con_info"
+    [ "barf"
+    , "base_GHCziPtr_Ptr_con_info"
     , "base_GHCziStable_StablePtr_con_info"
     , "ghczmprim_GHCziTypes_Czh_con_info"
     , "ghczmprim_GHCziTypes_Dzh_con_info"


### PR DESCRIPTION
This PR implements the following mechanism:

* `barf()` as seen in ghc rts. Since we don't have varargs ABI yet, we restrict `barf()` to take exactly one pointer arg, and slice away other args (or provide a `0` in case there's none).
* When the linker sees an unresolved symbol, it dynamically adds an error string as a data segment into the resulting module.
* When the `wasm-toolkit`/`binaryen` backends see an unresolved symbol, they attempt to substitute it with a `barf()` call rather than a simple `unreachable` opcode.

When execution of wasm reaches an unresolved symbol, then the symbol will show up in the js error message.