### PR TITLE
Make helper scripts dump directly to stdout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,8 +205,8 @@ jobs:
               # run test cases that can fail.
               stack --no-terminal test asterius:ghc-testsuite  -j8 --test-arguments="--timeout=30s" || true
               cp asterius/test-report.csv /tmp
-              python3 asterius/test/format-ghc-testsuite-report.py /tmp/test-report.csv -o /tmp/test-report-ascii.txt
-              python3 asterius/test/group-common-tests-ghc-testsuite-report.py /tmp/test-report.csv -o /tmp/test-report-grouped-by-error-ascii.txt
+              python3 asterius/test/format-ghc-testsuite-report.py /tmp/test-report.csv > /tmp/test-report-ascii.txt
+              python3 asterius/test/group-common-tests-ghc-testsuite-report.py /tmp/test-report.csv > /tmp/test-report-grouped-by-error-ascii.txt
  
       - store_artifacts:
           path: /tmp/test-report.csv

--- a/asterius/test/format-ghc-testsuite-report.py
+++ b/asterius/test/format-ghc-testsuite-report.py
@@ -13,7 +13,6 @@ import numpy as np
 def parse(s):
     p = argparse.ArgumentParser()
     p.add_argument("jsonpath", help="path to input JSON file")
-    p.add_argument("-o", "--out",  help="path to output HTML file", default="")
     return p.parse_args(s)
 
 def unescape_ascii(s):
@@ -28,10 +27,6 @@ def unescape_ascii(s):
 if __name__ == "__main__":
     p = parse(sys.argv[1:])
 
-    outpath = os.path.splitext(p.jsonpath)[0] + ".txt" if not p.out else p.out
-    # convert path to absolute path for better error messages
-    outpath = os.path.abspath(outpath)
-
 
     data = pd.read_csv(p.jsonpath, 
             dtype={"trOutcome": object, "trPath": object, "trErrorMessage": str})
@@ -42,8 +37,6 @@ if __name__ == "__main__":
 
     # Get ASCII printing working.
     out_ascii = AsciiTable(data.values.tolist()).table
-    with open(outpath, 'w') as f:
-        print("writing ASCII output to: %s" % outpath)
-        f.write(out_ascii)
+    print(out_ascii)
 
 

--- a/asterius/test/group-common-tests-ghc-testsuite-report.py
+++ b/asterius/test/group-common-tests-ghc-testsuite-report.py
@@ -17,7 +17,6 @@ import re
 def parse(s):
     p = argparse.ArgumentParser()
     p.add_argument("jsonpath", help="path to input JSON file")
-    p.add_argument("-o", "--out",  help="path to output HTML file", default="")
     return p.parse_args(s)
 
 def unescape_ascii(s):
@@ -68,11 +67,6 @@ def strip_wasm_line_numbers(s):
 if __name__ == "__main__":
     p = parse(sys.argv[1:])
 
-    outpath = os.path.splitext(p.jsonpath)[0] + "-aggregated.txt" if not p.out else p.out
-    # convert path to absolute path for better error messages
-    outpath = os.path.abspath(outpath)
-
-
     data = pd.read_csv(p.jsonpath, 
             dtype={"trOutcome": object, "trPath": object, "trErrorMessage": str})
     # replace nan with string for the possibly empty error messages.
@@ -96,8 +90,4 @@ if __name__ == "__main__":
 
     # print to table.
     out_ascii = AsciiTable(l).table
-    with open(outpath, 'w') as f:
-        print("writing ASCII output to: %s" % outpath)
-        f.write(out_ascii)
-
-
+    print(out_ascii)


### PR DESCRIPTION
This lets us:
- Be nice `*nix` citizens and just redirect / pipe their output
- Makes using them nicer during development. We no longer need to write
  to a file and then `cat` the file. We can just call the tool against
  the raw `test-report.csv` and see pretty-printed output.

It's a small workflow change that makes the script a little nicer to use.