### PR TITLE
Remove "sync mode"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,6 @@ jobs:
             stack --no-terminal test asterius:regression60
             stack --no-terminal test asterius:fib --test-arguments="--no-gc-sections"
             stack --no-terminal test asterius:fib --test-arguments="--binaryen --no-gc-sections"
-            stack --no-terminal test asterius:fib --test-arguments="--sync"
 
             cd ~/.local
             $CIRCLE_WORKING_DIRECTORY/utils/v8-node.py

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -145,23 +145,7 @@ export function newAsteriusInstance(req) {
       TSO: modulify(__asterius_tso_manager)
     }
   );
-  if (req.sync) {
-    const i = new WebAssembly.Instance(req.module, importObject);
-    __asterius_wasm_instance = i;
-    __asterius_memory.init(__asterius_wasm_memory, req.staticMBlocks);
-    __asterius_mblockalloc.init(__asterius_memory, req.staticMBlocks);
-    __asterius_heapalloc.init();
-    __asterius_integer_manager.heap = __asterius_heap_builder;
-    __asterius_bytestring_cbits.memory = __asterius_memory;
-    return Object.assign(__asterius_jsffi_instance, {
-      wasmModule: req.module,
-      wasmInstance: __asterius_wasm_instance,
-      symbolTable: req.symbolTable,
-      vault: __asterius_vault,
-      logger: __asterius_logger
-    });
-  } else
-    return WebAssembly.instantiate(req.module, importObject).then(i => {
+  return WebAssembly.instantiate(req.module, importObject).then(i => {
       __asterius_wasm_instance = i;
       __asterius_memory.init(__asterius_wasm_memory, req.staticMBlocks);
       __asterius_mblockalloc.init(__asterius_memory, req.staticMBlocks);

--- a/asterius/src/Asterius/JSGen/Wasm.hs
+++ b/asterius/src/Asterius/JSGen/Wasm.hs
@@ -7,8 +7,8 @@ module Asterius.JSGen.Wasm
 import Data.ByteString.Builder
 import System.FilePath
 
-genWasm :: Bool -> Bool -> FilePath -> Builder
-genWasm is_node is_sync base_name =
+genWasm :: Bool -> FilePath -> Builder
+genWasm is_node base_name =
   mconcat
     [ case () of
         ()
@@ -17,8 +17,6 @@ genWasm is_node is_sync base_name =
     , "export default "
     , case () of
         ()
-          | is_node && is_sync ->
-            "new WebAssembly.Module(fs.readFileSync(" <> out_wasm <> "))"
           | is_node ->
             "fs.promises.readFile(" <> out_wasm <>
             ").then(bufferSource => WebAssembly.compile(bufferSource))"

--- a/asterius/src/Asterius/JSRun/NonMain.hs
+++ b/asterius/src/Asterius/JSRun/NonMain.hs
@@ -49,7 +49,6 @@ distNonMain p extra_syms =
       , Asterius.Main.gcSections = True
       , fullSymTable = True
       , bundle = False
-      , sync = False
       , Asterius.Main.binaryen = False
       , Asterius.Main.debug = False
       , outputLinkReport = False

--- a/asterius/test/cloudflare.hs
+++ b/asterius/test/cloudflare.hs
@@ -8,7 +8,6 @@ main = do
   callProcess "ahc-link" $
     [ "--bundle"
     , "--browser"
-    , "--sync"
     , "--input-hs"
     , "test/cloudflare/cloudflare.hs"
     , "--input-mjs"

--- a/docs/ahc-link.md
+++ b/docs/ahc-link.md
@@ -63,15 +63,6 @@ Instead of copying the runtime `.mjs` modules to the target directory, generate 
 
 `--bundle` is supported by [`Parcel`](https://parceljs.org/) under the hood and performs minification on the bundled JavaScript file. It's likely beneficial since it reduces total size of scripts and doesn't require multiple requests for fetching them.
 
-## `--sync`
-
-Use synchronous `WebAssembly.Module`/`WebAssembly.Instance` constructors in output code. Additionally,
-
-* The `module` value exported by `xx.wasm.mjs` is no longer a `Promise`, but the `WebAssembly.Module` value itself.
-* The `newInstance` function exported by `xx.lib.mjs` is no longer async, but returns the Asterius instance synchronously.
-
-We don't recommend using `--sync` for most use cases (even for the Node.js target). It's intended for a special use case: Cloudflare Workers, where any initialization logic must be completed on the first run and can't be put in the event queue.
-
 ## More advanced options for hackers
 
 ### `--run`


### PR DESCRIPTION
This PR removes the "sync mode".

When we call `ahc-link`/`ahc-dist` with `--sync`, the resulting main js module performs WebAssembly compilation/instantiation synchronously. Back when we added this sync mode, its only intended use scenario is Cloudflare Workers: its runtime supports synchronous WebAssembly instantiation, and the fetch event handler must be already set up when the script finishes, thus we needed to synchronously return an asterius instance and call `hs_init`/`main` for proper event handling. We don't use "sync mode" in any other scenario, and synchronous WebAssembly compilation/instantiation is a known anti-pattern.

Right now, we've come to the point where asynchronous instantiation of the runtime is a must, and sync mode will cease to work, so we chop it off in this PR. Regarding Cloudflare Workers, we can still set up a dummy event handler which awaits the real handler from a top-level `Promise`, and set up the real handler asynchronously.

Why do we need asynchronous instantiation now? Say that we want the same functionality (e.g. crypto digest) from either web api or node, so we need to `import crypto from "crypto"` in node, which surely fails in a browser tab. We can do `import("crypto")` then handle the rejection to use web api, eventually exporting a module namespace object which exposes the same set of api for web/node, but this introduces asynchronous instantiation. Of course, we can seek to do some conditional compilation in js, but there isn't a satisfactory solution yet.