### PR TITLE
Fix a bug in the relooper

### DIFF
--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -31,7 +31,6 @@ import Control.Monad.Reader
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Short as SBS
 import Data.Foldable
-import Data.List
 import qualified Data.Map.Strict as M
 import Data.String
 import Data.Traversable
@@ -81,7 +80,7 @@ marshalCLabel clbl = do
 marshalLabel :: GHC.Label -> CodeGen SBS.ShortByteString
 marshalLabel lbl = do
   (dflags, _) <- ask
-  pure $ fromString $ asmPpr dflags $ GHC.mkLocalBlockLabel $ GHC.getUnique lbl
+  pure $ fromString $ asmPpr dflags lbl
 
 marshalCmmType :: GHC.CmmType -> CodeGen ValueType
 marshalCmmType t
@@ -1383,24 +1382,6 @@ marshalCmmProc GHC.CmmGraph {g_graph = GHC.GMany _ body _, ..} = do
             , addBranches = []
             }) :
         rbs
-      blocks_key_map =
-        M.fromList
-          (zip (sort (map fst blocks_unresolved)) (map showSBS [(0 :: Int) ..]))
-      blocks_key_subst = (blocks_key_map !)
-      blocks_resolved =
-        [ ( blocks_key_subst k
-          , b
-              { addBranches =
-                  map
-                    (\br ->
-                       case br of
-                         AddBranch {..} -> br {to = blocks_key_subst to}
-                         AddBranchForSwitch {..} ->
-                           br {to = blocks_key_subst to})
-                    (addBranches b)
-              })
-        | (k, b) <- blocks_unresolved
-        ]
   pure $
     adjustLocalRegs
       Function
@@ -1409,8 +1390,8 @@ marshalCmmProc GHC.CmmGraph {g_graph = GHC.GMany _ body _, ..} = do
         , body =
             CFG
               RelooperRun
-                { entry = blocks_key_subst entry_k
-                , blockMap = M.fromList blocks_resolved
+                { entry = entry_k
+                , blockMap = M.fromList blocks_unresolved
                 , labelHelper = 0
                 }
         }
@@ -1452,5 +1433,5 @@ marshalCmmIR :: GHC.Module -> CmmIR -> CodeGen AsteriusModule
 marshalCmmIR this_mod CmmIR {..} = marshalRawCmm this_mod cmmRaw
 
 marshalRawCmm :: GHC.Module -> [[GHC.RawCmmDecl]] -> CodeGen AsteriusModule
-marshalRawCmm this_mod cmm_decls =
+marshalRawCmm _ cmm_decls =
   mconcat <$> traverse marshalCmmDecl (mconcat cmm_decls)

--- a/asterius/src/Asterius/Passes/Relooper.hs
+++ b/asterius/src/Asterius/Passes/Relooper.hs
@@ -10,20 +10,18 @@ import Asterius.Internals
 import Asterius.Types
 import Data.List
 import qualified Data.Map.Strict as M
-import Data.String
 
 relooper :: RelooperRun -> Expression
 relooper RelooperRun {..} = result_expr
   where
     lbls = M.keys blockMap
-    def_lbl = fromString $ show $ length lbls - 1
     lbl_map = M.fromList $ zip lbls [0 ..]
     lbl_to_idx = (lbl_map !)
     set_block_lbl lbl = SetLocal {index = 0, value = ConstI32 $ lbl_to_idx lbl}
     initial_expr =
       Switch
         { names = lbls
-        , defaultName = def_lbl
+        , defaultName = "__asterius_unreachable"
         , condition = GetLocal {index = 0, valueType = I32}
         }
     loop_lbl = "__asterius_loop"


### PR DESCRIPTION
This PR fixes a silly bug in the relooper. Previously, when the codegen outputs a CFG, we substitute all label names with string representations of decimal numbers, and based on the assumption that the `__asterius_unreachable` label maps to the largest number, we set the fallback label to be "string of the largest number" in the relooper.

Normally, this won't be a problem, but when we're attempting to rewrite the CFG post label substitution (e.g. for async FFI), the assumption is broken, since new blocks are added and the "string of the largest number" label is non-existent. And..the substitution is not needed in the first place! We can just use the original label names per se, and simply use `__asterius_unreachable` as the fallback label.