### PR TITLE
Switch alllocator to use a "freelist of segments"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,9 @@ jobs:
 
 
               # run test cases that can fail.
-              stack --no-terminal test asterius:ghc-testsuite  -j8 --test-arguments="--timeout=30s" || true
+              # We have some tests that take quite long, for example, CmpWord8.
+              # make the timeout generous (15 minutes) for these tests
+              stack --no-terminal test asterius:ghc-testsuite  -j8 --test-arguments="--timeout=900s" || true
               cp asterius/test-report.csv /tmp
               python3 asterius/test/format-ghc-testsuite-report.py /tmp/test-report.csv > /tmp/test-report-ascii.txt
               python3 asterius/test/group-common-tests-ghc-testsuite-report.py /tmp/test-report.csv > /tmp/test-report-grouped-by-error-ascii.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
 
             # Run parts of the ghc-testuite that we have enabled for
             # regression testing.
-            stack test asterius:ghc-testsuite --test-arguments="  --timeout=30s -l test/ghc-testsuite-filter";
+            stack test asterius:ghc-testsuite --test-arguments="  --timeout=300s -l test/ghc-testsuite-filter";
 
   asterius-test-ghc-testsuite:
     docker:

--- a/asterius/rts/rts.mblockalloc.mjs
+++ b/asterius/rts/rts.mblockalloc.mjs
@@ -56,6 +56,7 @@ export class MBlockAlloc {
       const blocks = Math.floor((r - start) / rtsConstants.block_size);
     
       if (req_blocks < blocks) {
+        console.log("allocating from free segment");
         this.memory.i32Store(bd + rtsConstants.offset_bdescr_blocks, req_blocks);
         const rest_bd = bd + (rtsConstants.mblock_size * n);
         assertBdescrAligned(rest_bd);
@@ -87,10 +88,12 @@ export class MBlockAlloc {
       }
 
       if (req_blocks == blocks) {
+        console.log("allocating from free segment");
         this.freeSegments.splice(i, 1);
         return bd;
       }
     }
+    console.log("allocating from new segment");
     const mblock = this.getMBlocks(n),
           bd = mblock + rtsConstants.offset_first_bdescr,
           block_addr = mblock + rtsConstants.offset_first_block;
@@ -133,8 +136,5 @@ export class MBlockAlloc {
       r = sorted_bds[i + 1] - rtsConstants.offset_first_bdescr;
       this.freeSegment(l_end, r);
     }
-    // this.freeList.sort(
-    //     (bd0, bd1) => this.memory.i32Load(bd0 + rtsConstants.offset_bdescr_blocks) -
-    //               this.memory.i32Load(bd1 + rtsConstants.offset_bdescr_blocks));
   }
 }

--- a/asterius/rts/rts.mblockalloc.mjs
+++ b/asterius/rts/rts.mblockalloc.mjs
@@ -53,6 +53,14 @@ export class MBlockAlloc {
       assertMblockAligned(mblock);
       const start = mblock + rtsConstants.offset_first_block;
       const blocks = Math.floor((r - start) / rtsConstants.block_size);
+
+      // we have enough blocks, so we should initialize bd
+      if (req_blocks <= blocks) {
+        this.memory.i64Store(bd + rtsConstants.offset_bdescr_start, start);
+        this.memory.i64Store(bd + rtsConstants.offset_bdescr_free, start);
+        this.memory.i64Store(bd + rtsConstants.offset_bdescr_link, 0);
+        this.memory.i32Store(bd + rtsConstants.offset_bdescr_blocks, req_blocks);
+      }
     
       if (req_blocks < blocks) {
         this.memory.i32Store(bd + rtsConstants.offset_bdescr_blocks, req_blocks);
@@ -89,14 +97,9 @@ export class MBlockAlloc {
     if (l_end < r) {
         // memset a custom number purely for debugging help.
         this.memory.memset(l_end, 0x42 + i, r - l_end);
+
         const bd = l_end + rtsConstants.offset_first_bdescr;
         assertBdescrAligned(bd);
-        const start = l_end + rtsConstants.offset_first_block;
-        const blocks = Math.floor((r - start) / rtsConstants.block_size);
-        this.memory.i64Store(bd + rtsConstants.offset_bdescr_start, start);
-        this.memory.i64Store(bd + rtsConstants.offset_bdescr_free, start);
-        this.memory.i64Store(bd + rtsConstants.offset_bdescr_link, 0);
-        this.memory.i32Store(bd + rtsConstants.offset_bdescr_blocks, blocks);
         this.freeSegments.push([bd, r])
     }
   }

--- a/asterius/rts/rts.mblockalloc.mjs
+++ b/asterius/rts/rts.mblockalloc.mjs
@@ -68,7 +68,11 @@ export class MBlockAlloc {
       if (req_blocks <= blocks) {
         this.setupBdescr(bd, start, req_blocks);
       }
+      else {
+        continue;
+      }
     
+      // we have extra mblocks, so we should create a new bd.
       if (req_blocks < blocks) {
         this.memory.i32Store(bd + rtsConstants.offset_bdescr_blocks, req_blocks);
         const rest_mblock = mblock + (rtsConstants.mblock_size * n);
@@ -76,11 +80,12 @@ export class MBlockAlloc {
         this.freeSegments.splice(i, 1, [rest_mblock, r]);
       }
 
-
+      // we don't have extra.
       if (req_blocks == blocks) {
         this.freeSegments.splice(i, 1);
-        return bd;
       }
+
+      return bd;
     }
 
     const mblock = this.getMBlocks(n),

--- a/asterius/rts/rts.mblockalloc.mjs
+++ b/asterius/rts/rts.mblockalloc.mjs
@@ -44,8 +44,8 @@ export class MBlockAlloc {
 
   allocMegaGroup(n) {
     const req_blocks = 
-          ((rtsConstants.mblock_size * n) - rtsConstants.offset_first_block) / 
-          rtsConstants.block_size;
+          Math.ceil(((rtsConstants.mblock_size * n) - rtsConstants.offset_first_block) / 
+          rtsConstants.block_size);
 
     for (let i = 0; i < this.freeSegments.length; ++i) {
       const [bd, r] = this.freeSegments[i];
@@ -60,13 +60,14 @@ export class MBlockAlloc {
         const rest_bd = bd + (rtsConstants.mblock_size * n);
         assertBdescrAligned(rest_bd);
         const rest_start = rest_bd - rtsConstants.offset_first_bdescr + rtsConstants.offset_first_block;
+        const rest_blocks = Math.floor((r - rest_start) / rtsConstants.block_size);
         this.memory.i64Store(rest_bd + rtsConstants.offset_bdescr_start, rest_start);
         this.memory.i64Store(rest_bd + rtsConstants.offset_bdescr_free, rest_start);
         this.memory.i64Store(rest_bd + rtsConstants.offset_bdescr_link, 0);
         // 0xDEADBEEF = 3735928559
-        this.memory.i32Store(rest_bd + rtsConstants.offset_bdescr_blocks, 0xDEADBEEF);
-        // this.freeSegments.splice(i, 1, [rest_bd, r]);
-        this.freeSegments.splice(i, 1);
+        this.memory.i32Store(rest_bd + rtsConstants.offset_bdescr_blocks, rest_blocks);
+        this.freeSegments.splice(i, 1, [rest_bd, r]);
+        // this.freeSegments.splice(i, 1);
 
         
         // this.memory.i32Store(bd + rtsConstants.offset_bdescr_blocks, req_blocks);
@@ -106,7 +107,7 @@ export class MBlockAlloc {
         const bd = l_end + rtsConstants.offset_first_bdescr;
         assertBdescrAligned(bd);
         const start = l_end + rtsConstants.offset_first_block;
-        const blocks = (r - start) / rtsConstants.block_size;
+        const blocks = Math.floor((r - start) / rtsConstants.block_size);
         this.memory.i64Store(bd + rtsConstants.offset_bdescr_start, start);
         this.memory.i64Store(bd + rtsConstants.offset_bdescr_free, start);
         this.memory.i64Store(bd + rtsConstants.offset_bdescr_link, 0);

--- a/asterius/rts/rts.mblockalloc.mjs
+++ b/asterius/rts/rts.mblockalloc.mjs
@@ -56,7 +56,7 @@ export class MBlockAlloc {
       const blocks = Math.floor((r - start) / rtsConstants.block_size);
     
       if (req_blocks < blocks) {
-        console.log("allocating from free segment");
+        // console.log("allocating from free segment");
         this.memory.i32Store(bd + rtsConstants.offset_bdescr_blocks, req_blocks);
         const rest_bd = bd + (rtsConstants.mblock_size * n);
         assertBdescrAligned(rest_bd);
@@ -88,12 +88,12 @@ export class MBlockAlloc {
       }
 
       if (req_blocks == blocks) {
-        console.log("allocating from free segment");
+        // console.log("allocating from free segment");
         this.freeSegments.splice(i, 1);
         return bd;
       }
     }
-    console.log("allocating from new segment");
+    // console.log("allocating from new segment");
     const mblock = this.getMBlocks(n),
           bd = mblock + rtsConstants.offset_first_bdescr,
           block_addr = mblock + rtsConstants.offset_first_block;

--- a/asterius/rts/rts.mblockalloc.mjs
+++ b/asterius/rts/rts.mblockalloc.mjs
@@ -101,7 +101,6 @@ export class MBlockAlloc {
   preserveMegaGroups(bds) {
     this.freeSegments = [];
     const sorted_bds = Array.from(bds).sort((bd0, bd1) => bd0 - bd1);
-    sorted_bds.push(Memory.tagData(rtsConstants.mblock_size * this.capacity) + rtsConstants.offset_first_bdescr);
     this.freeSegment(0,
         Memory.tagData(rtsConstants.mblock_size * this.staticMBlocks),
         sorted_bds[0] - rtsConstants.offset_first_bdescr);
@@ -114,6 +113,5 @@ export class MBlockAlloc {
       r = sorted_bds[i + 1] - rtsConstants.offset_first_bdescr;
       this.freeSegment(i+1, l_end, r);
     }
-    this.size = this.capacity;
   }
 }

--- a/asterius/test/ghc-testsuite-filter
+++ b/asterius/test/ghc-testsuite-filter
@@ -2,7 +2,7 @@
 # !<regex> will blacklist stuff in <regex>. <regex> syntax given by whatever
 # is parsed by Regex.TDFA
 # Leading whitespace sensitive.
-numeric/|T9001
+numeric/|T9001|CmpWord8
 !CarryOverflow.hs
 !arith011
 !arith008


### PR DESCRIPTION
We change the freelist in the mblockallocator to become a list of "free segments". This eliminates error-prone bounds checking, and should be a more stable base for the megablock allocator. This should fix `CmpWord8`