### PR TITLE
implement FNV hash instead of MD5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ jobs:
             stack --no-terminal test asterius:cloudflare
             stack --no-terminal test asterius:exception
             stack --no-terminal test asterius:regression60
+            stack --no-terminal test asterius:sizeof_md5context
             stack --no-terminal test asterius:fib --test-arguments="--no-gc-sections"
             stack --no-terminal test asterius:fib --test-arguments="--binaryen --no-gc-sections"
 

--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -31,6 +31,8 @@ extra-source-files:
   - test/ghc-testsuite/**/*.stdout
   - test/exception/**/*.hs
   - test/regression60/**/*.hs
+  - test/regression60/**/*.hs
+  - test/sizeof_md5context/**/*.hs
 
 data-files:
   - rts/*.mjs
@@ -244,6 +246,13 @@ tests:
       - ansi-terminal
       - stm
       - cassava
+
+  sizeof_md5context:
+    source-dirs: test
+    main: sizeof_md5context.hs
+    ghc-options: -threaded -rtsopts
+    dependencies:
+      - asterius
 
   regression60:
     source-dirs: test

--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -31,7 +31,6 @@ extra-source-files:
   - test/ghc-testsuite/**/*.stdout
   - test/exception/**/*.hs
   - test/regression60/**/*.hs
-  - test/regression60/**/*.hs
   - test/sizeof_md5context/**/*.hs
 
 data-files:

--- a/asterius/rts/rts.md5.mjs
+++ b/asterius/rts/rts.md5.mjs
@@ -21,12 +21,14 @@ export class MD5 {
 
   // void MD5Init(struct MD5Context *context);
   __hsbase_MD5Init(ctxp) {
+      let hash = 5381;
+      this.memory.i64Store(ctxp, 5381);
   }
 
   // void MD5Update(struct MD5Context *context, byte const *buf, int len);
   __hsbase_MD5Update(ctxp, bufp, len) {
 	  let i = 0;
-      let hash = 5381;
+      let hash = this.memory.i64Load(ctxp, hash);
 	  while(i < len) {
           let c = this.memory.i8View[Memory.unTag(bufp) + i];
           hash = ((hash << 5) + hash) + c; // hash * 33 + c

--- a/asterius/rts/rts.md5.mjs
+++ b/asterius/rts/rts.md5.mjs
@@ -14,25 +14,19 @@ export class MD5 {
     Object.seal(this);
   }
 
-  // struct MD5Context {
-  //  word32 buf[4]; // 32 * 8 = 256 bits
-  //  word32 bytes[2];
-  //  word32 in[16];
-  // };
 
   // void MD5Init(struct MD5Context *context);
   __hsbase_MD5Init(ctxp) {
-      this.memory.i128Store(ctxp, BigInt(144066263297769815596495629667062367629));
+      const offset = 144066263297769815596495629667062367629n;
+      this.memory.i128Store(ctxp, offset);
   }
 
   // void MD5Update(struct MD5Context *context, byte const *buf, int len);
   __hsbase_MD5Update(ctxp, bufp, len) {
-      const prime = BigInt(309485009821345068724781371);
+      const prime = 309485009821345068724781371n;
 
 	  let i = 0;
       let hash = this.memory.i128Load(ctxp);
-      console.error("--");
-      console.error("hash loaded ", hash);
 	  while(i < len) {
           let c = BigInt(this.memory.i8View[Memory.unTag(bufp) + i]);
           hash = hash * prime;
@@ -41,7 +35,6 @@ export class MD5 {
           hash = hash & ((BigInt(1) << BigInt(128)) - BigInt(1));
 		  i++;
 	  }
-      console.error("hash stored ", hash);
       this.memory.i128Store(ctxp, hash);
 
   }

--- a/asterius/rts/rts.md5.mjs
+++ b/asterius/rts/rts.md5.mjs
@@ -1,9 +1,10 @@
 import { Memory } from "./rts.memory.mjs";
+
 export class MD5 {
   // We implement the 128-bit FNV-1a hash function:
   // https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
   // This is easier, and it is unclear whether GHC
-  // needs cryptographic hash functions. We assume that GHC does not ever 
+  // needs cryptographic hash functions. We assume that GHC does not ever
   // depend on the fact that the hash function _must be MD5_.
 
   // used by GHC/Fingerprint.hs
@@ -14,35 +15,32 @@ export class MD5 {
     Object.seal(this);
   }
 
-
   // void MD5Init(struct MD5Context *context);
   __hsbase_MD5Init(ctxp) {
-      const offset = BigInt("144066263297769815596495629667062367629");
-      this.memory.i128Store(ctxp, offset);
+    const offset = BigInt("144066263297769815596495629667062367629");
+    this.memory.i128Store(ctxp, offset);
   }
 
   // void MD5Update(struct MD5Context *context, byte const *buf, int len);
   __hsbase_MD5Update(ctxp, bufp, len) {
-      const prime = BigInt("309485009821345068724781371");
+    const prime = BigInt("309485009821345068724781371");
 
-	  let i = 0;
-      let hash = this.memory.i128Load(ctxp);
-	  while(i < len) {
-          let c = BigInt(this.memory.i8View[Memory.unTag(bufp) + i]);
-          hash = hash * prime;
-          hash = hash ^ c;
-          // only keep 128 bits, overflow is overflown.
-          hash = hash & ((BigInt(1) << BigInt(128)) - BigInt(1));
-		  i++;
-	  }
-      this.memory.i128Store(ctxp, hash);
-
+    let i = 0;
+    let hash = this.memory.i128Load(ctxp);
+    while (i < len) {
+      let c = BigInt(this.memory.i8View[Memory.unTag(bufp) + i]);
+      hash = hash * prime;
+      hash = hash ^ c;
+      // only keep 128 bits, overflow is overflown.
+      hash = hash & ((BigInt(1) << BigInt(128)) - BigInt(1));
+      i++;
+    }
+    this.memory.i128Store(ctxp, hash);
   }
 
-  
   // 16 byte = 128 bit.
   // void MD5Final(byte digest[16], struct MD5Context *context);
   __hsbase_MD5Final(digestp, ctxp) {
-      this.memory.i128Store(digestp, this.memory.i128Load(ctxp));
+    this.memory.i128Store(digestp, this.memory.i128Load(ctxp));
   }
 }

--- a/asterius/rts/rts.md5.mjs
+++ b/asterius/rts/rts.md5.mjs
@@ -21,20 +21,19 @@ export class MD5 {
 
   // void MD5Init(struct MD5Context *context);
   __hsbase_MD5Init(ctxp) {
-      let hash = 5381;
       this.memory.i64Store(ctxp, 5381);
   }
 
   // void MD5Update(struct MD5Context *context, byte const *buf, int len);
   __hsbase_MD5Update(ctxp, bufp, len) {
 	  let i = 0;
-      let hash = this.memory.i64Load(ctxp, hash);
+      let hash = this.memory.i64Load(ctxp);
 	  while(i < len) {
-          let c = this.memory.i8View[Memory.unTag(bufp) + i];
-          hash = ((hash << 5) + hash) + c; // hash * 33 + c
+          let c = BigInt(this.memory.i8View[Memory.unTag(bufp) + i]);
+          console.error("hash: ", hash, "|c: ", c);
+          hash = ((hash << BigInt(5)) + hash) + c; // hash * 33 + c
 		  i++;
 	  }
-
       this.memory.i64Store(ctxp, hash);
 
   }

--- a/asterius/rts/rts.md5.mjs
+++ b/asterius/rts/rts.md5.mjs
@@ -17,13 +17,13 @@ export class MD5 {
 
   // void MD5Init(struct MD5Context *context);
   __hsbase_MD5Init(ctxp) {
-      const offset = 144066263297769815596495629667062367629n;
+      const offset = BigInt("144066263297769815596495629667062367629");
       this.memory.i128Store(ctxp, offset);
   }
 
   // void MD5Update(struct MD5Context *context, byte const *buf, int len);
   __hsbase_MD5Update(ctxp, bufp, len) {
-      const prime = 309485009821345068724781371n;
+      const prime = BigInt("309485009821345068724781371");
 
 	  let i = 0;
       let hash = this.memory.i128Load(ctxp);

--- a/asterius/rts/rts.md5.mjs
+++ b/asterius/rts/rts.md5.mjs
@@ -1,0 +1,46 @@
+import { Memory } from "./rts.memory.mjs";
+export class MD5 {
+  // We implement the djb2 hash function (http://www.cse.yorku.ca/~oz/hash.html)
+  // rather than MD5, since it is easier, and it is unclear whether GHC
+  // needs cryptographic hash functions. We assume that GHC does not ever 
+  // depend on the fact that the hash function _must be MD5_.
+
+  // used by GHC/Fingerprint.hs
+  // C implementation header: libraries/base/include/md5.h
+  // C implementation source: libraries/base/cbits/md5.c
+  constructor(memory) {
+    this.memory = memory;
+    Object.seal(this);
+  }
+
+  // struct MD5Context {
+  //  word32 buf[4]; // 32 * 8 = 256 bits
+  //  word32 bytes[2];
+  //  word32 in[16];
+  // };
+
+  // void MD5Init(struct MD5Context *context);
+  __hsbase_MD5Init(ctxp) {
+  }
+
+  // void MD5Update(struct MD5Context *context, byte const *buf, int len);
+  __hsbase_MD5Update(ctxp, bufp, len) {
+	  let i = 0;
+      let hash = 5381;
+	  while(i < len) {
+          let c = this.memory.i8View[Memory.unTag(bufp) + i];
+          hash = ((hash << 5) + hash) + c; // hash * 33 + c
+		  i++;
+	  }
+
+      this.memory.i64Store(ctxp, hash);
+
+  }
+
+  
+  // 16 byte = 128 bit.
+  // void MD5Final(byte digest[16], struct MD5Context *context);
+  __hsbase_MD5Final(digestp, ctxp) {
+      this.memory.i64Store(digestp, this.memory.i64Load(ctxp));
+  }
+}

--- a/asterius/rts/rts.memory.mjs
+++ b/asterius/rts/rts.memory.mjs
@@ -42,6 +42,42 @@ export class Memory {
   i32Store(p, v) { this.dataView.setUint32(Memory.unTag(p), Number(v), true); }
   i64Load(p) { return this.dataView.getBigUint64(Memory.unTag(p), true); }
   i64Store(p, v) { this.dataView.setBigUint64(Memory.unTag(p), BigInt(v), true); }
+  i128Load(p) { 
+      console.log("*** load:");
+      // little endian: number with hex digits <0A0B> at address p 
+      // get stored as mem[p] = 0B, mem[p+1] = 0A
+      let low = this.dataView.getBigUint64(Memory.unTag(p), true);
+      console.log("low: ", low);
+      let high = this.dataView.getBigUint64(Memory.unTag(p) + 8, true);
+      console.log("high: ", high);
+      console.log("----");
+      return low | (high << BigInt(64));
+  }
+
+
+  i128Store(p, v) {
+      console.log("*** store v: ", v);
+      // create all 1s of 64 bits.
+      const lowmask = (BigInt(1) << BigInt(64)) - BigInt(1);
+
+      // little endian: number with digits <x y> at address p 
+      // get stored as mem[p] = y, mem[p+1] = x
+      let low = v & lowmask;
+      console.log("v & low: " , low);
+      this.dataView.setBigUint64(Memory.unTag(p), low, true);
+
+      let high = (v >> BigInt(64)) & lowmask;
+      console.log("v & high: " , high);
+
+      let v_recreated = ((high << BigInt(64)) | low);
+      console.log("v_recreated: " , v_recreated);
+      console.assert(v_recreated == BigInt(v));
+
+      // byte addressed, so +8 = 64-bit
+      this.dataView.setBigUint64(Memory.unTag(p) + 8, high, true);
+      console.log("---");
+  }
+
   f32Load(p) { return this.dataView.getFloat32(Memory.unTag(p), true); }
   f32Store(p, v) { this.dataView.setFloat32(Memory.unTag(p), Number(v), true); }
   f64Load(p) { return this.dataView.getFloat64(Memory.unTag(p), true); }

--- a/asterius/rts/rts.memory.mjs
+++ b/asterius/rts/rts.memory.mjs
@@ -42,8 +42,8 @@ export class Memory {
   i32Store(p, v) { this.dataView.setUint32(Memory.unTag(p), Number(v), true); }
   i64Load(p) { return this.dataView.getBigUint64(Memory.unTag(p), true); }
   i64Store(p, v) { this.dataView.setBigUint64(Memory.unTag(p), BigInt(v), true); }
-  i128Load(p) { 
-      // little endian: number with hex digits <0A0B> at address p 
+  i128Load(p) {
+      // little endian: number with hex digits <0A0B> at address p
       // get stored as mem[p] = 0B, mem[p+1] = 0A
       let low = this.dataView.getBigUint64(Memory.unTag(p), true);
       let high = this.dataView.getBigUint64(Memory.unTag(p) + 8, true);
@@ -55,12 +55,10 @@ export class Memory {
       // create all 1s of 64 bits.
       const lowmask = (BigInt(1) << BigInt(64)) - BigInt(1);
 
-      // little endian: number with digits <x y> at address p 
+      // little endian: number with digits <x y> at address p
       // get stored as mem[p] = y, mem[p+1] = x
       const low = v & lowmask;
-      const high = (v >> BigInt(64)) & lowmask;
-
-      console.assert(((high << BigInt(64)) | low) == v);
+      const high = v >> BigInt(64);
 
       // byte addressed, so +8 = 64-bit
       this.dataView.setBigUint64(Memory.unTag(p), low, true);

--- a/asterius/rts/rts.memory.mjs
+++ b/asterius/rts/rts.memory.mjs
@@ -43,39 +43,28 @@ export class Memory {
   i64Load(p) { return this.dataView.getBigUint64(Memory.unTag(p), true); }
   i64Store(p, v) { this.dataView.setBigUint64(Memory.unTag(p), BigInt(v), true); }
   i128Load(p) { 
-      console.log("*** load:");
       // little endian: number with hex digits <0A0B> at address p 
       // get stored as mem[p] = 0B, mem[p+1] = 0A
       let low = this.dataView.getBigUint64(Memory.unTag(p), true);
-      console.log("low: ", low);
       let high = this.dataView.getBigUint64(Memory.unTag(p) + 8, true);
-      console.log("high: ", high);
-      console.log("----");
       return low | (high << BigInt(64));
   }
 
 
   i128Store(p, v) {
-      console.log("*** store v: ", v);
       // create all 1s of 64 bits.
       const lowmask = (BigInt(1) << BigInt(64)) - BigInt(1);
 
       // little endian: number with digits <x y> at address p 
       // get stored as mem[p] = y, mem[p+1] = x
-      let low = v & lowmask;
-      console.log("v & low: " , low);
-      this.dataView.setBigUint64(Memory.unTag(p), low, true);
+      const low = v & lowmask;
+      const high = (v >> BigInt(64)) & lowmask;
 
-      let high = (v >> BigInt(64)) & lowmask;
-      console.log("v & high: " , high);
-
-      let v_recreated = ((high << BigInt(64)) | low);
-      console.log("v_recreated: " , v_recreated);
-      console.assert(v_recreated == BigInt(v));
+      console.assert(((high << BigInt(64)) | low) == v);
 
       // byte addressed, so +8 = 64-bit
+      this.dataView.setBigUint64(Memory.unTag(p), low, true);
       this.dataView.setBigUint64(Memory.unTag(p) + 8, high, true);
-      console.log("---");
   }
 
   f32Load(p) { return this.dataView.getFloat32(Memory.unTag(p), true); }

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -18,6 +18,7 @@ import { ByteStringCBits } from "./rts.bytestring.mjs";
 import { GC } from "./rts.gc.mjs";
 import { ExceptionHelper } from "./rts.exception.mjs";
 import { ThreadPaused } from "./rts.threadpaused.mjs";
+import { MD5 } from "./rts.md5.mjs"
 import { FloatCBits } from "./rts.float.mjs";
 import { Unicode } from "./rts.unicode.mjs";
 import * as rtsConstants from "./rts.constants.mjs";
@@ -42,7 +43,8 @@ export function newAsteriusInstance(req) {
     __asterius_exception_helper = new ExceptionHelper(__asterius_memory, __asterius_heapalloc, req.infoTables, req.symbolTable),
     __asterius_threadpaused = new ThreadPaused(__asterius_memory, req.infoTables, req.symbolTable),
     __asterius_float_cbits = new FloatCBits(__asterius_memory),
-    __asterius_unicode = new Unicode();
+    __asterius_unicode = new Unicode(),
+    __asterius_md5 = new MD5(__asterius_memory);
 
   function __asterius_show_I64(x) {
     return "0x" + x.toString(16).padStart(8, "0");
@@ -135,6 +137,7 @@ export function newAsteriusInstance(req) {
       MemoryTrap: modulify(__asterius_memory_trap),
       StablePtr: modulify(__asterius_stableptr_manager),
       Unicode: modulify(__asterius_unicode),
+      MD5: modulify(__asterius_md5),
       Tracing: modulify(__asterius_tracer),
       TSO: modulify(__asterius_tso_manager)
     }

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -118,7 +118,7 @@ rtsAsteriusModule opts =
     , functionMap =
         Map.fromList $
         map (\(func_sym, (_, func)) -> (func_sym, func))
-            (byteStringCBits <> floatCBits  <> unicodeCBits)
+            (byteStringCBits <> floatCBits  <> unicodeCBits <> md5CBits)
     }  <> mainFunction opts
        <> hsInitFunction opts
        <> scheduleWaitThreadFunction opts
@@ -480,7 +480,7 @@ rtsFunctionImports debug =
           , b <- ["8", "16"]
           ]
      else []) <>
-  map (fst . snd) (byteStringCBits <> floatCBits <> unicodeCBits)
+  map (fst . snd) (byteStringCBits <> floatCBits <> unicodeCBits <> md5CBits)
 
 rtsFunctionExports :: Bool -> Bool -> [FunctionExport]
 rtsFunctionExports debug has_main =
@@ -576,6 +576,15 @@ floatCBits =
     , ("__decodeFloat_Int", [I64, I64, F32], [])
     ]
 
+md5CBits :: [(AsteriusEntitySymbol, (FunctionImport, Function))]
+md5CBits =
+    map (\(func_sym, param_vts, ret_vts) ->
+       ( AsteriusEntitySymbol func_sym
+       , generateRTSWrapper "MD5" func_sym param_vts ret_vts))
+    [ ("__hsbase_MD5Init", [I64], [])
+    , ("__hsbase_MD5Update", [I64, I64, I64], [])
+    , ("__hsbase_MD5Final", [I64, I64], [])
+    ]
 
 generateRTSWrapper ::
      SBS.ShortByteString

--- a/asterius/test/sizeof_md5context.hs
+++ b/asterius/test/sizeof_md5context.hs
@@ -1,0 +1,7 @@
+import System.Environment
+import System.Process
+
+main :: IO ()
+main = do
+  args <- getArgs
+  callProcess "ahc-link" $ ["--input-hs", "test/sizeof_md5context/sizeof_md5context.hs", "--run"] <> args

--- a/asterius/test/sizeof_md5context/sizeof_md5context.hs
+++ b/asterius/test/sizeof_md5context/sizeof_md5context.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE CPP #-}
+
+#include "HsBaseConfig.h"
+import Control.Exception (assert)
+
+main :: IO ()
+main = assert (SIZEOF_STRUCT_MD5CONTEXT  == (88 :: Int)) (pure ())
+

--- a/asterius/test/sizeof_md5context/sizeof_md5context.hs
+++ b/asterius/test/sizeof_md5context/sizeof_md5context.hs
@@ -2,7 +2,11 @@
 
 #include "HsBaseConfig.h"
 import Control.Exception (assert)
+import GHC.Fingerprint
+import Control.Monad
 
 main :: IO ()
-main = assert (SIZEOF_STRUCT_MD5CONTEXT  == (88 :: Int)) (pure ())
+main = do
+  assert (SIZEOF_STRUCT_MD5CONTEXT  == (88 :: Int)) (pure ())
+  forM_ [1..10] $ \i -> print $ fingerprintString (replicate i ' ')
 

--- a/asterius/test/sizeof_md5context/sizeof_md5context.hs
+++ b/asterius/test/sizeof_md5context/sizeof_md5context.hs
@@ -3,10 +3,69 @@
 #include "HsBaseConfig.h"
 import Control.Exception (assert)
 import GHC.Fingerprint
+import GHC.Num
+import Foreign.C
+import Foreign
 import Control.Monad
+import Foreign.Marshal.Alloc
+
+data MD5Context
+
+foreign import ccall unsafe "__hsbase_MD5Init"
+   c_MD5Init   :: Ptr MD5Context -> IO ()
+foreign import ccall unsafe "__hsbase_MD5Update"
+   c_MD5Update :: Ptr MD5Context -> Ptr Word8 -> CInt -> IO ()
+foreign import ccall unsafe "__hsbase_MD5Final"
+   c_MD5Final  :: Ptr Word8 -> Ptr MD5Context -> IO ()
+
+dataPart1:: [Word8]
+dataPart1 = [fromIntegral 1]
+
+
+dataPart2:: [Word8]
+dataPart2 = [fromIntegral 3]
+
+
+-- | Use single call to c_MD5Update`
+singleShot :: IO Fingerprint
+singleShot = do
+  allocaBytes SIZEOF_STRUCT_MD5CONTEXT $ \pctxt -> do
+    c_MD5Init pctxt
+    withArrayLen (dataPart1 <> dataPart2) $ \len pbuf ->
+      c_MD5Update pctxt pbuf (fromIntegral len)
+    allocaBytes 16 $ \pdigest -> do
+      c_MD5Final pdigest pctxt
+      peek (castPtr pdigest :: Ptr Fingerprint)
+
+-- | Use two calls to `c_MD5Update`
+twoShot :: IO Fingerprint
+twoShot = do
+  allocaBytes SIZEOF_STRUCT_MD5CONTEXT $ \pctxt -> do
+    c_MD5Init pctxt
+    withArrayLen dataPart1 $ \len pbuf ->
+      c_MD5Update pctxt pbuf (fromIntegral len)
+    withArrayLen dataPart2 $ \len pbuf ->
+      c_MD5Update pctxt pbuf (fromIntegral len)
+    allocaBytes 16 $ \pdigest -> do
+      c_MD5Final pdigest pctxt
+      peek (castPtr pdigest :: Ptr Fingerprint)
+
 
 main :: IO ()
 main = do
   assert (SIZEOF_STRUCT_MD5CONTEXT  == (88 :: Int)) (pure ())
   forM_ [1..10] $ \i -> print $ fingerprintString (replicate i ' ')
+
+  -- | Ensure that calling c_MD5Update actually saves the state in the context.
+  -- | So, have one invocation of calling it once, and another invocation of
+  -- | calling it in two sequential invocations. Check that the result is the
+  -- | same
+
+  fingerprint1 <- singleShot
+  fingerprint2 <- twoShot
+
+  print (fingerprint1, fingerprint2)
+  assert (fingerprint1 == fingerprint2) (pure ())
+
+
 

--- a/ghc-toolkit/boot-libs/base/GHC/Fingerprint.hs
+++ b/ghc-toolkit/boot-libs/base/GHC/Fingerprint.hs
@@ -33,9 +33,11 @@ import System.IO
 
 import GHC.Fingerprint.Type
 
--- for SIZEOF_STRUCT_MD5CONTEXT:
--- #include "HsBaseConfig.h"
+#include "HsBaseConfig.h"
 
+-- for SIZEOF_STRUCT_MD5CONTEXT to be correct. For some reason,
+-- configure.ac sets SIZEOF_STRUCT_MD5CONTEXT to be 0. Here, we hardcode
+-- the correct value.
 {- Discovered by running:
   {-# LANGUAGE CPP #-}
 
@@ -44,7 +46,10 @@ import GHC.Fingerprint.Type
   main :: IO ()
   main = print (SIZEOF_STRUCT_MD5CONTEXT :: Int)
 -}
+#ifdef ASTERIUS
+#undef SIZEOF_STRUCT_MD5CONTEXT
 #define SIZEOF_STRUCT_MD5CONTEXT 88
+#endif
 
 -- XXX instance Storable Fingerprint
 -- defined in Foreign.Storable to avoid orphan instance

--- a/ghc-toolkit/boot-libs/base/GHC/Fingerprint.hs
+++ b/ghc-toolkit/boot-libs/base/GHC/Fingerprint.hs
@@ -34,7 +34,17 @@ import System.IO
 import GHC.Fingerprint.Type
 
 -- for SIZEOF_STRUCT_MD5CONTEXT:
-#include "HsBaseConfig.h"
+-- #include "HsBaseConfig.h"
+
+{- Discovered by running:
+  {-# LANGUAGE CPP #-}
+
+  #include "HsBaseConfig.h"
+
+  main :: IO ()
+  main = print (SIZEOF_STRUCT_MD5CONTEXT :: Int)
+-}
+#define SIZEOF_STRUCT_MD5CONTEXT 88
 
 -- XXX instance Storable Fingerprint
 -- defined in Foreign.Storable to avoid orphan instance


### PR DESCRIPTION
We implement a simple hash function to allow `Data.Typeable` to get going, and anything that depends on `GHC.Fingerprint`, really.

We implement a simple `FNV` hash, and hope that this suffices for what we need.

This should fix (at least):
- `test/ghc-testsuite/codeGen/T5129.hs`
- `test/ghc-testsuite/numeric/numrun013.hs`
- `test/ghc-testsuite/deSugar/DsMultiWayIf.hs`