### PR TITLE
Implement changes needed for `cgrun044` to pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,10 @@ jobs:
             stack --no-terminal test asterius:nomain
             stack --no-terminal test asterius:nomain --test-arguments="--tail-calls"
 
+            # run test cases that should pass from ghc-testsuite.
+            # At some point, this should cover entire subfolders like "numeric"
+            stack test asterius:ghc-testsuite --test-arguments "-p cgrun044"
+
   asterius-test-ghc-testsuite:
     docker:
       - image: debian:unstable
@@ -157,6 +161,9 @@ jobs:
             command: |
               # run the GHC testsuite and copy the test artifact to `/tmp`
               nodejs --version
+
+
+              # run test cases that can fail.
               stack --no-terminal test asterius:ghc-testsuite  -j8 --test-arguments="--timeout=30s" || true
               cp asterius/test-report.csv /tmp
               python3 asterius/test/format-ghc-testsuite-report.py /tmp/test-report.csv -o /tmp/test-report-ascii.txt

--- a/asterius/rts/rts.float.mjs
+++ b/asterius/rts/rts.float.mjs
@@ -99,11 +99,8 @@ export class FloatCBits {
   isDoubleDenormalized(x) {
     const bits = this.DoubleToIEEE(x);
 
-    console.log("x: %f | bits: %s", x, bits.toString(16));
     const exponent = this.doubleExponentFromBits(bits);
-    console.log("x: %f | exponent: %s", x, exponent.toString(16));
     const mantissa = this.doubleMantissaFromBits(bits);
-    console.log("x: %f | mantissa: %s", x, mantissa.toString(16));
     return exponent === BigInt(0) && mantissa !== BigInt(0);
   }
 
@@ -143,7 +140,6 @@ export class FloatCBits {
   }
 
   __decodeFloat_Int(manp, expp, f) {
-    console.error("inside decodeFloat\n");
     // https://github.com/ghc/ghc/blob/610ec224a49e092c802a336570fd9613ea15ef3c/rts/StgPrimFloat.c#L215
     let man, exp, sign;
     let high = this.FloatToIEEE(f);

--- a/asterius/rts/rts.float.mjs
+++ b/asterius/rts/rts.float.mjs
@@ -1,8 +1,8 @@
 // Implements primitives from primFloat.c
 export class FloatCBits {
-    constructor(memory) {
-        this.memory  = memory;
-        /* Constants copy-pasted by running this C program:
+  constructor(memory) {
+    this.memory = memory;
+    /* Constants copy-pasted by running this C program:
         #include <float.h>
         #include <stdio.h>
 
@@ -15,86 +15,229 @@ export class FloatCBits {
         Other code copy-pasted from C calculations.
         */
 
+    this.FLT_MIN_EXP = -125;
+    this.FLT_MANT_DIG = 24;
+    this.DBL_MIN_EXP = -1021;
+    this.DBL_MANT_DIG = 53;
 
-        this.FLT_MIN_EXP = -125;
-        this.FLT_MANT_DIG = 24;
-        this.DBL_MIN_EXP = -1021;
-        this.DBL_MANT_DIG = 53;
+    this.MY_DMINEXP = this.DBL_MIN_EXP - this.DBL_MANT_DIG - 1;
+    /* DMINEXP is defined in values.h on Linux (for example) */
+    this.DHIGHBIT = 0x00100000;
+    this.DMSBIT = 0x80000000;
 
-        this.MY_DMINEXP = ((this.DBL_MIN_EXP) - (this.DBL_MANT_DIG) - 1);
-        /* DMINEXP is defined in values.h on Linux (for example) */
-        this.DHIGHBIT = 0x00100000;
-        this.DMSBIT = 0x80000000;
+    this.MY_FMINEXP = this.FLT_MIN_EXP - this.FLT_MANT_DIG - 1;
+    this.FHIGHBIT = 0x00800000;
+    this.FMSBIT = 0x80000000;
 
-        this.MY_FMINEXP = ((this.FLT_MIN_EXP) - (this.FLT_MANT_DIG) - 1);
-        this.FHIGHBIT = 0x00800000;
-        this.FMSBIT = 0x80000000;
+    // buffer of 8 bytes to hold floats/doubles
+    this.buffer = new ArrayBuffer(8);
+    this.view = new DataView(this.buffer);
 
-        // buffer of 8 bytes to hold floats/doubles
-        this.buffer = new ArrayBuffer(8);
-        this.view = new DataView(this.buffer);
+    Object.seal(this);
+  }
 
-        Object.seal(this);
-    }
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+  isFloatNegativeZero(x) {
+    return Object.is(-0, x);
+  }
 
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
-    isFloatNegativeZero(x) {
-        return Object.is(-0, x);
-    }
+  isFloatNaN(x) {
+    return x != x;
+  }
 
-    isFloatNaN(x) {
-        return x != x;
-    }
-    isFloatInfinite(x) {
-        return !isFinite(x);
-    }
+  isDoubleNaN(x) {
+    return x != x;
+  }
 
-    // Does it really make sense to have two functions?  probably not...
-    isDoubleNegativeZero(x) {
-        return Object.is(-0, x);
-    }
+  // Remember, floats have 3 states: {finite, infinite, NaN}.
+  isFloatInfinite(x) {
+    return !isFinite(x) && !this.isFloatNaN(x);
+  }
 
-    FloatToIEEE(f) {
-        this.view.setFloat32(0, f);
-        return this.view.getUint32(0);
-    }
+  isDoubleInfinite(x) {
+    return !isFinite(x) && !this.isDoubleNaN(x);
+  }
 
-    IEEEToFloat(ieee) {
-        this.view.setUint32(0, ieee);
-        return this.view.getFloat32(0);
-    }
+  // extract the mantissa from the little endian representation of the bits
+  // of the float.
+  // little endian: <0A 0B> stored as mem[p] = 0A, mem[p + 1] = OB
+  floatMantissaFromBits(bits) {
+    const mask = (1 << 23) - 1;
+    return bits & mask;
+  }
 
+  // extract the exponent from the little endian representation of the bits
+  // of the float.
+  floatExponentFromBits(bits) {
+    const mask = (1 << 8) - 1;
+    const sign = this.floatSignFromBits(bits);
+    return ((bits >> 23) & mask) ^ (sign << 31);
+  }
 
-    __decodeFloat_Int(manp, expp, f) {
-        // https://github.com/ghc/ghc/blob/610ec224a49e092c802a336570fd9613ea15ef3c/rts/StgPrimFloat.c#L215
-        let man, exp, sign;
-        let high = this.FloatToIEEE(f);
+  floatSignFromBits(bits) {
+    return bits >> 31;
+  }
 
+  doubleMantissaFromBits(bits) {
+    const mask = (BigInt(1) << BigInt(52)) - BigInt(1);
+    return bits & mask;
+  }
 
-        if ((high & ~this.FMSBIT) == 0) {
-            man = 0;
-            exp = 0;
-        } else {
-            exp = ((high >> 23) & 0xff) + this.MY_FMINEXP;
-            high &= this.FHIGHBIT-1;
-            if (exp != this.MY_FMINEXP) /* don't add hidden bit to denorms */
-                high |= this.FHIGHBIT;
-            else {
-                exp += 1;
-                /* A denorm, normalize the mantissa */
-                while (! (high & this.FHIGHBIT)) {
-                    high <<= 1;
-                    exp -= 1;
-                }
-            }
+  doubleExponentFromBits(bits) {
+    const mask = BigInt((1 << 11) - 1);
+    const sign = this.doubleSignFromBits(bits);
 
-            man = high;
-            if (sign < 0) {
-                man = - man;
-            }
+    const bitsNoSign = bits ^ (sign << BigInt(63));
+    return (bitsNoSign >> BigInt(52)) & mask;
+  }
+
+  doubleSignFromBits(bits) {
+    return bits >> BigInt(63);
+  }
+
+  // Check if a double is denormal.
+  isDoubleDenormalized(x) {
+    const bits = this.DoubleToIEEE(x);
+
+    console.log("x: %f | bits: %s", x, bits.toString(16));
+    const exponent = this.doubleExponentFromBits(bits);
+    console.log("x: %f | exponent: %s", x, exponent.toString(16));
+    const mantissa = this.doubleMantissaFromBits(bits);
+    console.log("x: %f | mantissa: %s", x, mantissa.toString(16));
+    return exponent === BigInt(0) && mantissa !== BigInt(0);
+  }
+
+  isFloatDenormalized(x) {
+    const bits = this.FloatToIEEE(x);
+    const exponent = this.floatExponentFromBits(bits);
+    const mantissa = this.floatMantissaFromBits(bits);
+    return exponent === 0 && mantissa !== 0;
+  }
+
+  // Does it really make sense to have two functions?  probably not...
+  isDoubleNegativeZero(x) {
+    return Object.is(-0, x);
+  }
+
+  FloatToIEEE(f) {
+    this.view.setFloat32(0, f);
+    return this.view.getUint32(0);
+  }
+
+  DoubleToIEEE(d) {
+    this.view.setFloat64(0, d);
+    return this.view.getBigUint64(0);
+  }
+
+  // return two 32-bit integers, [low, high] from a 64 bit double;
+  DoubleTo2Int(d) {
+    this.view.setFloat64(0, d);
+    const low = this.view.getUint32(0);
+    const high = this.view.getUint32(/*offset=*/ 4);
+    return [low, high];
+  }
+
+  IEEEToFloat(ieee) {
+    this.view.setUint32(0, ieee);
+    return this.view.getFloat32(0);
+  }
+
+  IEEEToDouble(ieee) {
+    this.view.setUint64(0, ieee);
+    return this.view.getFloat64(0);
+  }
+
+  __decodeFloat_Int(manp, expp, f) {
+    console.error("inside decodeFloat\n");
+    // https://github.com/ghc/ghc/blob/610ec224a49e092c802a336570fd9613ea15ef3c/rts/StgPrimFloat.c#L215
+    let man, exp, sign;
+    let high = this.FloatToIEEE(f);
+
+    if ((high & ~this.FMSBIT) == 0) {
+      man = 0;
+      exp = 0;
+    } else {
+      exp = ((high >> 23) & 0xff) + this.MY_FMINEXP;
+      high &= this.FHIGHBIT - 1;
+      if (exp != this.MY_FMINEXP)
+        /* don't add hidden bit to denorms */
+        high |= this.FHIGHBIT;
+      else {
+        exp += 1;
+        /* A denorm, normalize the mantissa */
+        while (!(high & this.FHIGHBIT)) {
+          high <<= 1;
+          exp -= 1;
         }
+      }
 
-        this.memory.i64Store(manp, man);
-        this.memory.i64Store(expp, exp);
+      man = high;
+      if (sign < 0) {
+        man = -man;
+      }
     }
+
+    // TODO: double check! Is this i32 or i64? I suspect it is i32.
+    this.memory.i64Store(manp, man);
+    this.memory.i64Store(expp, exp);
+  }
+
+  // https://github.com/ghc/ghc/blob/610ec224a49e092c802a336570fd9613ea15ef3c/rts/StgPrimFloat.c
+  // From StgPrimFloat.c
+  // returns [man_sign, man_high,  man_low, exp]
+  __decodeDouble_2IntJS(dbl) {
+    let sign, iexp, man_low, man_high, man_sign;
+    const ints = this.DoubleTo2Int(dbl);
+    let low = ints[1];
+    let high = ints[0];
+    let exp = 0;
+
+    if (low == 0 && (high & ~this.DMSBIT) == 0) {
+      man_low = 0;
+      man_high = 0;
+      man_sign = 0;
+      iexp = 0;
+    } else {
+      iexp = ((high >> 20) & 0x7ff) + this.MY_DMINEXP;
+
+      // unsigned to signed conversion
+      this.view.setUint32(0, high);
+      sign = this.view.getInt32(0);
+
+      high &= this.DHIGHBIT - 1;
+      if (iexp != this.MY_DMINEXP)
+        /* don't add hidden bit to denorms */
+        high |= this.DHIGHBIT;
+      else {
+        iexp++;
+        /* A denorm, normalize the mantissa */
+        while (!(high & this.DHIGHBIT)) {
+          high <<= 1;
+          if (low & this.DMSBIT) high++;
+          low <<= 1;
+          iexp--;
+        }
+      }
+      exp = iexp;
+      man_low = low;
+      man_high = high;
+      man_sign = sign < 0 ? -1 : 1;
+    }
+
+    return [man_sign, man_high, man_low, exp];
+  }
+
+  // From GHC/Integer/Type.hs
+  decodeDoubleInteger(d) {
+    const out = this.__decodeDouble_2IntJS(d);
+    const man_sign = out[0];
+    const man_high = out[1];
+    const man_low = out[2];
+    const exp = out[3];
+
+    const acc =
+      BigInt(man_sign) *
+      (BigInt(man_high) * (BigInt(1) << BigInt(32)) + BigInt(man_low));
+    return [acc, exp];
+  }
 }

--- a/asterius/rts/rts.float.mjs
+++ b/asterius/rts/rts.float.mjs
@@ -142,11 +142,6 @@ export class FloatCBits {
     return this.view.getFloat32(0);
   }
 
-  IEEEToDouble(ieee) {
-    this.view.setUint64(0, ieee);
-    return this.view.getFloat64(0);
-  }
-
   __decodeFloat_Int(manp, expp, f) {
     console.error("inside decodeFloat\n");
     // https://github.com/ghc/ghc/blob/610ec224a49e092c802a336570fd9613ea15ef3c/rts/StgPrimFloat.c#L215

--- a/asterius/rts/rts.integer.mjs
+++ b/asterius/rts/rts.integer.mjs
@@ -79,20 +79,6 @@ export class IntegerManager {
   encodeDoubleInteger(i0, i1) {
     return Number(this.decode(i0)) * 2 ** i1;
   }
-  decodeDoubleInteger(d) {
-    const [, sgn, i, f] = /^(-?)([01]+)\.?([01]*)$/.exec(d.toString(2));
-    let s = i + f, acc = BigInt(0), e = f ? -f.length : 0;
-    while (s) {
-      const c = s.slice(0, 53);
-      s = s.slice(c.length);
-      acc = (acc << BigInt(c.length)) | BigInt(Number.parseInt(c, 2));
-    }
-    if (acc !== BigInt(0))
-      while ((acc & BigInt(1)) === BigInt(0)) {
-        acc = acc >> BigInt(1);
-        e += 1;
-      }
-    return [ sgn ? -acc : acc, e ];
-  }
+
   doubleFromInteger(i) { return Number(this.decode(i)); }
 }

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -93,6 +93,8 @@ export function newAsteriusInstance(req) {
       __asterius_wasm_instance.exports.rts_checkSchedStatus(tid);
     },
     Integer: __asterius_integer_manager,
+    floatCBits: __asterius_float_cbits,
+    Float: __asterius_float_cbits,
     stdio: {
       putChar: (h, c) => __asterius_fs.writeSync(h, String.fromCodePoint(c)),
       stdout: () => __asterius_fs.root.get("/dev/stdout"),

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -93,7 +93,6 @@ export function newAsteriusInstance(req) {
       __asterius_wasm_instance.exports.rts_checkSchedStatus(tid);
     },
     Integer: __asterius_integer_manager,
-    floatCBits: __asterius_float_cbits,
     Float: __asterius_float_cbits,
     stdio: {
       putChar: (h, c) => __asterius_fs.writeSync(h, String.fromCodePoint(c)),

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -93,7 +93,7 @@ export function newAsteriusInstance(req) {
       __asterius_wasm_instance.exports.rts_checkSchedStatus(tid);
     },
     Integer: __asterius_integer_manager,
-    Float: __asterius_float_cbits,
+    FloatCBits: __asterius_float_cbits,
     stdio: {
       putChar: (h, c) => __asterius_fs.writeSync(h, String.fromCodePoint(c)),
       stdout: () => __asterius_fs.root.get("/dev/stdout"),

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -590,8 +590,13 @@ floatCBits =
        ( AsteriusEntitySymbol func_sym
        , generateRTSWrapper "floatCBits" func_sym param_vts ret_vts))
     [ ("isFloatNegativeZero", [F32], [I64])
+    , ("isDoubleNegativeZero", [F64], [I64])
     , ("isFloatNaN", [F32], [I64])
+    , ("isDoubleNaN", [F64], [I64])
+    , ("isFloatDenormalized", [F32], [I64])
+    , ("isDoubleDenormalized", [F64], [I64])
     , ("isFloatInfinite", [F32], [I64])
+    , ("isDoubleInfinite", [F64], [I64])
     , ("__decodeFloat_Int", [I64, I64, F32], [])
     ]
 

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -433,12 +433,10 @@ marshalCmmMachOp (GHC.MO_F_Neg w) [x] =
     w
     (do xe <- marshalAndCastCmmExpr x F32
         pure
-          ( Binary {binaryOp = SubFloat32, operand0 = ConstF32 0, operand1 = xe}
-          , F32))
+          (Unary { unaryOp = NegFloat32, operand0 = xe }, F32))
     (do xe <- marshalAndCastCmmExpr x F64
         pure
-          ( Binary {binaryOp = SubFloat64, operand0 = ConstF64 0, operand1 = xe}
-          , F64))
+          (Unary { unaryOp= NegFloat64, operand0 = xe }, F64))
 marshalCmmMachOp (GHC.MO_F_Mul w) [x, y] =
   marshalCmmBinMachOp MulFloat32 F32 F32 F32 MulFloat64 F64 F64 F64 w x y
 marshalCmmMachOp (GHC.MO_F_Quot w) [x, y] =

--- a/ghc-toolkit/boot-libs/integer-simple/GHC/Integer/Type.hs
+++ b/ghc-toolkit/boot-libs/integer-simple/GHC/Integer/Type.hs
@@ -166,7 +166,8 @@ encodeDoubleInteger :: Integer -> Int# -> Double#
 encodeDoubleInteger (Integer m) n = js_encodeDoubleInteger m n
 
 decodeDoubleInteger :: Double# -> (# Integer, Int# #)
-decodeDoubleInteger d = (# Integer (js_decodeDoubleInteger_m d), js_decodeDoubleInteger_n d #)
+decodeDoubleInteger d = (# Integer (js_decodeDoubleInteger_m d), js_decodeDoubleInteger_e d #)
+
 
 doubleFromInteger :: Integer -> Double#
 doubleFromInteger (Integer i) = js_doubleFromInteger i
@@ -256,7 +257,7 @@ foreign import javascript "__asterius_jsffi.Integer.remInteger(${1},${2})" js_re
 
 foreign import javascript "__asterius_jsffi.Integer.encodeDoubleInteger(${1},${2})" js_encodeFloatInteger :: Int# -> Int# -> Float#
 
-foreign import javascript "__asterius_jsffi.Integer.encode(__asterius_jsffi.Integer.decodeDoubleInteger(${1})[0])" js_decodeFloatInteger_m :: Float# -> Int#
+foreign import javascript "__asterius_jsffi.Integer.encode(__asterius_jsffi.floatCBits.decodeDoubleInteger(${1})[0])" js_decodeFloatInteger_m :: Float# -> Int#
 
 foreign import javascript "__asterius_jsffi.Integer.decodeDoubleInteger(${1})[1]" js_decodeFloatInteger_n :: Float# -> Int#
 
@@ -264,9 +265,9 @@ foreign import javascript "__asterius_jsffi.Integer.doubleFromInteger(${1})" js_
 
 foreign import javascript "__asterius_jsffi.Integer.encodeDoubleInteger(${1},${2})" js_encodeDoubleInteger :: Int# -> Int# -> Double#
 
-foreign import javascript "__asterius_jsffi.Integer.encode(__asterius_jsffi.Integer.decodeDoubleInteger(${1})[0])" js_decodeDoubleInteger_m :: Double# -> Int#
+foreign import javascript "__asterius_jsffi.Integer.encode(__asterius_jsffi.floatCBits.decodeDoubleInteger(${1})[0])" js_decodeDoubleInteger_m :: Double# -> Int#
 
-foreign import javascript "__asterius_jsffi.Integer.decodeDoubleInteger(${1})[1]" js_decodeDoubleInteger_n :: Double# -> Int#
+foreign import javascript "__asterius_jsffi.Float.decodeDoubleInteger(${1})[1]" js_decodeDoubleInteger_e :: Double# -> Int#
 
 foreign import javascript "__asterius_jsffi.Integer.doubleFromInteger(${1})" js_doubleFromInteger :: Int# -> Double#
 

--- a/ghc-toolkit/boot-libs/integer-simple/GHC/Integer/Type.hs
+++ b/ghc-toolkit/boot-libs/integer-simple/GHC/Integer/Type.hs
@@ -267,7 +267,7 @@ foreign import javascript "__asterius_jsffi.Integer.encodeDoubleInteger(${1},${2
 
 foreign import javascript "__asterius_jsffi.Integer.encode(__asterius_jsffi.floatCBits.decodeDoubleInteger(${1})[0])" js_decodeDoubleInteger_m :: Double# -> Int#
 
-foreign import javascript "__asterius_jsffi.Float.decodeDoubleInteger(${1})[1]" js_decodeDoubleInteger_e :: Double# -> Int#
+foreign import javascript "__asterius_jsffi.floatCBits.decodeDoubleInteger(${1})[1]" js_decodeDoubleInteger_e :: Double# -> Int#
 
 foreign import javascript "__asterius_jsffi.Integer.doubleFromInteger(${1})" js_doubleFromInteger :: Int# -> Double#
 

--- a/ghc-toolkit/boot-libs/integer-simple/GHC/Integer/Type.hs
+++ b/ghc-toolkit/boot-libs/integer-simple/GHC/Integer/Type.hs
@@ -257,7 +257,7 @@ foreign import javascript "__asterius_jsffi.Integer.remInteger(${1},${2})" js_re
 
 foreign import javascript "__asterius_jsffi.Integer.encodeDoubleInteger(${1},${2})" js_encodeFloatInteger :: Int# -> Int# -> Float#
 
-foreign import javascript "__asterius_jsffi.Integer.encode(__asterius_jsffi.floatCBits.decodeDoubleInteger(${1})[0])" js_decodeFloatInteger_m :: Float# -> Int#
+foreign import javascript "__asterius_jsffi.Integer.encode(__asterius_jsffi.FloatCBits.decodeDoubleInteger(${1})[0])" js_decodeFloatInteger_m :: Float# -> Int#
 
 foreign import javascript "__asterius_jsffi.Integer.decodeDoubleInteger(${1})[1]" js_decodeFloatInteger_n :: Float# -> Int#
 
@@ -265,9 +265,9 @@ foreign import javascript "__asterius_jsffi.Integer.doubleFromInteger(${1})" js_
 
 foreign import javascript "__asterius_jsffi.Integer.encodeDoubleInteger(${1},${2})" js_encodeDoubleInteger :: Int# -> Int# -> Double#
 
-foreign import javascript "__asterius_jsffi.Integer.encode(__asterius_jsffi.floatCBits.decodeDoubleInteger(${1})[0])" js_decodeDoubleInteger_m :: Double# -> Int#
+foreign import javascript "__asterius_jsffi.Integer.encode(__asterius_jsffi.FloatCBits.decodeDoubleInteger(${1})[0])" js_decodeDoubleInteger_m :: Double# -> Int#
 
-foreign import javascript "__asterius_jsffi.floatCBits.decodeDoubleInteger(${1})[1]" js_decodeDoubleInteger_e :: Double# -> Int#
+foreign import javascript "__asterius_jsffi.FloatCBits.decodeDoubleInteger(${1})[1]" js_decodeDoubleInteger_e :: Double# -> Int#
 
 foreign import javascript "__asterius_jsffi.Integer.doubleFromInteger(${1})" js_doubleFromInteger :: Int# -> Double#
 


### PR DESCRIPTION
This fixes double decoding, and implement various bits of the `float` RTS primitives that the test depends on.

@TerrorJack I propose that we teach CI about some ghc testsuite tests which we expect to pass from now on, so that these tests do not regress.

