### PR TITLE
Fix makeHaskellCallback* implementation

### DIFF
--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -79,7 +79,7 @@ export function newAsteriusInstance(req) {
       const tid = await __asterius_exports.rts_evalLazyIO(
         __asterius_exports.rts_apply(
           __asterius_stableptr_manager.deRefStablePtr(sp),
-          __asterius_exports.rts_mkInt(
+          __asterius_exports.rts_mkStablePtr(
             __asterius_stableptr_manager.newJSVal(ev)
           )
         )
@@ -90,9 +90,9 @@ export function newAsteriusInstance(req) {
       const tid = await __asterius_exports.rts_evalLazyIO(
         __asterius_exports.rts_apply(
           __asterius_exports.rts_apply(
-            __asterius_stableptr_manager.deRefStablePtr(sp), __asterius_exports.rts_mkInt(
+            __asterius_stableptr_manager.deRefStablePtr(sp), __asterius_exports.rts_mkStablePtr(
               __asterius_stableptr_manager.newJSVal(x))),
-          __asterius_exports.rts_mkInt(
+          __asterius_exports.rts_mkStablePtr(
             __asterius_stableptr_manager.newJSVal(y))));
       __asterius_exports.rts_checkSchedStatus(tid);
     },


### PR DESCRIPTION
This PR fixes the `makeHaskellCallback*` functions in `rts.mjs`, switching to use `rts_mkStablePtr` instead of `rts_mkInt` to construct `JSVal` closures on the heap. We switched the internal representation of `JSVal` to `StablePtr` a long time ago but missed the update here.