### PR TITLE
Staging a part of ongoing async FFI work

### DIFF
--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -744,11 +744,7 @@ rtsEvalHelper BuiltinsOptions {..} create_thread_func_sym = do
   setReturnTypes [I32]
   p <- param I64
   enter 0
-  tso <-
-    call'
-      create_thread_func_sym
-      [mainCapability, constI64 $ roundup_bytes_to_words threadStateSize, p]
-      I64
+  tso <- call' create_thread_func_sym [p] I64
   call "scheduleWaitThread" [tso]
   exit 0
   emit $ loadI32 tso offset_StgTSO_id
@@ -875,11 +871,11 @@ scheduleWaitThreadFunction BuiltinsOptions {} =
             , emit $ emitErrorMessage [] "IllegalThreadReturnCode")
     callImport "__asterius_gcRootTSO" [convertUInt64ToFloat64 t]
 
-createThreadFunction _ =
+createThreadFunction BuiltinsOptions {..} =
   runEDSL "createThread" $ do
     setReturnTypes [I64]
-    [cap, alloc_words] <- params [I64, I64]
-    tso_p <- call' "allocatePinned" [cap, alloc_words] I64
+    let alloc_words = constI64 $ roundup_bytes_to_words threadStateSize
+    tso_p <- call' "allocatePinned" [mainCapability, alloc_words] I64
     stack_p <- i64Local $ tso_p `addInt64` constI64 offset_StgTSO_StgStack
     storeI64 stack_p 0 $ symbol "stg_STACK_info"
     stack_size_w <-
@@ -899,7 +895,7 @@ createThreadFunction _ =
     storeI32 tso_p offset_StgTSO_flags $ constI32 0
     storeI32 tso_p offset_StgTSO_dirty $ constI32 1
     storeI32 tso_p offset_StgTSO_saved_errno $ constI32 0
-    storeI64 tso_p offset_StgTSO_cap cap
+    storeI64 tso_p offset_StgTSO_cap mainCapability
     storeI64 tso_p offset_StgTSO_stackobj stack_p
     storeI32 tso_p offset_StgTSO_tot_stack_size $ wrapInt64 stack_size_w
     storeI64 tso_p offset_StgTSO_alloc_limit (constI64 0)
@@ -921,8 +917,8 @@ pushClosure tso c = do
 createThreadHelper :: (Expression -> [Expression]) -> EDSL ()
 createThreadHelper mk_closures = do
   setReturnTypes [I64]
-  [cap, stack_size, closure] <- params [I64, I64, I64]
-  t <- call' "createThread" [cap, stack_size] I64
+  closure <- param I64
+  t <- call' "createThread" [] I64
   for_ (mk_closures closure) $ pushClosure t
   emit t
 

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -30,6 +30,7 @@ import Control.Monad.Except
 import Control.Monad.Reader
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Short as SBS
+import Data.Foldable
 import Data.List
 import qualified Data.Map.Strict as M
 import Data.String
@@ -1348,4 +1349,5 @@ marshalCmmIR :: GHC.Module -> CmmIR -> CodeGen AsteriusModule
 marshalCmmIR this_mod CmmIR {..} = marshalRawCmm this_mod cmmRaw
 
 marshalRawCmm :: GHC.Module -> [[GHC.RawCmmDecl]] -> CodeGen AsteriusModule
-marshalRawCmm _ = fmap mconcat . traverse marshalCmmDecl . mconcat
+marshalRawCmm this_mod cmm_decls =
+  mconcat <$> traverse marshalCmmDecl (mconcat cmm_decls)

--- a/asterius/src/Asterius/FrontendPlugin.hs
+++ b/asterius/src/Asterius/FrontendPlugin.hs
@@ -7,6 +7,7 @@ module Asterius.FrontendPlugin
 import Asterius.CodeGen
 import Asterius.Internals
 import Asterius.JSFFI
+import Asterius.Types
 import Asterius.TypesConv
 import Control.Exception
 import Control.Monad
@@ -42,12 +43,12 @@ frontendPlugin =
                   dflags <- GHC.getDynFlags
                   setDynFlagsRef dflags
                   let mod_sym = marshalToModuleSymbol ms_mod
-                  liftIO $
+                  liftIO $ do
+                    get_ffi_mod <- readIORef get_ffi_mod_ref
+                    ffi_mod <- get_ffi_mod mod_sym
                     case runCodeGen (marshalHaskellIR ms_mod ir) dflags ms_mod of
                       Left err -> throwIO err
                       Right m' -> do
-                        get_ffi_mod <- readIORef get_ffi_mod_ref
-                        ffi_mod <- get_ffi_mod mod_sym
                         let m = ffi_mod <> m'
                         encodeFile obj_path m
                         when is_debug $ do

--- a/asterius/src/Asterius/Passes/LocalRegs.hs
+++ b/asterius/src/Asterius/Passes/LocalRegs.hs
@@ -46,7 +46,7 @@ resolveLocalRegs FunctionType {..} t =
         _ -> pure t
     _ -> pure t
   where
-    base_idx = 2 + length paramTypes
+    base_idx = 3 + length paramTypes
     idx :: UnresolvedLocalReg -> m BinaryenIndex
     idx reg =
       state $ \ps@PassesState {..} ->
@@ -63,4 +63,4 @@ resolveLocalRegs FunctionType {..} t =
 
 {-# INLINABLE localRegTable #-}
 localRegTable :: PassesState -> [ValueType]
-localRegTable PassesState {..} = I32 : I32 : reverse localRegStack
+localRegTable PassesState {..} = I32 : I32 : I32 : reverse localRegStack

--- a/ghc-toolkit/boot-libs/rts/PrimOps.cmm
+++ b/ghc-toolkit/boot-libs/rts/PrimOps.cmm
@@ -922,9 +922,7 @@ stg_forkzh ( gcptr closure )
 
     gcptr threadid;
 
-    ("ptr" threadid) = ccall createIOThread( MyCapability() "ptr",
-                                  TO_W_(RtsFlags_GcFlags_initialStkSize(RtsFlags)),
-                                  closure "ptr");
+    ("ptr" threadid) = ccall createIOThread( closure "ptr" );
 
     /* start blocked if the current thread is blocked */
     StgTSO_flags(threadid) = %lobits16(
@@ -947,8 +945,6 @@ again: MAYBE_GC(again);
     gcptr threadid;
 
     ("ptr" threadid) = ccall createIOThread(
-        MyCapability() "ptr",
-        TO_W_(RtsFlags_GcFlags_initialStkSize(RtsFlags)),
         closure "ptr");
 
     /* start blocked if the current thread is blocked */


### PR DESCRIPTION
Following #187:

* `createThread` function takes zero arguments and get config from `BuiltinsOptions`.
* `ffi_mod` is fetched before we run the cmm -> wasm codegen, so in case the codegen requires `FFIMarshalState` later we can fetch it.
* We reserve another `i32` local reg for cmm functions for the "entry hook" block.