### PR TITLE
Fix arith005. Change rintFloat and rintDouble

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,7 @@ jobs:
             stack test asterius:ghc-testsuite --test-arguments "-p arith008"
             stack test asterius:ghc-testsuite --test-arguments "-p arith007"
             stack test asterius:ghc-testsuite --test-arguments "-p arith006"
+            stack test asterius:ghc-testsuite --test-arguments "-p arith005"
             stack test asterius:ghc-testsuite --test-arguments "-p arith004"
             stack test asterius:ghc-testsuite --test-arguments "-p arith002"
             stack test asterius:ghc-testsuite --test-arguments "-p arith001"

--- a/asterius/rts/rts.float.mjs
+++ b/asterius/rts/rts.float.mjs
@@ -332,7 +332,8 @@ export class FloatCBits {
 
     // put back the double together
     const reconstructDouble = () => {
-      const mantFull = (mant0 << BigInt(32)) | mant1;
+      // const mantFull = (mant0 << BigInt(32)) | mant1;
+      const mantFull = (mant1 << BigInt(32)) | mant0;
 
       const bits = (sign << BigInt(63)) | (exp << BigInt(52)) | mantFull;
       const n =  Number(this.IEEEToDouble(bits));

--- a/asterius/test/ghc-testsuite/numeric/FloatFnInverses.hs
+++ b/asterius/test/ghc-testsuite/numeric/FloatFnInverses.hs
@@ -12,7 +12,8 @@ main = mapM_ print
 --    invDeviation @Double exp log <$> [-10, -5 .. 300]
 --  , invDeviation @Float  exp log <$> [-10 .. 60]
    -- @sin@ is only invertible on @[-π/2…π/2] <-> [-1…1]@.
- [invDeviation @Double sin asin (-1.3)]
+-- [invDeviation @Double sin asin (-1.3)]
+   [invDeviation' (-1.3)]
 -- , invDeviation @Float  sin asin <$> [-1.5, -1.4 .. 1.5]
 --   -- @cos@ is invertible on @[0…π] <-> [-1…1]@.
 -- , invDeviation @Double cos acos <$> [0, 0.1 .. 3]
@@ -30,6 +31,11 @@ main = mapM_ print
 -- , invDeviation @Double atanh tanh <$> [-0.99, -0.87 .. 0.9]
 -- , invDeviation @Float  atanh tanh <$> [-0.99, -0.87 .. 0.9]
 -- ]
+
+invDeviation' :: Double -> Double
+invDeviation' v =
+  let x = (asin (sin (x) / x)) - 1
+  in fromIntegral (round $ x * 2^36) / 2^36
 
 invDeviation :: KnownNumDeviation a
           => (a -> a) -- ^ Some numerical function @f@.

--- a/asterius/test/ghc-testsuite/numeric/FloatFnInverses.hs
+++ b/asterius/test/ghc-testsuite/numeric/FloatFnInverses.hs
@@ -5,31 +5,31 @@
 
 main :: IO ()
 main = mapM_ print
- [ -- @recip@ is self-inverse on @ℝ\\{0}@.
-   invDeviation @Double recip recip <$> [-1e20, -1e3, -1, -1e-40, 1e-40, 1e90]
- , invDeviation @Float  recip recip <$> [-1e10, -10, -1, -1e-20, 1e-20, 1e30]
- , -- @exp@ is invertible on @ℝ <-> [0…∞[@, but grows very fast.
-   invDeviation @Double exp log <$> [-10, -5 .. 300]
- , invDeviation @Float  exp log <$> [-10 .. 60]
+--  [ -- @recip@ is self-inverse on @ℝ\\{0}@.
+--    invDeviation @Double recip recip <$> [-1e20, -1e3, -1, -1e-40, 1e-40, 1e90]
+--  , invDeviation @Float  recip recip <$> [-1e10, -10, -1, -1e-20, 1e-20, 1e30]
+--  , -- @exp@ is invertible on @ℝ <-> [0…∞[@, but grows very fast.
+--    invDeviation @Double exp log <$> [-10, -5 .. 300]
+--  , invDeviation @Float  exp log <$> [-10 .. 60]
    -- @sin@ is only invertible on @[-π/2…π/2] <-> [-1…1]@.
- , invDeviation @Double sin asin <$> [-1.5, -1.4 .. 1.5]
- , invDeviation @Float  sin asin <$> [-1.5, -1.4 .. 1.5]
-   -- @cos@ is invertible on @[0…π] <-> [-1…1]@.
- , invDeviation @Double cos acos <$> [0, 0.1 .. 3]
- , invDeviation @Float  cos acos <$> [0, 0.1 .. 3]
-   -- @tan@ is invertible on @]-π/4…π/4[ <-> ]-∞…∞[@.
- , invDeviation @Double tan atan <$> [-0.7, -0.6 .. 0.7]
- , invDeviation @Float  tan atan <$> [-0.7, -0.6 .. 0.7]
-   -- @sinh@ is invertible on @ℝ <-> ℝ@, but grows very fast.
- , invDeviation @Double sinh asinh <$> [-700, -672 .. 700]
- , invDeviation @Float  sinh asinh <$> [-80, -71 .. 80]
-   -- @cosh@ is invertible on @[0…∞[ <-> [1…∞[@, but grows fast
- , invDeviation @Double cosh acosh <$> [0, 15 .. 700]
- , invDeviation @Float  cosh acosh <$> [0, 15 .. 80]
-   -- @tanh@ is invertible on @ℝ <-> ]-1…1[@.
- , invDeviation @Double atanh tanh <$> [-0.99, -0.87 .. 0.9]
- , invDeviation @Float  atanh tanh <$> [-0.99, -0.87 .. 0.9]
- ]
+ [invDeviation @Double sin asin (-1.3)]
+-- , invDeviation @Float  sin asin <$> [-1.5, -1.4 .. 1.5]
+--   -- @cos@ is invertible on @[0…π] <-> [-1…1]@.
+-- , invDeviation @Double cos acos <$> [0, 0.1 .. 3]
+-- , invDeviation @Float  cos acos <$> [0, 0.1 .. 3]
+--   -- @tan@ is invertible on @]-π/4…π/4[ <-> ]-∞…∞[@.
+-- , invDeviation @Double tan atan <$> [-0.7, -0.6 .. 0.7]
+-- , invDeviation @Float  tan atan <$> [-0.7, -0.6 .. 0.7]
+--   -- @sinh@ is invertible on @ℝ <-> ℝ@, but grows very fast.
+-- , invDeviation @Double sinh asinh <$> [-700, -672 .. 700]
+-- , invDeviation @Float  sinh asinh <$> [-80, -71 .. 80]
+--   -- @cosh@ is invertible on @[0…∞[ <-> [1…∞[@, but grows fast
+-- , invDeviation @Double cosh acosh <$> [0, 15 .. 700]
+-- , invDeviation @Float  cosh acosh <$> [0, 15 .. 80]
+--   -- @tanh@ is invertible on @ℝ <-> ]-1…1[@.
+-- , invDeviation @Double atanh tanh <$> [-0.99, -0.87 .. 0.9]
+-- , invDeviation @Float  atanh tanh <$> [-0.99, -0.87 .. 0.9]
+-- ]
 
 invDeviation :: KnownNumDeviation a
           => (a -> a) -- ^ Some numerical function @f@.

--- a/asterius/test/ghc-testsuite/numeric/FloatFnInverses.hs
+++ b/asterius/test/ghc-testsuite/numeric/FloatFnInverses.hs
@@ -5,37 +5,31 @@
 
 main :: IO ()
 main = mapM_ print
---  [ -- @recip@ is self-inverse on @ℝ\\{0}@.
---    invDeviation @Double recip recip <$> [-1e20, -1e3, -1, -1e-40, 1e-40, 1e90]
---  , invDeviation @Float  recip recip <$> [-1e10, -10, -1, -1e-20, 1e-20, 1e30]
---  , -- @exp@ is invertible on @ℝ <-> [0…∞[@, but grows very fast.
---    invDeviation @Double exp log <$> [-10, -5 .. 300]
---  , invDeviation @Float  exp log <$> [-10 .. 60]
+ [ -- @recip@ is self-inverse on @ℝ\\{0}@.
+   invDeviation @Double recip recip <$> [-1e20, -1e3, -1, -1e-40, 1e-40, 1e90]
+ , invDeviation @Float  recip recip <$> [-1e10, -10, -1, -1e-20, 1e-20, 1e30]
+ , -- @exp@ is invertible on @ℝ <-> [0…∞[@, but grows very fast.
+   invDeviation @Double exp log <$> [-10, -5 .. 300]
+ , invDeviation @Float  exp log <$> [-10 .. 60]
    -- @sin@ is only invertible on @[-π/2…π/2] <-> [-1…1]@.
--- [invDeviation @Double sin asin (-1.3)]
-   [invDeviation' (-1.3)]
--- , invDeviation @Float  sin asin <$> [-1.5, -1.4 .. 1.5]
---   -- @cos@ is invertible on @[0…π] <-> [-1…1]@.
--- , invDeviation @Double cos acos <$> [0, 0.1 .. 3]
--- , invDeviation @Float  cos acos <$> [0, 0.1 .. 3]
---   -- @tan@ is invertible on @]-π/4…π/4[ <-> ]-∞…∞[@.
--- , invDeviation @Double tan atan <$> [-0.7, -0.6 .. 0.7]
--- , invDeviation @Float  tan atan <$> [-0.7, -0.6 .. 0.7]
---   -- @sinh@ is invertible on @ℝ <-> ℝ@, but grows very fast.
--- , invDeviation @Double sinh asinh <$> [-700, -672 .. 700]
--- , invDeviation @Float  sinh asinh <$> [-80, -71 .. 80]
---   -- @cosh@ is invertible on @[0…∞[ <-> [1…∞[@, but grows fast
--- , invDeviation @Double cosh acosh <$> [0, 15 .. 700]
--- , invDeviation @Float  cosh acosh <$> [0, 15 .. 80]
---   -- @tanh@ is invertible on @ℝ <-> ]-1…1[@.
--- , invDeviation @Double atanh tanh <$> [-0.99, -0.87 .. 0.9]
--- , invDeviation @Float  atanh tanh <$> [-0.99, -0.87 .. 0.9]
--- ]
-
-invDeviation' :: Double -> Double
-invDeviation' v =
-  let x = (asin (sin (x) / x)) - 1
-  in fromIntegral (round $ x * 2^36) / 2^36
+ , invDeviation @Double sin asin <$> [-1.5, -1.4 .. 1.5]
+ , invDeviation @Float  sin asin <$> [-1.5, -1.4 .. 1.5]
+   -- @cos@ is invertible on @[0…π] <-> [-1…1]@.
+ , invDeviation @Double cos acos <$> [0, 0.1 .. 3]
+ , invDeviation @Float  cos acos <$> [0, 0.1 .. 3]
+   -- @tan@ is invertible on @]-π/4…π/4[ <-> ]-∞…∞[@.
+ , invDeviation @Double tan atan <$> [-0.7, -0.6 .. 0.7]
+ , invDeviation @Float  tan atan <$> [-0.7, -0.6 .. 0.7]
+   -- @sinh@ is invertible on @ℝ <-> ℝ@, but grows very fast.
+ , invDeviation @Double sinh asinh <$> [-700, -672 .. 700]
+ , invDeviation @Float  sinh asinh <$> [-80, -71 .. 80]
+   -- @cosh@ is invertible on @[0…∞[ <-> [1…∞[@, but grows fast
+ , invDeviation @Double cosh acosh <$> [0, 15 .. 700]
+ , invDeviation @Float  cosh acosh <$> [0, 15 .. 80]
+   -- @tanh@ is invertible on @ℝ <-> ]-1…1[@.
+ , invDeviation @Double atanh tanh <$> [-0.99, -0.87 .. 0.9]
+ , invDeviation @Float  atanh tanh <$> [-0.99, -0.87 .. 0.9]
+ ]
 
 invDeviation :: KnownNumDeviation a
           => (a -> a) -- ^ Some numerical function @f@.


### PR DESCRIPTION
- Use (>>>) instead of (>>) for right shifting to ensure unsigned
  result.
- Fix implementation of floatExponentFromBits.

- Fix general mistakes in `rintFloat` and `rintDouble` that occured
  during translation.