### PR TITLE
Provide a `binaryen` Cabal flag in the `asterius` package to disable the binaryen backend

### DIFF
--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -7,6 +7,11 @@ copyright: (c) 2018 Tweag I/O
 license: BSD3
 github: tweag/asterius
 
+flags:
+  binaryen:
+    default: true
+    manual: true
+
 extra-source-files:
   - CHANGELOG.md
   - LICENSE
@@ -48,7 +53,6 @@ ghc-options: -Wall
 dependencies:
   - base
   - binary
-  - binaryen
   - bytestring
   - Cabal
   - containers
@@ -68,6 +72,12 @@ dependencies:
   - template-haskell
   - transformers
   - wasm-toolkit
+
+when:
+  - condition: flag(binaryen)
+    dependencies:
+      - binaryen
+    cpp-options: -DBINARYEN
 
 library:
   source-dirs: src

--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -8,6 +9,10 @@ module Asterius.Backends.Binaryen
   ( MarshalError(..)
   , marshalModule
   , serializeModule
+  , c_BinaryenSetDebugInfo
+  , c_BinaryenSetOptimizeLevel
+  , c_BinaryenSetShrinkLevel
+  , c_BinaryenModuleValidate
   ) where
 
 import Asterius.Internals
@@ -16,7 +21,13 @@ import Asterius.Internals.MagicNumber
 import Asterius.Internals.Marshal
 import Asterius.Types
 import Asterius.TypesConv
+
+#if defined(BINARYEN)
+
 import Bindings.Binaryen.Raw
+
+#endif
+
 import Control.Exception
 import Control.Monad
 import Control.Monad.Cont
@@ -38,6 +49,8 @@ newtype MarshalError =
   deriving (Show)
 
 instance Exception MarshalError
+
+#if defined(BINARYEN)
 
 marshalBool :: Bool -> Int8
 marshalBool flag =
@@ -575,3 +588,23 @@ serializeModule m =
         buf <- peek buf_p
         len <- peek len_p
         BS.unsafePackMallocCStringLen (castPtr buf, fromIntegral len)
+
+#else
+
+err =
+  error
+    "The `asterius` package was configured without the `binaryen` Cabal flag."
+
+marshalModule = err
+
+serializeModule = err
+
+c_BinaryenSetDebugInfo = err
+
+c_BinaryenSetOptimizeLevel = err
+
+c_BinaryenSetShrinkLevel = err
+
+c_BinaryenModuleValidate = err
+
+#endif

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -28,7 +28,6 @@ import Asterius.Types
   , FFIMarshalState(..)
   , Module
   )
-import Bindings.Binaryen.Raw
 import Control.Monad
 import Control.Monad.Except
 import Data.Binary.Get
@@ -340,15 +339,15 @@ ahcDistMain logger task@Task {..} (final_m, err_msgs, report) = do
     writeFile p $ show final_m
   if binaryen
     then (do logger "[INFO] Converting linked IR to binaryen IR"
-             c_BinaryenSetDebugInfo 1
-             c_BinaryenSetOptimizeLevel 0
-             c_BinaryenSetShrinkLevel 0
+             Binaryen.c_BinaryenSetDebugInfo 1
+             Binaryen.c_BinaryenSetOptimizeLevel 0
+             Binaryen.c_BinaryenSetShrinkLevel 0
              m_ref <-
                Binaryen.marshalModule
                  (staticsSymbolMap report <> functionSymbolMap report)
                  final_m
              logger "[INFO] Validating binaryen IR"
-             pass_validation <- c_BinaryenModuleValidate m_ref
+             pass_validation <- Binaryen.c_BinaryenModuleValidate m_ref
              when (pass_validation /= 1) $
                fail "[ERROR] binaryen validation failed"
              m_bin <- Binaryen.serializeModule m_ref

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -48,7 +48,6 @@ module Asterius.Types
   ) where
 
 import Asterius.Internals.Binary
-import Bindings.Binaryen.Raw hiding (RelooperBlock)
 import Control.Exception
 import Data.Binary
 import qualified Data.ByteString.Short as SBS
@@ -57,6 +56,8 @@ import qualified Data.Map.Lazy as LM
 import Data.String
 import Foreign
 import GHC.Generics
+
+type BinaryenIndex = Word32
 
 data AsteriusCodeGenError
   = UnsupportedCmmLit SBS.ShortByteString


### PR DESCRIPTION
The `binaryen` package has a custom `Setup.hs` script to handle building/linking of `binaryen`, which can make things nasty and produce cryptic linker errors when building `asterius` in certain ways (e.g. with nix). Here we provide a `binaryen` Cabal flag for the `asterius` package which is on by default, but when switched off can disable the `binaryen` dependency of `asterius`.