### PR TITLE
Optimize JSVal marshaling for exported functions

### DIFF
--- a/asterius/rts/rts.exports.mjs
+++ b/asterius/rts/rts.exports.mjs
@@ -32,12 +32,13 @@ async function rts_eval_common(e, f, p) {
 }
 
 export class Exports {
-  constructor(memory, reentrancy_guard, symbol_table, tso_manager, exports) {
+  constructor(memory, reentrancy_guard, symbol_table, tso_manager, exports, stableptr_manager) {
     this.context = Object.freeze({
       memory: memory,
       reentrancyGuard: reentrancy_guard,
       symbolTable: symbol_table,
-      tsoManager: tso_manager
+      tsoManager: tso_manager,
+      stablePtrManager: stableptr_manager
     });
     Object.assign(this, exports);
   }

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -51,7 +51,7 @@ export function newAsteriusInstance(req) {
     __asterius_float_cbits = new FloatCBits(__asterius_memory),
     __asterius_messages = new Messages(__asterius_memory, __asterius_fs),
     __asterius_unicode = new Unicode(),
-    __asterius_exports = new Exports(__asterius_memory, __asterius_reentrancy_guard, req.symbolTable, __asterius_tso_manager, req.exports),
+    __asterius_exports = new Exports(__asterius_memory, __asterius_reentrancy_guard, req.symbolTable, __asterius_tso_manager, req.exports, __asterius_stableptr_manager),
     __asterius_md5 = new MD5(__asterius_memory);
   __asterius_tso_manager.exports = __asterius_exports;
 


### PR DESCRIPTION
This PR optimizes the experience of passing `JSVal` as parameters and return value of exported functions.

Previously, users needed to manually create `JSVal` ids for parameters, and unwrap the result `JSVal` id to fetch the real JavaScript value. Now users can pass arbitrary JavaScript values directly as parameters, and get the JavaScript result value.

For example, say that we exported `f :: JSVal -> IO JSVal` in `x.hs`. In the entry module, we can just use `await i.exports.f(any_js_value)` to call `f` and get the result.