### PR TITLE
Fix `localeEncoding`

### DIFF
--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -99,6 +99,11 @@ rtsAsteriusModule opts =
                 { staticsType = ConstBytes
                 , asteriusStatics = [SymbolStatic "prog_name" 0]
                 })
+          , ( "__asterius_localeEncoding"
+            , AsteriusStatics
+                { staticsType = ConstBytes
+                , asteriusStatics = [Serialized "UTF-8\0"]
+                })
           , ( "__asterius_pc"
             , AsteriusStatics
                 { staticsType = Bytes
@@ -147,6 +152,7 @@ rtsAsteriusModule opts =
        <> resumeThreadFunction opts
        <> performMajorGCFunction opts
        <> performGCFunction opts
+       <> localeEncodingFunction opts
        <> (if debug opts then generateRtsAsteriusDebugModule opts else mempty)
        -- | Add in the module that contain functions which need to be
        -- | exposed to the outside world. So add in the module, and
@@ -643,7 +649,7 @@ generateWrapperModule mod = mod {
 
 
 
-mainFunction, hsInitFunction, rtsApplyFunction, rtsEvalFunction, rtsEvalIOFunction, rtsEvalLazyIOFunction, rtsGetSchedStatusFunction, rtsCheckSchedStatusFunction, scheduleWaitThreadFunction, createThreadFunction, createGenThreadFunction, createIOThreadFunction, createStrictIOThreadFunction, allocatePinnedFunction, newCAFFunction, stgReturnFunction, getStablePtrWrapperFunction, deRefStablePtrWrapperFunction, freeStablePtrWrapperFunction, rtsMkBoolFunction, rtsMkDoubleFunction, rtsMkCharFunction, rtsMkIntFunction, rtsMkWordFunction, rtsMkPtrFunction, rtsMkStablePtrFunction, rtsGetBoolFunction, rtsGetDoubleFunction, loadI64Function, printI64Function, assertEqI64Function, printF32Function, printF64Function, strlenFunction, memchrFunction, memcpyFunction, memsetFunction, memcmpFunction, fromJSArrayBufferFunction, toJSArrayBufferFunction, fromJSStringFunction, fromJSArrayFunction, threadPausedFunction, dirtyMutVarFunction, raiseExceptionHelperFunction, barfFunction, getProgArgvFunction, suspendThreadFunction, resumeThreadFunction, performMajorGCFunction, performGCFunction ::
+mainFunction, hsInitFunction, rtsApplyFunction, rtsEvalFunction, rtsEvalIOFunction, rtsEvalLazyIOFunction, rtsGetSchedStatusFunction, rtsCheckSchedStatusFunction, scheduleWaitThreadFunction, createThreadFunction, createGenThreadFunction, createIOThreadFunction, createStrictIOThreadFunction, allocatePinnedFunction, newCAFFunction, stgReturnFunction, getStablePtrWrapperFunction, deRefStablePtrWrapperFunction, freeStablePtrWrapperFunction, rtsMkBoolFunction, rtsMkDoubleFunction, rtsMkCharFunction, rtsMkIntFunction, rtsMkWordFunction, rtsMkPtrFunction, rtsMkStablePtrFunction, rtsGetBoolFunction, rtsGetDoubleFunction, loadI64Function, printI64Function, assertEqI64Function, printF32Function, printF64Function, strlenFunction, memchrFunction, memcpyFunction, memsetFunction, memcmpFunction, fromJSArrayBufferFunction, toJSArrayBufferFunction, fromJSStringFunction, fromJSArrayFunction, threadPausedFunction, dirtyMutVarFunction, raiseExceptionHelperFunction, barfFunction, getProgArgvFunction, suspendThreadFunction, resumeThreadFunction, performMajorGCFunction, performGCFunction, localeEncodingFunction ::
      BuiltinsOptions -> AsteriusModule
 mainFunction BuiltinsOptions {} =
   runEDSL  "main" $ do
@@ -1234,6 +1240,11 @@ performMajorGCFunction _ =
     [convertUInt64ToFloat64 $ getLVal $ global CurrentTSO]
 
 performGCFunction _ = runEDSL "performGC" $ call "performMajorGC" []
+
+localeEncodingFunction _ =
+  runEDSL "localeEncoding" $ do
+    setReturnTypes [I64]
+    emit $ symbol "__asterius_localeEncoding"
 
 getF64GlobalRegFunction ::
   BuiltinsOptions


### PR DESCRIPTION
This PR fixes `localeEncoding` called by `iconvEncoding` in `GHC.IO.Encoding.Iconv`. `localeEncoding` always return `UTF-8` at the moment. After #133 is reviewed and merged as well, this will make functions like `withCString` work.