### PR TITLE
implement isDoubleFinite/isFloatFinite: fix numrun016

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,7 @@ jobs:
             stack test asterius:ghc-testsuite --test-arguments "-p numrun013"
             stack test asterius:ghc-testsuite --test-arguments "-p numrun014"
             stack test asterius:ghc-testsuite --test-arguments "-p numrun015"
+            stack test asterius:ghc-testsuite --test-arguments "-p numrun016"
 
 
             stack test asterius:ghc-testsuite --test-arguments "-p arith013"

--- a/asterius/rts/rts.float.mjs
+++ b/asterius/rts/rts.float.mjs
@@ -56,6 +56,14 @@ export class FloatCBits {
     return x != x;
   }
 
+  isFloatFinite(x) {
+    return isFinite(x);
+  }
+
+  isDoubleFinite(x) {
+    return isFinite(x);
+  }
+
   // Remember, floats have 3 states: {finite, infinite, NaN}.
   isFloatInfinite(x) {
     return !isFinite(x) && !this.isFloatNaN(x);

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -596,6 +596,8 @@ floatCBits =
     , ("isDoubleNegativeZero", [F64], [I64])
     , ("isFloatNaN", [F32], [I64])
     , ("isDoubleNaN", [F64], [I64])
+    , ("isFloatFinite", [F32], [I64])
+    , ("isDoubleFinite", [F64], [I64])
     , ("isFloatDenormalized", [F32], [I64])
     , ("isDoubleDenormalized", [F64], [I64])
     , ("isFloatInfinite", [F32], [I64])


### PR DESCRIPTION
Another one bites the dust of the newline issue:

- This is on top of #163, #165 

```
Progress 1/2: asterius-0.0.1asterius ghc-testsuite
  test/ghc-testsuite/numeric/numrun016.hs
    test/ghc-testsuite/numeric/numrun016.hs: FAIL (1.45s)
      expected: "0.0 :+ 3.141592653589793\n0.0 :+ 3.1415927"
       but got: "0.0 :+ 3.141592653589793\n0.0 :+ 3.1415927\n"
```