### PR TITLE
Fix getProgArgv

### DIFF
--- a/asterius/src/Asterius/Ld.hs
+++ b/asterius/src/Asterius/Ld.hs
@@ -20,6 +20,7 @@ import qualified Data.Set as Set
 import Data.Set (Set)
 import Data.Traversable
 import Prelude hiding (IO)
+import System.FilePath
 
 data LinkTask = LinkTask
   { linkOutput :: FilePath
@@ -67,7 +68,9 @@ linkModules LinkTask {..} m =
     True
     gcSections
     binaryen
-    (rtsAsteriusModule defaultBuiltinsOptions {Asterius.Builtins.debug = debug} <>
+    (rtsAsteriusModule
+       defaultBuiltinsOptions
+         {progName = takeBaseName linkOutput, Asterius.Builtins.debug = debug} <>
      m)
     (Set.unions
        [ Set.fromList rootSymbols


### PR DESCRIPTION
This PR fixes `System.Environment.getProgArgv`. Since `argv` makes little sense in a web setting, we hard-code it to contain exactly one C string, which is the program name taken from the `ahc-ld` output path.

Note that `getProgName` and `getArgs` still doesn't work yet, due to lack of `iconv`. That will be fixed in a subsequent PR.