### PR TITLE
Teach circle to bail out for builds that have secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,13 @@ jobs:
     docker:
       - image: docker:edge-git
     steps:
+      - run:
+          name: Ensure we are on `tweag/asterius`
+          command: |
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              echo "Nothing to do for forked PRs, so marking this step successful"
+              circleci step halt
+            fi
       - setup_remote_docker
       - checkout
       - run:
@@ -272,6 +279,13 @@ jobs:
     docker:
       - image: docker:edge-git
     steps:
+      - run:
+          name: Ensure we are on `tweag/asterius`
+          command: |
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              echo "Nothing to do for forked PRs, so marking this step successful"
+              circleci step halt
+            fi
       - setup_remote_docker
       - checkout
       - run:


### PR DESCRIPTION
Edit the circleCI config as described at https://circleci.com/blog/managing-secrets-when-you-have-pull-requests-from-outside-contributors/ so that we can enable builds on forks without having the build fail on docker and documentation builds due to secrets