### PR TITLE
Add error messages to the GC runtime

### DIFF
--- a/asterius/rts/rts.gc.mjs
+++ b/asterius/rts/rts.gc.mjs
@@ -345,7 +345,7 @@ export class GC {
   scavengeClosure(c) {
     const info = Number(this.memory.i64Load(c)),
           type = this.memory.i32Load(info + rtsConstants.offset_StgInfoTable_type);
-    if (!this.infoTables.has(info)) throw new WebAssembly.RuntimeError();
+    if (!this.infoTables.has(info)) throw new WebAssembly.RuntimeError("closure does not have info table: " +  c);
     switch (info) {
       case this.symbolTable.base_GHCziStable_StablePtr_con_info:
       case this.symbolTable.integerzmwiredzmin_GHCziIntegerziType_Integer_con_info: {

--- a/asterius/rts/rts.gc.mjs
+++ b/asterius/rts/rts.gc.mjs
@@ -175,7 +175,7 @@ export class GC {
               break;
             }
             default:
-              throw new WebAssembly.RuntimeError();
+              throw new WebAssembly.RuntimeError("unhandled closure type: " + type);
           }
         }
       } else {


### PR DESCRIPTION
We had `throw new WebAssembly.RuntimeError()` which is less valuable than having an error message. So add error messages to the code.