### PR TITLE
Fix broken browser target

### DIFF
--- a/asterius/rts/rts.messages.mjs
+++ b/asterius/rts/rts.messages.mjs
@@ -1,4 +1,3 @@
-import {format } from "util";
 export class Messages {
     constructor(memory, fs) {
         this.memory = memory;
@@ -7,7 +6,7 @@ export class Messages {
     }
 
     debugBelch2(fmt, arg) {
-        let s = format(this.memory.strLoad(fmt), this.memory.strLoad(arg));
+        const s = `${this.memory.strLoad(arg)}\n`;
         console.error(s);
         this.fs.writeSync(this.fs.stderr(), s);
     }


### PR DESCRIPTION
This PR fixes the broken browser target. When implementing `debugBelch2` for `Debug.Trace`, we added a node-only `import` which couldn't be resolved in browsers. Since the format string is always `%s\n` in practice, so we ignore the passed in `fmt` parameter for now.

To prevent similar regressions in the future, we really need to set up headless chrome/firefox unit tests.