### PR TITLE
Fix threadPaused

### DIFF
--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -17,6 +17,7 @@ import { MemoryFileSystem } from "./rts.fs.mjs";
 import { ByteStringCBits } from "./rts.bytestring.mjs";
 import { GC } from "./rts.gc.mjs";
 import { ExceptionHelper } from "./rts.exception.mjs";
+import { ThreadPaused } from "./rts.threadpaused.mjs";
 import { FloatCBits } from "./rts.float.mjs";
 import { Unicode } from "./rts.unicode.mjs";
 import * as rtsConstants from "./rts.constants.mjs";
@@ -40,6 +41,7 @@ export function newAsteriusInstance(req) {
     __asterius_bytestring_cbits = new ByteStringCBits(null),
     __asterius_gc = new GC(__asterius_memory, __asterius_mblockalloc, __asterius_heapalloc, __asterius_stableptr_manager, __asterius_tso_manager, req.infoTables, req.pinnedStaticClosures, req.symbolTable),
     __asterius_exception_helper = new ExceptionHelper(__asterius_memory, __asterius_heapalloc, req.infoTables, req.symbolTable),
+    __asterius_threadpaused = new ThreadPaused(__asterius_memory, req.infoTables, req.symbolTable),
     __asterius_float_cbits = new FloatCBits(__asterius_memory),
     __asterius_unicode = new Unicode();
 
@@ -134,6 +136,7 @@ export function newAsteriusInstance(req) {
       floatCBits: modulify(__asterius_float_cbits),
       GC: modulify(__asterius_gc),
       ExceptionHelper: modulify(__asterius_exception_helper),
+      ThreadPaused: modulify(__asterius_threadpaused),
       HeapAlloc: modulify(__asterius_heapalloc),
       HeapBuilder: modulify(__asterius_heap_builder),
       MBlockAlloc: modulify(__asterius_mblockalloc),

--- a/asterius/rts/rts.threadpaused.mjs
+++ b/asterius/rts/rts.threadpaused.mjs
@@ -1,0 +1,76 @@
+import * as ClosureTypes from "./rts.closuretypes.mjs";
+import * as rtsConstants from "./rts.constants.mjs";
+
+export class ThreadPaused {
+  constructor(memory, info_tables, symbol_table) {
+    this.memory = memory;
+    this.infoTables = info_tables;
+    this.symbolTable = symbol_table;
+    Object.freeze(this);
+  }
+
+  threadPaused(cap, tso) {
+    const stackobj = Number(
+      this.memory.i64Load(tso + rtsConstants.offset_StgTSO_stackobj)
+    );
+    let p = Number(
+      this.memory.i64Load(stackobj + rtsConstants.offset_StgStack_sp)
+    );
+    while (true) {
+      const info = Number(this.memory.i64Load(p)),
+        type = this.memory.i32Load(
+          info + rtsConstants.offset_StgInfoTable_type
+        ),
+        raw_layout = this.memory.i64Load(
+          info + rtsConstants.offset_StgInfoTable_layout
+        );
+      if (!this.infoTables.has(info))
+        throw new WebAssembly.RuntimeError(
+          "threadPaused: invalid info pointer"
+        );
+      switch (type) {
+        case ClosureTypes.UPDATE_FRAME: {
+          if (info === this.symbolTable.stg_marked_upd_frame_info) return;
+          this.memory.i64Store(p, this.symbolTable.stg_marked_upd_frame_info);
+          const bh = Number(
+            this.memory.i64Load(p + rtsConstants.offset_StgUpdateFrame_updatee)
+          );
+          this.memory.i64Store(bh, this.symbolTable.stg_BLACKHOLE_info);
+          this.memory.i64Store(bh + rtsConstants.offset_StgInd_indirectee, tso);
+          const size = Number(raw_layout & BigInt(0x3f));
+          p += (1 + size) << 3;
+          break;
+        }
+        case ClosureTypes.CATCH_FRAME:
+        case ClosureTypes.RET_SMALL: {
+          const size = Number(raw_layout & BigInt(0x3f));
+          p += (1 + size) << 3;
+          break;
+        }
+        case ClosureTypes.STOP_FRAME: {
+          return;
+        }
+        case ClosureTypes.RET_BIG: {
+          const size = Number(
+            this.memory.i64Load(
+              Number(raw_layout) + rtsConstants.offset_StgLargeBitmap_size
+            )
+          );
+          p += (1 + size) << 3;
+          break;
+        }
+        case ClosureTypes.RET_FUN: {
+          const size = Number(
+            this.memory.i64Load(p + rtsConstants.offset_StgRetFun_size)
+          );
+          p += rtsConstants.sizeof_StgRetFun + (size << 3);
+          break;
+        }
+        default:
+          throw new WebAssembly.RuntimeError(
+            "threadPaused: unsupported stack frame"
+          );
+      }
+    }
+  }
+}

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -412,6 +412,12 @@ rtsFunctionImports debug =
       , externalBaseName = "barf"
       , functionType = FunctionType {paramTypes = [F64], returnTypes = []}
       }
+  , FunctionImport
+      { internalName = "__asterius_threadPaused"
+      , externalModuleName = "ThreadPaused"
+      , externalBaseName = "threadPaused"
+      , functionType = FunctionType {paramTypes = [F64, F64], returnTypes = []}
+      }
   ] <>
   (if debug
      then [ FunctionImport
@@ -1200,7 +1206,10 @@ fromJSArrayFunction _ =
       callImport' "__asterius_fromJSArray_imp" [convertUInt64ToFloat64 arr] F64
     emit addr
 
-threadPausedFunction _ = runEDSL "threadPaused" $ void $ params [I64, I64]
+threadPausedFunction _ =
+  runEDSL "threadPaused" $ do
+    args <- params [I64, I64]
+    callImport "__asterius_threadPaused" $ map convertUInt64ToFloat64 args
 
 dirtyMutVarFunction _ =
   runEDSL "dirty_MUT_VAR" $ do

--- a/asterius/src/Asterius/Ld.hs
+++ b/asterius/src/Asterius/Ld.hs
@@ -55,6 +55,7 @@ rtsUsedSymbols =
     , "stg_ARR_WORDS_info"
     , "stg_BLACKHOLE_info"
     , "stg_DEAD_WEAK_info"
+    , "stg_marked_upd_frame_info"
     , "stg_NO_FINALIZER_closure"
     , "stg_raise_info"
     , "stg_WEAK_info"


### PR DESCRIPTION
This PR fixes the previously no-op `threadPaused`. We now properly traverse the stack and perform lazy blackholing for update frames.