### PR TITLE
Fix "safe" ccalls

### DIFF
--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -143,6 +143,8 @@ rtsAsteriusModule opts =
        <> raiseExceptionHelperFunction opts
        <> barfFunction opts
        <> getProgArgvFunction opts
+       <> suspendThreadFunction opts
+       <> resumeThreadFunction opts
        <> (if debug opts then generateRtsAsteriusDebugModule opts else mempty)
        -- | Add in the module that contain functions which need to be
        -- | exposed to the outside world. So add in the module, and
@@ -639,7 +641,7 @@ generateWrapperModule mod = mod {
 
 
 
-mainFunction, hsInitFunction, rtsApplyFunction, rtsEvalFunction, rtsEvalIOFunction, rtsEvalLazyIOFunction, rtsGetSchedStatusFunction, rtsCheckSchedStatusFunction, scheduleWaitThreadFunction, createThreadFunction, createGenThreadFunction, createIOThreadFunction, createStrictIOThreadFunction, allocatePinnedFunction, newCAFFunction, stgReturnFunction, getStablePtrWrapperFunction, deRefStablePtrWrapperFunction, freeStablePtrWrapperFunction, rtsMkBoolFunction, rtsMkDoubleFunction, rtsMkCharFunction, rtsMkIntFunction, rtsMkWordFunction, rtsMkPtrFunction, rtsMkStablePtrFunction, rtsGetBoolFunction, rtsGetDoubleFunction, loadI64Function, printI64Function, assertEqI64Function, printF32Function, printF64Function, strlenFunction, memchrFunction, memcpyFunction, memsetFunction, memcmpFunction, fromJSArrayBufferFunction, toJSArrayBufferFunction, fromJSStringFunction, fromJSArrayFunction, threadPausedFunction, dirtyMutVarFunction, raiseExceptionHelperFunction, barfFunction, getProgArgvFunction ::
+mainFunction, hsInitFunction, rtsApplyFunction, rtsEvalFunction, rtsEvalIOFunction, rtsEvalLazyIOFunction, rtsGetSchedStatusFunction, rtsCheckSchedStatusFunction, scheduleWaitThreadFunction, createThreadFunction, createGenThreadFunction, createIOThreadFunction, createStrictIOThreadFunction, allocatePinnedFunction, newCAFFunction, stgReturnFunction, getStablePtrWrapperFunction, deRefStablePtrWrapperFunction, freeStablePtrWrapperFunction, rtsMkBoolFunction, rtsMkDoubleFunction, rtsMkCharFunction, rtsMkIntFunction, rtsMkWordFunction, rtsMkPtrFunction, rtsMkStablePtrFunction, rtsGetBoolFunction, rtsGetDoubleFunction, loadI64Function, printI64Function, assertEqI64Function, printF32Function, printF64Function, strlenFunction, memchrFunction, memcpyFunction, memsetFunction, memcmpFunction, fromJSArrayBufferFunction, toJSArrayBufferFunction, fromJSStringFunction, fromJSArrayFunction, threadPausedFunction, dirtyMutVarFunction, raiseExceptionHelperFunction, barfFunction, getProgArgvFunction, suspendThreadFunction, resumeThreadFunction ::
      BuiltinsOptions -> AsteriusModule
 mainFunction BuiltinsOptions {} =
   runEDSL  "main" $ do
@@ -1210,6 +1212,18 @@ getProgArgvFunction _ =
     [argc, argv] <- params [I64, I64]
     storeI64 argc 0 $ constI64 1
     storeI64 argv 0 $ symbol "prog_argv"
+
+suspendThreadFunction _ =
+  runEDSL "suspendThread" $ do
+    setReturnTypes [I64]
+    [reg, _] <- params [I64, I64]
+    emit reg
+
+resumeThreadFunction _ =
+  runEDSL "resumeThread" $ do
+    setReturnTypes [I64]
+    reg <- param I64
+    emit reg
 
 getF64GlobalRegFunction ::
   BuiltinsOptions

--- a/asterius/test/fib/fib.hs
+++ b/asterius/test/fib/fib.hs
@@ -51,7 +51,7 @@ sizeofBinTree :: BinTree -> Int
 sizeofBinTree Tip = 1
 sizeofBinTree (Branch x y) = 1 + sizeofBinTree x + sizeofBinTree y
 
-foreign import ccall unsafe "print_i64" print_i64 :: Int -> IO ()
+foreign import ccall safe "print_i64" print_i64 :: Int -> IO ()
 foreign import ccall unsafe "assert_eq_i64" assert_eq_i64 :: Int -> Int -> IO ()
 
 foreign import ccall unsafe "print_f64" print_f64 :: Double -> IO ()


### PR DESCRIPTION
This PR fixes `foreign import ccall safe` by implementing no-op `suspendThread`/`resumeThread`.

The original versions of those two functions are based on `Capability`/`Task`/`InCall` data structures, and in our case, we don't have multi-threads yet, nor do we intend to implement threads with `Task`/`InCall`s, so it's safe to have no-op versions first.

When we later add multi-thread support, we'll revisit this ticket and have `suspendThread`/`resumeThread` collaborate with the new TSO manager.