### PR TITLE
Implement reentrancy guard

### DIFF
--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -3,6 +3,7 @@ import { encodeUTF8, decodeUTF8 } from "./rts.utf8.mjs";
 import { encodeUTF16, decodeUTF16 } from "./rts.utf16.mjs";
 import { encodeUTF32, decodeUTF32 } from "./rts.utf32.mjs";
 import { encodeLatin1, decodeLatin1 } from "./rts.latin1.mjs";
+import { ReentrancyGuard } from "./rts.reentrancy.mjs";
 import { EventLogManager } from "./rts.eventlog.mjs";
 import { Tracer } from "./rts.tracing.mjs";
 import { Memory } from "./rts.memory.mjs";
@@ -24,7 +25,8 @@ import { Unicode } from "./rts.unicode.mjs";
 import * as rtsConstants from "./rts.constants.mjs";
 
 export function newAsteriusInstance(req) {
-  let __asterius_logger = new EventLogManager(req.symbolTable),
+  let __asterius_reentrancy_guard = new ReentrancyGuard(["Scheduler", "GC"]),
+    __asterius_logger = new EventLogManager(req.symbolTable),
     __asterius_tracer = new Tracer(__asterius_logger, req.symbolTable),
     __asterius_wasm_instance = null,
     __asterius_wasm_table = new WebAssembly.Table({element: "anyfunc", initial: req.tableSlots}),
@@ -39,7 +41,7 @@ export function newAsteriusInstance(req) {
     __asterius_integer_manager = new IntegerManager(__asterius_stableptr_manager, __asterius_heap_builder),
     __asterius_fs = new MemoryFileSystem(__asterius_logger),
     __asterius_bytestring_cbits = new ByteStringCBits(null),
-    __asterius_gc = new GC(__asterius_memory, __asterius_mblockalloc, __asterius_heapalloc, __asterius_stableptr_manager, __asterius_tso_manager, req.infoTables, req.pinnedStaticClosures, req.symbolTable),
+    __asterius_gc = new GC(__asterius_memory, __asterius_mblockalloc, __asterius_heapalloc, __asterius_stableptr_manager, __asterius_tso_manager, req.infoTables, req.pinnedStaticClosures, req.symbolTable, __asterius_reentrancy_guard),
     __asterius_exception_helper = new ExceptionHelper(__asterius_memory, __asterius_heapalloc, req.infoTables, req.symbolTable),
     __asterius_threadpaused = new ThreadPaused(__asterius_memory, req.infoTables, req.symbolTable),
     __asterius_float_cbits = new FloatCBits(__asterius_memory),
@@ -127,6 +129,7 @@ export function newAsteriusInstance(req) {
       bytestring: modulify(__asterius_bytestring_cbits),
       // cannot name this float since float is a keyword.
       floatCBits: modulify(__asterius_float_cbits),
+      ReentrancyGuard: modulify(__asterius_reentrancy_guard),
       GC: modulify(__asterius_gc),
       ExceptionHelper: modulify(__asterius_exception_helper),
       ThreadPaused: modulify(__asterius_threadpaused),

--- a/asterius/rts/rts.reentrancy.mjs
+++ b/asterius/rts/rts.reentrancy.mjs
@@ -1,0 +1,19 @@
+export class ReentrancyGuard {
+  constructor(names) {
+    this.names = names;
+    this.flags = this.names.map(() => false);
+    Object.freeze(this);
+  }
+
+  enter(i) {
+    if (this.flags[i])
+      throw new WebAssembly.RuntimeError(
+        `ReentrancyGuard: ${this.names[i]} reentered!`
+      );
+    this.flags[i] = true;
+  }
+
+  exit(i) {
+    this.flags[i] = false;
+  }
+}


### PR DESCRIPTION
Before more radical experiments regarding the FFI mechanism and scheduler, here we implement a simple reentrancy guard to ensure certain components of rts won't be reentered, and panics immediately otherwise. The guard is currently applied to two places: `gcRootTSO`, which is our gc entry function, and all `rts_eval*` functions, which creates a new thread and enters the scheduler to perform evaluation.