### PR TITLE
Fix test failure due to stack major upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .stack-work/
+stack.yaml.lock
 wabt/wabt/bin
 asterius.cabal
 ghc-toolkit.cabal


### PR DESCRIPTION
After `stack` upgrades to 2, it seems that more ghc related environment variables are passed for various `stack` commands, e.g. `stack test` or `stack exec`, thus leaking host ghc package db to `ahc`, causing `ahc` to fail.

To make `ahc` work properly when called by `stack` commands, we now shadow all environment variables with name `GHC_*`/`HASKELL_*`.