### PR TITLE
Workaround `hackage-security` issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,8 @@ jobs:
           name: Build asterius
           command: |
             git submodule update --init --recursive
+            mkdir ~/.stack
+            cp .circleci/stack.config.yaml ~/.stack/config.yaml
             stack --no-terminal -j8 build --test --no-run-tests
             stack --no-terminal exec ahc-boot
 
@@ -191,6 +193,8 @@ jobs:
             name: Build asterius
             command: |
               git submodule update --init --recursive
+              mkdir ~/.stack
+              cp .circleci/stack.config.yaml ~/.stack/config.yaml
               stack --no-terminal -j8 build --test --no-run-tests
               stack --no-terminal exec ahc-boot
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,8 +195,8 @@ jobs:
               git submodule update --init --recursive
               mkdir /root/.stack
               cp .circleci/stack.config.yaml /root/.stack/config.yaml
-              stack --no-terminal -j8 build --test --no-run-tests --verbose
-              stack --no-terminal exec ahc-boot --verbose
+              stack --no-terminal -j8 build --test --no-run-tests
+              stack --no-terminal exec ahc-boot
 
               cd ~/.local
               $CIRCLE_WORKING_DIRECTORY/utils/v8-node.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,8 @@ jobs:
           name: Build asterius
           command: |
             git submodule update --init --recursive
-            mkdir ~/.stack
-            cp .circleci/stack.config.yaml ~/.stack/config.yaml
+            mkdir /root/.stack
+            cp .circleci/stack.config.yaml /root/.stack/config.yaml
             stack --no-terminal -j8 build --test --no-run-tests
             stack --no-terminal exec ahc-boot
 
@@ -193,8 +193,8 @@ jobs:
             name: Build asterius
             command: |
               git submodule update --init --recursive
-              mkdir ~/.stack
-              cp .circleci/stack.config.yaml ~/.stack/config.yaml
+              mkdir /root/.stack
+              cp .circleci/stack.config.yaml /root/.stack/config.yaml
               stack --no-terminal -j8 build --test --no-run-tests
               stack --no-terminal exec ahc-boot
 
@@ -217,7 +217,7 @@ jobs:
               cp asterius/test-report.csv /tmp
               python3 asterius/test/format-ghc-testsuite-report.py /tmp/test-report.csv > /tmp/test-report-ascii.txt
               python3 asterius/test/group-common-tests-ghc-testsuite-report.py /tmp/test-report.csv > /tmp/test-report-grouped-by-error-ascii.txt
- 
+
       - store_artifacts:
           path: /tmp/test-report.csv
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,8 +195,8 @@ jobs:
               git submodule update --init --recursive
               mkdir /root/.stack
               cp .circleci/stack.config.yaml /root/.stack/config.yaml
-              stack --no-terminal -j8 build --test --no-run-tests
-              stack --no-terminal exec ahc-boot
+              stack --no-terminal -j8 build --test --no-run-tests --verbose
+              stack --no-terminal exec ahc-boot --verbose
 
               cd ~/.local
               $CIRCLE_WORKING_DIRECTORY/utils/v8-node.py

--- a/.circleci/stack.config.yaml
+++ b/.circleci/stack.config.yaml
@@ -1,0 +1,17 @@
+package-indices:
+- download-prefix: https://hackage.haskell.org/
+  hackage-security:
+    keyids:
+    - 0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d
+    - 1ea9ba32c526d1cc91ab5e5bd364ec5e9e8cb67179a471872f6e26f0ae773d42
+    - 280b10153a522681163658cb49f632cde3f38d768b736ddbc901d99a1a772833
+    - 2a96b1889dc221c17296fcc2bb34b908ca9734376f0f361660200935916ef201
+    - 2c6c3627bd6c982990239487f1abd02e08a02e6cf16edb105a8012d444d870c3
+    - 51f0161b906011b52c6613376b1ae937670da69322113a246a09f807c62f6921
+    - 772e9f4c7db33d251d5c6e357199c819e569d130857dc225549b40845ff0890d
+    - aa315286e6ad281ad61182235533c41e806e5a787e0b6d1e7eef3f09d137d2e9
+    - fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0
+    key-threshold: 3 # number of keys required
+
+    # ignore expiration date, see https://github.com/commercialhaskell/stack/pull/4614
+    ignore-expiry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM debian:unstable
 
+COPY .circleci/stack.config.yaml /root/.stack/config.yaml
 COPY asterius /root/asterius/asterius
 COPY binaryen /root/asterius/binaryen
 COPY ghc-toolkit /root/asterius/ghc-toolkit


### PR DESCRIPTION
Due to a `hackage-security` issue, all jobs on CircleCI are red today.

See: https://github.com/commercialhaskell/stack/issues/4928

