### PR TITLE
Fix noDuplicate#

### DIFF
--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -71,6 +71,16 @@ rtsAsteriusModule opts =
                 { staticsType = Bytes
                 , asteriusStatics = [Serialized $ encodeStorable (0 :: Word64)]
                 })
+          , ( "n_capabilities"
+            , AsteriusStatics
+                { staticsType = ConstBytes
+                , asteriusStatics = [Serialized $ encodeStorable (1 :: Word32)]
+                })
+          , ( "enabled_capabilities"
+            , AsteriusStatics
+                { staticsType = ConstBytes
+                , asteriusStatics = [Serialized $ encodeStorable (1 :: Word32)]
+                })
           , ( "__asterius_pc"
             , AsteriusStatics
                 { staticsType = Bytes


### PR DESCRIPTION
This PR fixes the `noDuplicate#` primop, making `unsafePerformIO` work. Also, `getNumCapabilities` is working.