### PR TITLE
Fix T9001

### DIFF
--- a/asterius/rts/rts.gc.mjs
+++ b/asterius/rts/rts.gc.mjs
@@ -288,14 +288,30 @@ export class GC {
           c += (1 + size) << 3;
           break;
         }
+        
+        // https://github.com/ghc/ghc/blob/2ff77b9894eecf51fa619ed2266ca196e296cd1e/rts/Printer.c#L609
+        // https://github.com/ghc/ghc/blob/2ff77b9894eecf51fa619ed2266ca196e296cd1e/rts/sm/Scav.c#L1944
         case ClosureTypes.RET_FUN: {
+          const retfun = c;
           const size =
-              Number(this.memory.i64Load(c + rtsConstants.offset_StgRetFun_size)),
-                fun_info = Number(this.memory.i64Load(
-                  Memory.unDynTag(this.memory.i64Load(c + rtsConstants.offset_StgRetFun_fun))));
-          switch (this.memory.i32Load(
-              fun_info + rtsConstants.offset_StgFunInfoTable_f +
-              rtsConstants.offset_StgFunInfoExtraFwd_fun_type)) {
+              Number(this.memory.i64Load(retfun + rtsConstants.offset_StgRetFun_size));
+
+          // NOTE: the order is important. The scavenging will move all the
+          // data inside, so that when we grab "fun", we grab the right fun
+          // that has been moved.
+          this.scavengeClosureAt(retfun + rtsConstants.offset_StgRetFun_fun);
+          let fun = Number(this.memory.i64Load(retfun + rtsConstants.offset_StgRetFun_fun));
+          const fun_info_p = fun + 0;
+          const fun_info = Number(this.memory.i64Load(Memory.unDynTag(fun_info_p)));
+
+          const fun_type = this.memory.i32Load(
+            fun_info + rtsConstants.offset_StgFunInfoTable_f +
+            rtsConstants.offset_StgFunInfoExtraFwd_fun_type);
+
+          const ret_fun_payload = retfun + rtsConstants.offset_StgRetFun_payload;
+
+                
+          switch (fun_type) {
             case FunTypes.ARG_GEN: {
               this.scavengeSmallBitmap(
                   c + rtsConstants.offset_StgRetFun_payload,
@@ -319,16 +335,20 @@ export class GC {
               throw new WebAssembly.RuntimeError();
             }
             default: {
-              this.scavengeSmallBitmap(
-                  c + rtsConstants.offset_StgRetFun_payload,
-                  BigInt(stg_arg_bitmaps[this.memory.i32Load(
-                      fun_info + rtsConstants.offset_StgFunInfoTable_f +
-                      rtsConstants.offset_StgFunInfoExtraFwd_fun_type)]) >>
-                      BigInt(6),
-                  size);
+              // https://github.com/ghc/ghc/blob/bf73419518ca550e85188616f860961c7e2a336b/includes/rts/Constants.h#L186
+              const BITMAP_SIZE_MASK = 0x3f;
+              const BITMAP_BITS_SHIFT = 6;
+              const bitmap = stg_arg_bitmaps[fun_type];
+                
+              // https://github.com/ghc/ghc/blob/2ff77b9894eecf51fa619ed2266ca196e296cd1e/includes/rts/storage/InfoTables.h#L116
+              const bitmap_bits =  BigInt(bitmap) >> BigInt(BITMAP_BITS_SHIFT);
+              const bitmap_size = bitmap & BITMAP_SIZE_MASK;
+
+              this.scavengeSmallBitmap(ret_fun_payload, bitmap_bits, bitmap_size);
+
               break;
-            }
-          }
+            } // end case default
+          } //end switch (fun_type)
           c += rtsConstants.sizeof_StgRetFun + (size << 3);
           break;
         }

--- a/asterius/test/ghc-testsuite-filter
+++ b/asterius/test/ghc-testsuite-filter
@@ -2,7 +2,7 @@
 # !<regex> will blacklist stuff in <regex>. <regex> syntax given by whatever
 # is parsed by Regex.TDFA
 # Leading whitespace sensitive.
-numeric/
+numeric/|T9001
 !CarryOverflow.hs
 !arith011
 !arith008


### PR DESCRIPTION
Fix the GC bug that was exposed by T9001. The bug revolves around the phase ordering that was present around evacuating the function in a `RET_FUN` frame. 