### PR TITLE
Compile `.cmm` files in other boot libs

### DIFF
--- a/asterius/src/Asterius/Internals/Directory.hs
+++ b/asterius/src/Asterius/Internals/Directory.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE TupleSections #-}
+
+module Asterius.Internals.Directory
+  ( listFilesRecursive
+  ) where
+
+import Data.Foldable
+import Data.Traversable
+import System.Directory
+import System.FilePath
+
+listFilesRecursive :: FilePath -> IO [FilePath]
+listFilesRecursive = w []
+  where
+    w acc bp = do
+      fds <- map (normalise . (bp </>)) <$> listDirectory bp
+      tagged_fds <- for fds $ \fd -> (fd, ) <$> doesFileExist fd
+      foldrM
+        (\(fd, is_f) acc' ->
+           if is_f
+             then pure (fd : acc')
+             else w acc' fd)
+        acc
+        tagged_fds


### PR DESCRIPTION
It seems `cmm-sources` in `.cabal` files isn't working yet, and other boot libs may contain `.cmm` as well (`base` & `ghc-heap` at the moment), so here we are.