### PR TITLE
Fix dynamic pointer tagging issue in GC.

### DIFF
--- a/asterius/rts/rts.gc.mjs
+++ b/asterius/rts/rts.gc.mjs
@@ -292,7 +292,7 @@ export class GC {
           const size =
               Number(this.memory.i64Load(c + rtsConstants.offset_StgRetFun_size)),
                 fun_info = Number(this.memory.i64Load(
-                    this.memory.i64Load(c + rtsConstants.offset_StgRetFun_fun)));
+                  Memory.unDynTag(this.memory.i64Load(c + rtsConstants.offset_StgRetFun_fun))));
           switch (this.memory.i32Load(
               fun_info + rtsConstants.offset_StgFunInfoTable_f +
               rtsConstants.offset_StgFunInfoExtraFwd_fun_type)) {


### PR DESCRIPTION
- Do what `scav.c` does: https://github.com/ghc/ghc/blob/2ff77b9894eecf51fa619ed2266ca196e296cd1e/rts/sm/Scav.c#L1950

This also led to the discovery of the same bug _upstream_ from
`Printer.c`:
  https://github.com/ghc/ghc/blob/2ff77b9894eecf51fa619ed2266ca196e296cd1e/rts/Printer.c#L615

The MR fixing `ghc` upstream is at:
https://gitlab.haskell.org/ghc/ghc/merge_requests/1324