### PR TITLE
suspendThread should call threadPaused

### DIFF
--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -1268,6 +1268,7 @@ suspendThreadFunction _ =
   runEDSL "suspendThread" $ do
     setReturnTypes [I64]
     [reg, _] <- params [I64, I64]
+    call "threadPaused" [mainCapability, getLVal $ global CurrentTSO]
     emit reg
 
 resumeThreadFunction _ =


### PR DESCRIPTION
A sequel to #138: we should call `threadPaused` in `suspendThread` since the calls to "safe" ccall imports should also be a gc safepoint.