### PR TITLE
Debug the crash that we get on writing 0x42 in freeSegment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,17 @@
 version: 2
 
 jobs:
-  asterius-test:
+  asterius-boot:
     docker:
       - image: debian:unstable
     environment:
-      - ASTERIUS_BUILD_OPTIONS: -j8
+      - ASTERIUS_BUILD_OPTIONS: -j2
       - DEBIAN_FRONTEND: noninteractive
-      - GHCRTS: -A512M -I0 -qg -qb -N8
+      - GHCRTS: -N2
       - LANG: C.UTF-8
-      - MAKEFLAGS: -j8
+      - MAKEFLAGS: -j2
       - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-      - STACK_ROOT: /tmp/.stack
-    resource_class: xlarge
-    working_directory: /tmp/asterius
+      - WABT_BINDIR: /root/.local/bin
     steps:
       - run:
           name: Install dependencies
@@ -43,16 +41,72 @@ jobs:
             apt install -y nodejs
             mkdir -p /root/.local/bin
             curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C /root/.local/bin '*/stack'
-            curl https://downloads.haskell.org/~cabal/cabal-install-latest/cabal-install-2.4.1.0-x86_64-unknown-linux.tar.xz | tar xJ -C /root/.local/bin 'cabal'
       - checkout
 
       - run:
-          name: Build asterius
+          name: Boot
           command: |
             git submodule update --init --recursive
-            stack --no-terminal -j8 build --test --no-run-tests
+            stack --no-terminal -j2 build --test --no-run-tests
             stack --no-terminal exec ahc-boot
 
+      - persist_to_workspace:
+          root: /root
+          paths:
+            - .local
+            - .stack
+            - project/.stack-work
+            - project/asterius/.stack-work
+            - project/binaryen/.stack-work
+            - project/ghc-toolkit/.stack-work
+            - project/inline-js/inline-js-core/.stack-work
+            - project/npm-utils/.stack-work
+            - project/wabt/.stack-work
+            - project/wasm-toolkit/.stack-work
+            - project/stack.yaml.lock
+
+  asterius-test:
+    docker:
+      - image: debian:unstable
+    environment:
+      - DEBIAN_FRONTEND: noninteractive
+      - GHCRTS: -N2
+      - LANG: C.UTF-8
+      - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apt update
+            apt full-upgrade -y
+            apt install -y \
+              automake \
+              cmake \
+              curl \
+              g++ \
+              git \
+              gnupg \
+              libffi-dev \
+              libgmp-dev \
+              libncurses-dev \
+              libnuma-dev \
+              make \
+              openssh-client \
+              python-minimal \
+              python3-minimal \
+              xz-utils \
+              zlib1g-dev
+            curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+            echo "deb https://deb.nodesource.com/node_12.x sid main" > /etc/apt/sources.list.d/nodesource.list
+            apt update
+            apt install -y nodejs
+      - checkout
+      - run:
+          name: Initialize submodules
+          command: |
+            git submodule update --init --recursive
+      - attach_workspace:
+          at: /root
       - run:
           name: Test asterius
           command: |
@@ -73,9 +127,9 @@ jobs:
             stack --no-terminal test asterius:fib --test-arguments="--no-gc-sections"
             stack --no-terminal test asterius:fib --test-arguments="--binaryen --no-gc-sections"
 
-            cd ~/.local
-            $CIRCLE_WORKING_DIRECTORY/utils/v8-node.py
-            cd $CIRCLE_WORKING_DIRECTORY
+            cd /root/.local
+            /root/project/utils/v8-node.py
+            cd /root/project
             stack --no-terminal test asterius:fib --test-arguments="--debug" > /dev/null
             stack --no-terminal test asterius:jsffi --test-arguments="--debug" > /dev/null
             stack --no-terminal test asterius:array --test-arguments="--debug" > /dev/null
@@ -94,21 +148,16 @@ jobs:
 
             # Run parts of the ghc-testuite that we have enabled for
             # regression testing.
-            stack test asterius:ghc-testsuite --test-arguments="  --timeout=30s -l test/ghc-testsuite-filter";
+            stack test asterius:ghc-testsuite --test-arguments="--timeout=30s -l test/ghc-testsuite-filter";
 
   asterius-test-ghc-testsuite:
     docker:
       - image: debian:unstable
     environment:
-      - ASTERIUS_BUILD_OPTIONS: -j8
       - DEBIAN_FRONTEND: noninteractive
-      - GHCRTS: -A512M -I0 -qg -qb -N8
+      - GHCRTS: -N2
       - LANG: C.UTF-8
-      - MAKEFLAGS: -j8
       - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-      - STACK_ROOT: /tmp/.stack
-    resource_class: xlarge
-    working_directory: /tmp/asterius
     steps:
       - run:
           name: Install dependencies
@@ -137,22 +186,15 @@ jobs:
             echo "deb https://deb.nodesource.com/node_12.x sid main" > /etc/apt/sources.list.d/nodesource.list
             apt update
             apt install -y nodejs
-            nodejs --version
-            mkdir -p /root/.local/bin
-            curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C /root/.local/bin '*/stack'
-            curl https://downloads.haskell.org/~cabal/cabal-install-latest/cabal-install-2.4.1.0-x86_64-unknown-linux.tar.xz | tar xJ -C /root/.local/bin 'cabal'
+            node --version
 
       - checkout
       - run:
-            name: Build asterius
-            command: |
-              git submodule update --init --recursive
-              stack --no-terminal -j8 build --test --no-run-tests
-              stack --no-terminal exec ahc-boot
-
-              cd ~/.local
-              $CIRCLE_WORKING_DIRECTORY/utils/v8-node.py
-              cd $CIRCLE_WORKING_DIRECTORY
+          name: Initialize submodules
+          command: |
+            git submodule update --init --recursive
+      - attach_workspace:
+          at: /root
 
       - run:
             name: Run GHC test suite on asterius
@@ -161,23 +203,215 @@ jobs:
             no_output_timeout: 30m
             command: |
               # run the GHC testsuite and copy the test artifact to `/tmp`
-              nodejs --version
+              node --version
 
 
               # run test cases that can fail.
-              stack --no-terminal test asterius:ghc-testsuite  -j8 --test-arguments="--timeout=30s" || true
+              stack --no-terminal test asterius:ghc-testsuite --test-arguments="--timeout=30s" || true
               cp asterius/test-report.csv /tmp
-              python3 asterius/test/format-ghc-testsuite-report.py /tmp/test-report.csv > /tmp/test-report-ascii.txt
-              python3 asterius/test/group-common-tests-ghc-testsuite-report.py /tmp/test-report.csv > /tmp/test-report-grouped-by-error-ascii.txt
 
       - store_artifacts:
           path: /tmp/test-report.csv
 
-      - store_artifacts:
-          path: /tmp/test-report-ascii.txt
+  asterius-test-ghc-testsuite-yolo:
+    docker:
+      - image: debian:unstable
+    environment:
+      - ASTERIUS_GHC_TESTSUITE_OPTIONS: --yolo
+      - DEBIAN_FRONTEND: noninteractive
+      - GHCRTS: -N2
+      - LANG: C.UTF-8
+      - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apt update
+            apt full-upgrade -y
+            apt install -y python3-numpy python3-pandas python3-terminaltables
+            apt install -y \
+              automake \
+              cmake \
+              curl \
+              g++ \
+              git \
+              gnupg \
+              libffi-dev \
+              libgmp-dev \
+              libncurses-dev \
+              libnuma-dev \
+              make \
+              openssh-client \
+              python-minimal \
+              python3-minimal \
+              xz-utils \
+              zlib1g-dev
+            curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+            echo "deb https://deb.nodesource.com/node_12.x sid main" > /etc/apt/sources.list.d/nodesource.list
+            apt update
+            apt install -y nodejs
+            node --version
+
+      - checkout
+      - run:
+          name: Initialize submodules
+          command: |
+            git submodule update --init --recursive
+      - attach_workspace:
+          at: /root
+
+      - run:
+            name: Run GHC test suite on asterius
+            # Allow a large timeout so we have enough time to write out the
+            # CSV file.
+            no_output_timeout: 30m
+            command: |
+              # run the GHC testsuite and copy the test artifact to `/tmp`
+              node --version
+
+
+              # run test cases that can fail.
+              stack --no-terminal test asterius:ghc-testsuite --test-arguments="--timeout=30s" || true
+              cp asterius/test-report.csv /tmp
 
       - store_artifacts:
-          path: /tmp/test-report-grouped-by-error-ascii.txt
+          path: /tmp/test-report.csv
+
+  asterius-test-ghc-testsuite-debug:
+    docker:
+      - image: debian:unstable
+    environment:
+      - ASTERIUS_GHC_TESTSUITE_OPTIONS: --debug
+      - DEBIAN_FRONTEND: noninteractive
+      - GHCRTS: -N2
+      - LANG: C.UTF-8
+      - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apt update
+            apt full-upgrade -y
+            apt install -y python3-numpy python3-pandas python3-terminaltables
+            apt install -y \
+              automake \
+              cmake \
+              curl \
+              g++ \
+              git \
+              gnupg \
+              libffi-dev \
+              libgmp-dev \
+              libncurses-dev \
+              libnuma-dev \
+              make \
+              openssh-client \
+              python-minimal \
+              python3-minimal \
+              xz-utils \
+              zlib1g-dev
+            curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+            echo "deb https://deb.nodesource.com/node_12.x sid main" > /etc/apt/sources.list.d/nodesource.list
+            apt update
+            apt install -y nodejs
+            node --version
+
+      - checkout
+      - run:
+          name: Initialize submodules
+          command: |
+            git submodule update --init --recursive
+      - attach_workspace:
+          at: /root
+
+      - run:
+            name: Run GHC test suite on asterius
+            # Allow a large timeout so we have enough time to write out the
+            # CSV file.
+            no_output_timeout: 30m
+            command: |
+              cd /root/.local
+              /root/project/utils/v8-node.py
+              cd /root/project
+
+              # run the GHC testsuite and copy the test artifact to `/tmp`
+              node --version
+
+
+              # run test cases that can fail.
+              stack --no-terminal test asterius:ghc-testsuite --test-arguments="--timeout=30s" || true
+              cp asterius/test-report.csv /tmp
+
+      - store_artifacts:
+          path: /tmp/test-report.csv
+
+  asterius-test-ghc-testsuite-debug-yolo:
+    docker:
+      - image: debian:unstable
+    environment:
+      - ASTERIUS_GHC_TESTSUITE_OPTIONS: --debug --yolo
+      - DEBIAN_FRONTEND: noninteractive
+      - GHCRTS: -N2
+      - LANG: C.UTF-8
+      - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apt update
+            apt full-upgrade -y
+            apt install -y python3-numpy python3-pandas python3-terminaltables
+            apt install -y \
+              automake \
+              cmake \
+              curl \
+              g++ \
+              git \
+              gnupg \
+              libffi-dev \
+              libgmp-dev \
+              libncurses-dev \
+              libnuma-dev \
+              make \
+              openssh-client \
+              python-minimal \
+              python3-minimal \
+              xz-utils \
+              zlib1g-dev
+            curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+            echo "deb https://deb.nodesource.com/node_12.x sid main" > /etc/apt/sources.list.d/nodesource.list
+            apt update
+            apt install -y nodejs
+            node --version
+
+      - checkout
+      - run:
+          name: Initialize submodules
+          command: |
+            git submodule update --init --recursive
+      - attach_workspace:
+          at: /root
+
+      - run:
+            name: Run GHC test suite on asterius
+            # Allow a large timeout so we have enough time to write out the
+            # CSV file.
+            no_output_timeout: 30m
+            command: |
+              cd /root/.local
+              /root/project/utils/v8-node.py
+              cd /root/project
+
+              # run the GHC testsuite and copy the test artifact to `/tmp`
+              node --version
+
+
+              # run test cases that can fail.
+              stack --no-terminal test asterius:ghc-testsuite --test-arguments="--timeout=30s" || true
+              cp asterius/test-report.csv /tmp
+
+      - store_artifacts:
+          path: /tmp/test-report.csv
 
   asterius-build-docker:
     docker:
@@ -208,6 +442,13 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
       LANG: C.UTF-8
     steps:
+      - run:
+          name: Ensure we are on `tweag/asterius`
+          command: |
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              echo "Nothing to do for forked PRs, so marking this step successful"
+              circleci step halt
+            fi
       - run:
           name: Install dependencies
           command: |
@@ -268,8 +509,22 @@ workflows:
   version: 2
   build:
     jobs:
-      - asterius-test
-      - asterius-test-ghc-testsuite
+      - asterius-boot
+      - asterius-test:
+          requires:
+            - asterius-boot
+      - asterius-test-ghc-testsuite:
+          requires:
+            - asterius-boot
+      - asterius-test-ghc-testsuite-yolo:
+          requires:
+            - asterius-boot
+      - asterius-test-ghc-testsuite-debug:
+          requires:
+            - asterius-boot
+      - asterius-test-ghc-testsuite-debug-yolo:
+          requires:
+            - asterius-boot
       - asterius-build-docker
       - asterius-build-docs
       - asterius-update-docker-tag:

--- a/asterius/rts/rts.gc.mjs
+++ b/asterius/rts/rts.gc.mjs
@@ -372,7 +372,12 @@ export class GC {
   scavengeClosure(c) {
     const info = Number(this.memory.i64Load(c)),
           type = this.memory.i32Load(info + rtsConstants.offset_StgInfoTable_type);
-    if (!this.infoTables.has(info)) throw new WebAssembly.RuntimeError();
+    if (!this.infoTables.has(info)) { 
+      console.log(`ticks = []`);
+      console.log(`ticks.append(("c", ${c}))`);
+      // console.log(`ticks.append("info", ${info})`);
+      throw new WebAssembly.RuntimeError(`c: ${c} | info: ${info}`);
+    }
     switch (info) {
       case this.symbolTable.base_GHCziStable_StablePtr_con_info:
       case this.symbolTable.integerzmwiredzmin_GHCziIntegerziType_Integer_con_info: {

--- a/asterius/rts/rts.gc.mjs
+++ b/asterius/rts/rts.gc.mjs
@@ -552,7 +552,7 @@ export class GC {
 
     this.evacuateClosure(tso);
     this.scavengeWorkList();
-    this.mblockAlloc.preserveMegaGroups(this.liveMBlocks);
+    this.mblockAlloc.preserveMegaGroups(this.liveMBlocks, this.heapAlloc.getPools());
     this.stablePtrManager.preserveJSVals(this.liveJSVals);
     this.closureIndirects.clear();
     this.liveMBlocks.clear();

--- a/asterius/rts/rts.heapalloc.mjs
+++ b/asterius/rts/rts.heapalloc.mjs
@@ -37,12 +37,19 @@ export class HeapAlloc {
                                              rtsConstants.offset_bdescr_blocks),
         current_limit = current_start + rtsConstants.block_size * current_blocks,
         new_free = current_free + b;
+
     if (new_free <= current_limit) {
       this.memory.i64Store(
           this.currentPools[pool_i] + rtsConstants.offset_bdescr_free, new_free);
       return current_free;
     }
-    this.currentPools[pool_i] = this.hpAlloc(b);
+
+    const new_pool = this.hpAlloc(b);
+    console.log(`# pool_i: ${pool_i}`);
+    console.log(`# | currentPools: [${[...this.currentPools]}]`);
+    console.log(`# | overwriting old heap pool: ${this.currentPools[pool_i]}`);
+    console.log(`# | new pool: ${new_pool}`);
+    this.currentPools[pool_i] = new_pool;
     if (pool_i)
       this.memory.i16Store(
           this.currentPools[pool_i] + rtsConstants.offset_bdescr_flags,

--- a/asterius/rts/rts.heapalloc.mjs
+++ b/asterius/rts/rts.heapalloc.mjs
@@ -55,4 +55,17 @@ export class HeapAlloc {
     return current_free;
   }
   allocatePinned(n) { return this.allocate(n, true); }
+
+  getPools() {
+    let pools = []
+    for(let i = 0; i < 2; ++i) {
+      const bd = this.currentPools[i];
+      const start = Number(this.memory.i64Load(bd + rtsConstants.offset_bdescr_start));
+      const blocks = this.memory.i32Load(bd + rtsConstants.offset_bdescr_blocks);
+      const end = start + blocks * rtsConstants.block_size;
+
+      pools.push([bd, start, end]);
+    }
+    return pools;
+  }
 }

--- a/asterius/rts/rts.heapalloc.mjs
+++ b/asterius/rts/rts.heapalloc.mjs
@@ -60,11 +60,7 @@ export class HeapAlloc {
     let pools = []
     for(let i = 0; i < 2; ++i) {
       const bd = this.currentPools[i];
-      const start = Number(this.memory.i64Load(bd + rtsConstants.offset_bdescr_start));
-      const blocks = this.memory.i32Load(bd + rtsConstants.offset_bdescr_blocks);
-      const end = start + blocks * rtsConstants.block_size;
-
-      pools.push([bd, start, end]);
+      pools.push(bd); //[bd, start, end]);
     }
     return pools;
   }

--- a/asterius/rts/rts.mblockalloc.mjs
+++ b/asterius/rts/rts.mblockalloc.mjs
@@ -74,7 +74,7 @@ export class MBlockAlloc {
           // ---
           // this.freeList.splice(i, 1, [rest_start, r]);
           // this.freeList.splice(i, 1, [rest_start, r]);
-          this.freeList.splice(i, 1);
+          this.freeList.splice(i, 1, [rest_bd, r]);
         } else {
           this.freeList.splice(i, 1);
         } // end req_blocks < blocks

--- a/asterius/rts/rts.mblockalloc.mjs
+++ b/asterius/rts/rts.mblockalloc.mjs
@@ -61,19 +61,6 @@ export class MBlockAlloc {
             ((rtsConstants.mblock_size / rtsConstants.block_size) -
               rtsConstants.blocks_per_mblock);
           this.setupBdescr(rest_bd, rest_start, rest_nblocks);
-          // ---
-          // this.memory.i64Store(rest_bd + rtsConstants.offset_bdescr_start,
-          //                      rest_start);
-          // this.memory.i64Store(rest_bd + rtsConstants.offset_bdescr_free, rest_start);
-          // this.memory.i64Store(rest_bd + rtsConstants.offset_bdescr_link, 0);
-          // this.memory.i32Store(rest_bd + rtsConstants.offset_bdescr_blocks,
-          //                      blocks - req_blocks -
-          //                          ((rtsConstants.mblock_size / rtsConstants.block_size) -
-          //                           rtsConstants.blocks_per_mblock));
-          // this.freeList.splice(i, 1, rest_bd);
-          // ---
-          // this.freeList.splice(i, 1, [rest_start, r]);
-          // this.freeList.splice(i, 1, [rest_start, r]);
           this.freeList.splice(i, 1, [rest_bd, r]);
         } else {
           this.freeList.splice(i, 1);
@@ -87,10 +74,6 @@ export class MBlockAlloc {
           bd = mblock + rtsConstants.offset_first_bdescr,
           block_addr = mblock + rtsConstants.offset_first_block;
     this.setupBdescr(bd, block_addr, req_blocks);
-    // this.memory.i64Store(bd + rtsConstants.offset_bdescr_start, block_addr);
-    // this.memory.i64Store(bd + rtsConstants.offset_bdescr_free, block_addr);
-    // this.memory.i64Store(bd + rtsConstants.offset_bdescr_link, 0);
-    // this.memory.i32Store(bd + rtsConstants.offset_bdescr_blocks, req_blocks);
     this.all_bds.add(bd);
     return bd;
   }

--- a/asterius/rts/rts.mblockalloc.mjs
+++ b/asterius/rts/rts.mblockalloc.mjs
@@ -67,7 +67,7 @@ export class MBlockAlloc {
 
   freeSegment(l_end, r) {
     if (l_end < r) {
-      this.memory.memset(l_end, 0, r - l_end);
+      this.memory.memset(l_end, 0x42, r - l_end);
       const bd = l_end + rtsConstants.offset_first_bdescr,
             start = l_end + rtsConstants.offset_first_block,
             blocks = (r - start) / rtsConstants.block_size;

--- a/asterius/rts/rts.mblockalloc.mjs
+++ b/asterius/rts/rts.mblockalloc.mjs
@@ -1,5 +1,6 @@
 import * as rtsConstants from "./rts.constants.mjs";
 import { Memory } from "./rts.memory.mjs";
+import * as assert from "assert"
 
 export class MBlockAlloc {
   constructor() {
@@ -21,6 +22,7 @@ export class MBlockAlloc {
   }
 
   getMBlocks(n) {
+    assert.equal(n > 0, true);
     if (this.size + n > this.capacity) {
       const d = Math.max(n, this.capacity);
       this.memory.grow(d * (rtsConstants.mblock_size / rtsConstants.pageSize));
@@ -28,7 +30,7 @@ export class MBlockAlloc {
     }
     const prev_size = this.size;
     this.size += n;
-    let mblock =  Memory.tagData(prev_size * rtsConstants.mblock_size);
+    let mblock = Memory.tagData(prev_size * rtsConstants.mblock_size);
     this.all_bds.add(mblock + rtsConstants.offset_first_bdescr);
     return mblock;
   }
@@ -93,6 +95,7 @@ export class MBlockAlloc {
 
     for(let i = 0; i < heapPools.length; ++i) {
       const [bd, l, r] = heapPools[i];
+      // add the heap pool into the used block descriptors list.
       bds.add(bd);
       console.log(`segments.append([${l}, ${r}, "heappool"])`);
     }
@@ -115,7 +118,7 @@ export class MBlockAlloc {
 
     this.freeList = [];
     const sorted_bds = Array.from(bds).sort((bd0, bd1) => bd0 - bd1);
-    sorted_bds.push(Memory.tagData(rtsConstants.mblock_size * this.capacity) + rtsConstants.offset_first_bdescr);
+    // sorted_bds.push(Memory.tagData(rtsConstants.mblock_size * this.capacity) + rtsConstants.offset_first_bdescr);
 
 
     
@@ -136,7 +139,7 @@ export class MBlockAlloc {
         (bd0, bd1) => this.memory.i32Load(bd0 + rtsConstants.offset_bdescr_blocks) -
                   this.memory.i32Load(bd1 + rtsConstants.offset_bdescr_blocks));
 
-    console.log(`draw_segments(segments)`);
+    // console.log(`draw_segments(segments)`);
     console.log(`####### run ipython -i draw.py and copy-paste code in between #####`);
   }
 }

--- a/asterius/rts/rts.mblockalloc.mjs
+++ b/asterius/rts/rts.mblockalloc.mjs
@@ -142,9 +142,8 @@ export class MBlockAlloc {
       const flags = this.memory.i16Load(bd + rtsConstants.offset_bdescr_flags);
       // if we are in a heap region, then just don't touch it
       // similarly, if we are in a pinned region, don't touch it
-      if (heapPoolsSet.has(bd) || flags & rtsConstants.BF_PINNED) {
-        continue;
-        // l_end = l_start - rtsConstants.offset_bdescr_start + rtsConstants.mblock_size;
+      if (heapPoolsSet.has(bd)) {
+        l_end = l_start - rtsConstants.offset_bdescr_start + rtsConstants.mblock_size;
       }
 
       const r = bd_next - rtsConstants.offset_first_bdescr;

--- a/asterius/test/fib/fib.hs
+++ b/asterius/test/fib/fib.hs
@@ -63,38 +63,37 @@ main = do
 
   performGC
 
-  putStrLn $ "xx"
   -- Test that assert_eq works
-  -- assert_eq_i64 10 10
+  assert_eq_i64 10 10
 
-  -- print_i64 $ fib 10
-  -- assert_eq_i64 (fib 10) 55
+  print_i64 $ fib 10
+  assert_eq_i64 (fib 10) 55
 
-  -- print_i64 $ fact 5
-  -- assert_eq_i64 (fact 5) 120
+  print_i64 $ fact 5
+  assert_eq_i64 (fact 5) 120
 
-  -- print_f64 $ cos 0.5
-  -- print_f64 $ 2 ** 3
+  print_f64 $ cos 0.5
+  print_f64 $ 2 ** 3
 
-  -- let sizeof3Tree = sizeofBinTree $ force $ genBinTree 3
-  -- print_i64 $ sizeof3Tree
-  -- -- 2^4 - 1
-  -- assert_eq_i64 sizeof3Tree 15
+  let sizeof3Tree = sizeofBinTree $ force $ genBinTree 3
+  print_i64 $ sizeof3Tree
+  -- 2^4 - 1
+  assert_eq_i64 sizeof3Tree 15
 
-  -- let sizeof5Tree = sizeofBinTree $ force $ genBinTree 5
-  -- print_i64 $ sizeof5Tree
-  -- -- 2^6 - 1
-  -- assert_eq_i64 sizeof5Tree 63
+  let sizeof5Tree = sizeofBinTree $ force $ genBinTree 5
+  print_i64 $ sizeof5Tree
+  -- 2^6 - 1
+  assert_eq_i64 sizeof5Tree 63
 
-  -- print_i64 $ facts !! 5
-  -- assert_eq_i64 (facts !! 5) 120
+  print_i64 $ facts !! 5
+  assert_eq_i64 (facts !! 5) 120
 
-  -- let factmapAt5 = factMap 10 IM.! 5
-  -- print_i64 $ factmapAt5
-  -- assert_eq_i64 factmapAt5 120
+  let factmapAt5 = factMap 10 IM.! 5
+  print_i64 $ factmapAt5
+  assert_eq_i64 factmapAt5 120
 
-  -- -- 0! + 1! + 2! + 3! + 4! + 5!
-  -- print_i64 $ sumFacts 5
-  -- assert_eq_i64 (sumFacts 5) (154)
+  -- 0! + 1! + 2! + 3! + 4! + 5!
+  print_i64 $ sumFacts 5
+  assert_eq_i64 (sumFacts 5) (154)
 
-  -- performGC
+  performGC

--- a/asterius/test/fib/fib.hs
+++ b/asterius/test/fib/fib.hs
@@ -63,39 +63,38 @@ main = do
 
   performGC
 
-  putStrLn $ trace "trace message" ""
-
+  putStrLn $ "xx"
   -- Test that assert_eq works
-  assert_eq_i64 10 10
+  -- assert_eq_i64 10 10
 
-  print_i64 $ fib 10
-  assert_eq_i64 (fib 10) 55
+  -- print_i64 $ fib 10
+  -- assert_eq_i64 (fib 10) 55
 
-  print_i64 $ fact 5
-  assert_eq_i64 (fact 5) 120
+  -- print_i64 $ fact 5
+  -- assert_eq_i64 (fact 5) 120
 
-  print_f64 $ cos 0.5
-  print_f64 $ 2 ** 3
+  -- print_f64 $ cos 0.5
+  -- print_f64 $ 2 ** 3
 
-  let sizeof3Tree = sizeofBinTree $ force $ genBinTree 3
-  print_i64 $ sizeof3Tree
-  -- 2^4 - 1
-  assert_eq_i64 sizeof3Tree 15
+  -- let sizeof3Tree = sizeofBinTree $ force $ genBinTree 3
+  -- print_i64 $ sizeof3Tree
+  -- -- 2^4 - 1
+  -- assert_eq_i64 sizeof3Tree 15
 
-  let sizeof5Tree = sizeofBinTree $ force $ genBinTree 5
-  print_i64 $ sizeof5Tree
-  -- 2^6 - 1
-  assert_eq_i64 sizeof5Tree 63
+  -- let sizeof5Tree = sizeofBinTree $ force $ genBinTree 5
+  -- print_i64 $ sizeof5Tree
+  -- -- 2^6 - 1
+  -- assert_eq_i64 sizeof5Tree 63
 
-  print_i64 $ facts !! 5
-  assert_eq_i64 (facts !! 5) 120
+  -- print_i64 $ facts !! 5
+  -- assert_eq_i64 (facts !! 5) 120
 
-  let factmapAt5 = factMap 10 IM.! 5
-  print_i64 $ factmapAt5
-  assert_eq_i64 factmapAt5 120
+  -- let factmapAt5 = factMap 10 IM.! 5
+  -- print_i64 $ factmapAt5
+  -- assert_eq_i64 factmapAt5 120
 
-  -- 0! + 1! + 2! + 3! + 4! + 5!
-  print_i64 $ sumFacts 5
-  assert_eq_i64 (sumFacts 5) (154)
+  -- -- 0! + 1! + 2! + 3! + 4! + 5!
+  -- print_i64 $ sumFacts 5
+  -- assert_eq_i64 (sumFacts 5) (154)
 
-  performGC
+  -- performGC

--- a/draw.py
+++ b/draw.py
@@ -17,7 +17,10 @@ def draw_bar(minx, maxx, l, r, height, color):
     rect = patches.Rectangle((l, 0), r - l, height, linewidth=1, facecolor=color, alpha=0.4)
     ax.add_patch(rect)
 
-def draw_segments(segments):
+def draw_tick(minx, maxx, pos, color):
+    draw_bar(minx, maxx, pos, pos + 0.005 * (maxx - minx), 1.0, color)
+
+def draw():
     minx = 1e20
     maxx = 0
     for [l, r, _] in segments:
@@ -36,8 +39,11 @@ def draw_segments(segments):
             height = 0.8
         elif ty == "free":
             color = "black"
-            height = 1
+            height = 0.9
 
         assert color is not None
         draw_bar(minx, maxx, l, r, height, color)
+
+    for (tickname, tickpos) in ticks:
+        draw_tick(minx, maxx, tickpos, "purple")
     plt.show()

--- a/draw.py
+++ b/draw.py
@@ -1,0 +1,40 @@
+import matplotlib.pyplot as plt
+import matplotlib.patches as patches
+
+
+# Create figure and axes
+fig,ax = plt.subplots(1)
+
+def draw_bar(minx, maxx, l, r, color):
+    print("minx: %s | maxx: %s" % (minx, maxx))
+    # normalize
+    l = (l - minx) / float(maxx - minx)
+    r = (r - minx) / float(maxx - minx)
+
+    print("l: %s | r: %s | width: %s" % (l, r, r - l))
+
+    Y = 0
+    HEIGHT = 10
+    rect = patches.Rectangle((l, 0), r - l, HEIGHT, linewidth=3, facecolor=color, alpha=0.1)
+    ax.add_patch(rect)
+
+def draw_segments(freeSegments, allbds):
+    minx = 1e20
+    maxx = 0
+    for [l, r] in freeSegments:
+        minx = min(minx, l)
+        maxx = max(maxx, r)
+
+    for [l, r, _] in allbds:
+        minx = min(minx, l)
+        maxx = max(maxx, r)
+
+    for [l, r] in freeSegments:
+        draw_bar(minx, maxx, l, r, 'red')
+
+
+    for [l, r, live] in allbds:
+        draw_bar(minx, maxx, l, r, 'green' if live else 'blue')
+
+def show():
+    plt.show()

--- a/draw.py
+++ b/draw.py
@@ -5,7 +5,7 @@ import matplotlib.patches as patches
 # Create figure and axes
 fig,ax = plt.subplots(1)
 
-def draw_bar(minx, maxx, l, r, color):
+def draw_bar(minx, maxx, l, r, height, color):
     print("minx: %s | maxx: %s" % (minx, maxx))
     # normalize
     l = (l - minx) / float(maxx - minx)
@@ -14,27 +14,30 @@ def draw_bar(minx, maxx, l, r, color):
     print("l: %s | r: %s | width: %s" % (l, r, r - l))
 
     Y = 0
-    HEIGHT = 10
-    rect = patches.Rectangle((l, 0), r - l, HEIGHT, linewidth=3, facecolor=color, alpha=0.1)
+    rect = patches.Rectangle((l, 0), r - l, height, linewidth=1, facecolor=color, alpha=0.4)
     ax.add_patch(rect)
 
-def draw_segments(freeSegments, allbds):
+def draw_segments(segments):
     minx = 1e20
     maxx = 0
-    for [l, r] in freeSegments:
+    for [l, r, _] in segments:
         minx = min(minx, l)
         maxx = max(maxx, r)
 
-    for [l, r, _] in allbds:
-        minx = min(minx, l)
-        maxx = max(maxx, r)
+    for [l, r, ty] in segments:
+        if ty == "live":
+            color = "blue"
+            height = 0.5
+        if ty == "dead":
+            color = "red"
+            height = 0.2
+        elif ty == "heappool":
+            color = "green"
+            height = 0.8
+        elif ty == "free":
+            color = "black"
+            height = 1
 
-    for [l, r] in freeSegments:
-        draw_bar(minx, maxx, l, r, 'red')
-
-
-    for [l, r, live] in allbds:
-        draw_bar(minx, maxx, l, r, 'green' if live else 'blue')
-
-def show():
+        assert color is not None
+        draw_bar(minx, maxx, l, r, height, color)
     plt.show()


### PR DESCRIPTION
In theory, zeroing out memory that is no longer used and `0x42`ing memory that is no longer used is equivalent. In practice, it appears to not be equivalent...

This branch is trying to find out _why_, _what_ invariants are broken.

`fib.hs` crashes on wiping memory with `0x42`