### PR TITLE
Fix T11108

### DIFF
--- a/asterius/rts/rts.gc.mjs
+++ b/asterius/rts/rts.gc.mjs
@@ -175,7 +175,7 @@ export class GC {
               break;
             }
             default:
-              throw new WebAssembly.RuntimeError();
+              throw new WebAssembly.RuntimeError("unhandled closure type: " + type);
           }
         }
       } else {

--- a/asterius/test/ghc-testsuite/rts/T11108.hs
+++ b/asterius/test/ghc-testsuite/rts/T11108.hs
@@ -1,19 +1,19 @@
 {-# LANGUAGE RecursiveDo, LambdaCase, BangPatterns #-}
-
+{-# LANGUAGE DeriveGeneric #-}
+import GHC.Generics (Generic, Generic1)
 import Control.Monad.Fix
 import Data.IORef
 import System.Mem.Weak
 import System.Mem
-
+import Control.Exception(evaluate)
+import Control.DeepSeq
 import Control.Monad
 import Data.Foldable
 
 data Pull = Pull
   { weakSelf  :: Weak Pull
   , compute :: Weak Pull -> IO Int
-  , invalidators :: IORef [Weak Pull]
-  , cached  :: IORef (Maybe Int)
-  }
+  } deriving(Generic)
 
 
 makePull :: (Weak Pull -> IO Int) -> IO Pull
@@ -21,8 +21,7 @@ makePull f = do
   rec
     -- This seems to be the culprit, changing the order makes the weakRef get gc'ed
     -- In this configuration it crashes
-
-    !foo <- Pull weak f <$> newIORef [] <*> newIORef Nothing
+    let !foo = Pull weak f
     weak <- mkWeakPtr foo Nothing
 
   return foo
@@ -30,26 +29,17 @@ makePull f = do
 
 invalidate :: Pull -> IO ()
 invalidate p = do
-  writeIORef (cached p) Nothing
-  invs <- readIORef (invalidators p)
-  writeIORef (invalidators p) []
-  traverse_ (deRefWeak >=> traverse_ invalidate) invs
+  return ()
 
 
 pull :: Weak Pull -> Pull -> IO Int
 pull weak p = do
-  modifyIORef (invalidators p) (weak :)
   pull' p
 
 pull' :: Pull -> IO Int
 pull' p = do
-  readIORef (cached p) >>= \case
-    Nothing -> do
       r <- compute p (weakSelf p)
-      writeIORef (cached p) (Just r)
       return r
-
-    Just r -> return r
 
 add :: Pull -> Int -> IO (Pull)
 add p n = makePull (\w -> (+n) <$> pull w p)
@@ -57,21 +47,12 @@ add p n = makePull (\w -> (+n) <$> pull w p)
 main = do
   h <- newIORef 0
 
+  performGC
+
   source <- makePull (const $ readIORef h)
-  p <- foldM add source (take 1000 (repeat 1))   -- 100 is not enough for crash
-
-  forM_ [1..10] $ \i -> do
-
-    writeIORef h i
-    invalidate source -- Crashes here on second iteration
-
-    --performGC
-    -- This avoids the crash
-
-    print =<< pull' p
-
-
-
+  p <- foldM add source (take 10000 (repeat 1))   -- 100 is not enough for crash
+  print =<< pull' p
+  performGC
 
 
 

--- a/asterius/test/ghc-testsuite/rts/T11108.hs
+++ b/asterius/test/ghc-testsuite/rts/T11108.hs
@@ -26,23 +26,13 @@ makePull f = do
 
   return foo
 
-
-invalidate :: Pull -> IO ()
-invalidate p = do
-  return ()
-
-
-pull :: Weak Pull -> Pull -> IO Int
-pull weak p = do
-  pull' p
-
 pull' :: Pull -> IO Int
 pull' p = do
       r <- compute p (weakSelf p)
       return r
 
 add :: Pull -> Int -> IO (Pull)
-add p n = makePull (\w -> (+n) <$> pull w p)
+add p n = makePull (\w -> (+n) <$> pull'  p)
 
 main = do
   h <- newIORef 0

--- a/asterius/test/ghc-testsuite/rts/T11108.hs
+++ b/asterius/test/ghc-testsuite/rts/T11108.hs
@@ -11,24 +11,24 @@ import Control.Monad
 import Data.Foldable
 
 data Pull = Pull
-  { weakSelf  :: Weak Pull
-  , compute :: Weak Pull -> IO Int
+  {
+  compute :: Pull -> IO Int
   } deriving(Generic)
 
 
-makePull :: (Weak Pull -> IO Int) -> IO Pull
+makePull :: (Pull -> IO Int) -> IO Pull
 makePull f = do
   rec
     -- This seems to be the culprit, changing the order makes the weakRef get gc'ed
     -- In this configuration it crashes
-    let !foo = Pull weak f
-    weak <- mkWeakPtr foo Nothing
+    let !foo = Pull f
+    -- weak <- mkWeakPtr foo Nothing
 
   return foo
 
 pull' :: Pull -> IO Int
 pull' p = do
-      r <- compute p (weakSelf p)
+      r <- compute p p
       return r
 
 incr :: Pull -> IO Pull 

--- a/asterius/test/ghc-testsuite/rts/T11108.hs
+++ b/asterius/test/ghc-testsuite/rts/T11108.hs
@@ -44,8 +44,4 @@ main = do
   h <- newIORef 0
   source <- makePull (const $ readIORef h)
   p <- repeatM 10000 incr source
-  print =<< pull' p
-  performGC
-
-
-
+  return ()


### PR DESCRIPTION
This appears to have an `MVar` on the heap. On running, I get the error:

```
RuntimeError: unhandled closure type: 40
    at GC.evacuateClosure (file:///home/bollu/work/asterius/asterius/test/ghc-testsuite/rts/rts.gc.mjs:178:21)
    at GC.scavengeClosureAt (file:///home/bollu/work/asterius/asterius/test/ghc-testsuite/rts/rts.gc.mjs:191:34)
    at GC.scavengePointersFirst (file:///home/bollu/work/asterius/asterius/test/ghc-testsuite/rts/rts.gc.mjs:195:41)
    at GC.scavengeClosure (file:///home/bollu/work/asterius/asterius/test/ghc-testsuite/rts/rts.gc.mjs:384:14)
    at GC.scavengeWorkList (file:///home/bollu/work/asterius/asterius/test/ghc-testsuite/rts/rts.gc.mjs:342:39)
    at GC.gcRootTSO (file:///home/bollu/work/asterius/asterius/test/ghc-testsuite/rts/rts.gc.mjs:520:10)
    at scheduleWaitThread (wasm-function[1544]:246)
    at scheduleWaitThread_wrapper (wasm-function[1545]:6)
    at Exports.rts_evalLazyIO (file:///home/bollu/work/asterius/asterius/test/ghc-testsuite/rts/rts.exports.mjs:30:10)
    at Exports.main (file:///home/bollu/work/asterius/asterius/test/ghc-testsuite/rts/rts.exports.mjs:36:17)
ahc-link: callProcess: node "--experimental-wasm-bigint" "--experimental-modules" "T11108.mjs" (exit 1): failed
```

and closure type `40` is [`#define MVAR_DIRTY 40`](https://github.com/ghc/ghc/blob/master/includes/rts/storage/ClosureTypes.h#L62)