### PR TITLE
Fix handling of IND objects in gc

### DIFF
--- a/asterius/rts/rts.gc.mjs
+++ b/asterius/rts/rts.gc.mjs
@@ -120,8 +120,13 @@ export class GC {
               break;
             }
             case ClosureTypes.IND: {
-              dest_c = this.copyClosure(untagged_c, rtsConstants.sizeof_StgInd);
-              break;
+              dest_c = this.evacuateClosure(
+                this.memory.i64Load(
+                  untagged_c + rtsConstants.offset_StgInd_indirectee
+                )
+              );
+              this.closureIndirects.set(untagged_c, dest_c);
+              return dest_c;
             }
             case ClosureTypes.PAP: {
               const n_args = this.memory.i32Load(untagged_c +
@@ -460,7 +465,7 @@ export class GC {
         break;
       }
       case ClosureTypes.IND: {
-        this.scavengeClosure(c + rtsConstants.offset_StgInd_indirectee);
+        this.scavengeClosureAt(c + rtsConstants.offset_StgInd_indirectee);
         break;
       }
       case ClosureTypes.IND_STATIC: {


### PR DESCRIPTION
This PR fixes handling of `IND` heap objects in gc:

* When evacuating an `IND` object, we no longer copy it; instead we evacuate its `indirectee` and return the new address, thus removing the indirection. This was supposed to be an important optimization of ghc rts.
* The scavenging code of `IND` didn't properly set the `indirectee` field to the new address..now that `IND` is eliminated in `evacuateClosure`, we might not go through this branch any more, but still we fixed it.