### PR TITLE
Turn the scheduler into a background daemon

### DIFF
--- a/asterius/rts/rts.channel.mjs
+++ b/asterius/rts/rts.channel.mjs
@@ -1,0 +1,17 @@
+export class Channel {
+  constructor() {
+    this.init();
+    Object.seal(this);
+  }
+
+  init() {
+    this.promise = new Promise((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    }).then(r => (this.init(), r), err => (this.init(), Promise.reject(err)));
+  }
+
+  take() {
+    return this.promise;
+  }
+}

--- a/asterius/rts/rts.exports.mjs
+++ b/asterius/rts/rts.exports.mjs
@@ -1,39 +1,56 @@
+import { Channel } from "./rts.channel.mjs";
 import * as rtsConstants from "./rts.constants.mjs";
 
-async function rts_eval_common(e, f, p) {
+async function scheduler_loop(e) {
   e.context.reentrancyGuard.enter(0);
-  const tso = e[f](p);
-  e.context.memory.i64Store(
-    e.context.symbolTable.__asterius_func,
-    e.context.symbolTable.stg_returnToStackTop
-  );
   while (true) {
-    e.scheduleWaitThread(tso, false);
-    const ret = Number(
-      e.context.memory.i64Load(
-        e.context.symbolTable.MainCapability +
-          rtsConstants.offset_Capability_r +
-          rtsConstants.offset_StgRegTable_rRet
-      )
+    const [f, p, resolve, reject] = await e.context.channel.take(),
+      tso = e[f](p);
+    e.context.memory.i64Store(
+      e.context.symbolTable.__asterius_func,
+      e.context.symbolTable.stg_returnToStackTop
     );
-    switch (ret) {
-      case 4: {
-        await e.context.tsoManager.promise;
-        break;
+    let running = true;
+    while (running) {
+      e.scheduleWaitThread(tso, false);
+      const ret = Number(
+        e.context.memory.i64Load(
+          e.context.symbolTable.MainCapability +
+            rtsConstants.offset_Capability_r +
+            rtsConstants.offset_StgRegTable_rRet
+        )
+      );
+      switch (ret) {
+        case 4: {
+          await e.context.tsoManager.promise;
+          break;
+        }
+        case 5: {
+          resolve(e.context.tsoManager.getTSOid(tso));
+          running = false;
+          break;
+        }
+        default: {
+          reject(new WebAssembly.RuntimeError(`Invalid rRet ${ret}`));
+          running = false;
+          break;
+        }
       }
-      case 5: {
-        e.context.reentrancyGuard.exit(0);
-        return e.context.tsoManager.getTSOid(tso);
-      }
-      default:
-        throw new WebAssembly.RuntimeError(`Invalid rRet ${ret}`);
     }
   }
 }
 
 export class Exports {
-  constructor(memory, reentrancy_guard, symbol_table, tso_manager, exports, stableptr_manager) {
+  constructor(
+    memory,
+    reentrancy_guard,
+    symbol_table,
+    tso_manager,
+    exports,
+    stableptr_manager
+  ) {
     this.context = Object.freeze({
+      channel: new Channel(),
       memory: memory,
       reentrancyGuard: reentrancy_guard,
       symbolTable: symbol_table,
@@ -41,18 +58,25 @@ export class Exports {
       stablePtrManager: stableptr_manager
     });
     Object.assign(this, exports);
+    scheduler_loop(this);
   }
 
   rts_eval(p) {
-    return rts_eval_common(this, "createGenThread", p);
+    return new Promise((resolve, reject) =>
+      this.context.channel.resolve(["createGenThread", p, resolve, reject])
+    );
   }
 
   rts_evalIO(p) {
-    return rts_eval_common(this, "createStrictIOThread", p);
+    return new Promise((resolve, reject) =>
+      this.context.channel.resolve(["createStrictIOThread", p, resolve, reject])
+    );
   }
 
   rts_evalLazyIO(p) {
-    return rts_eval_common(this, "createIOThread", p);
+    return new Promise((resolve, reject) =>
+      this.context.channel.resolve(["createIOThread", p, resolve, reject])
+    );
   }
 
   main() {

--- a/asterius/rts/rts.exports.mjs
+++ b/asterius/rts/rts.exports.mjs
@@ -63,19 +63,19 @@ export class Exports {
 
   rts_eval(p) {
     return new Promise((resolve, reject) =>
-      this.context.channel.resolve(["createGenThread", p, resolve, reject])
+      this.context.channel.put(["createGenThread", p, resolve, reject])
     );
   }
 
   rts_evalIO(p) {
     return new Promise((resolve, reject) =>
-      this.context.channel.resolve(["createStrictIOThread", p, resolve, reject])
+      this.context.channel.put(["createStrictIOThread", p, resolve, reject])
     );
   }
 
   rts_evalLazyIO(p) {
     return new Promise((resolve, reject) =>
-      this.context.channel.resolve(["createIOThread", p, resolve, reject])
+      this.context.channel.put(["createIOThread", p, resolve, reject])
     );
   }
 

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -104,7 +104,7 @@ export function newAsteriusInstance(req) {
       stdout: () => __asterius_fs.root.get("/dev/stdout"),
       stderr: () => __asterius_fs.root.get("/dev/stderr")
     },
-    setPromise: (vt, p) => __asterius_tso_manager.setPromise(vt, p)
+    setPromise: (i, vt, p) => __asterius_tso_manager.setPromise(i, vt, p)
   };
   const importObject = Object.assign(
     req.jsffiFactory(__asterius_jsffi_instance),

--- a/asterius/rts/rts.tso.mjs
+++ b/asterius/rts/rts.tso.mjs
@@ -54,7 +54,7 @@ export class TSOManager {
     return this.memory.i32Load(tso + rtsConstants.offset_StgTSO_id);
   }
 
-  setPromise(vt, p) {
+  setPromise(i, vt, p) {
     this.promise = p.then(
       r => {
         switch (vt) {
@@ -103,7 +103,7 @@ export class TSOManager {
     );
   }
 
-  resetPromise() {
+  resetPromise(i) {
     this.promise = undefined;
     this.memory.memset(this.symbolTable.__asterius_func, 0, 8);
     this.memory.memset(this.symbolTable.__asterius_regs, 0, 1024);

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -323,7 +323,7 @@ rtsFunctionImports debug =
       { internalName = "__asterius_resetPromise"
       , externalModuleName = "TSO"
       , externalBaseName = "resetPromise"
-      , functionType = FunctionType {paramTypes = [], returnTypes = []}
+      , functionType = FunctionType {paramTypes = [I32], returnTypes = []}
       }
   , FunctionImport
       { internalName = "__asterius_hpAlloc"


### PR DESCRIPTION
This PR is the first step towards multi-threading in asterius: turn the scheduler into a background daemon.

The `rts_eval*` functions are the exposed rts interfaces for evaluation. Previously, each call to `rts_eval*` maps to a call to the scheduler loop which returns asynchronously. However, it's apparent that:

* The scheduler loop is non-reentrant, and a `rts_eval*` call cannot be made before the previous one returns
* During evaluation, we may encounter other evaluation requests (e.g. from `fork#`)
* When a `rts_eval*` call is supposed to return, there may be ongoing background evaluation work.

To better coordinate the evaluation of multiple closures, we now daemonize the scheduler loop:

* A `Channel` JavaScript class is implemented for passing evaluation requests.
* The `Exports` class constructor kicks off a scheduler loop immediately. The loop `await`s requests from the `Channel`.
* All `rts_eval*` calls now simply send requests to the `Channel`, and the result will be available asynchronously.

Since we now work with a single global scheduler loop, it'll be much easier to do the bookkeeping for multiple threads.