### PR TITLE
Improve CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ jobs:
             echo "deb https://deb.nodesource.com/node_12.x sid main" > /etc/apt/sources.list.d/nodesource.list
             apt update
             apt install -y nodejs
-            nodejs --version
+            node --version
 
       - checkout
       - run:
@@ -200,7 +200,7 @@ jobs:
             no_output_timeout: 30m
             command: |
               # run the GHC testsuite and copy the test artifact to `/tmp`
-              nodejs --version
+              node --version
 
 
               # run test cases that can fail.
@@ -246,7 +246,7 @@ jobs:
             echo "deb https://deb.nodesource.com/node_12.x sid main" > /etc/apt/sources.list.d/nodesource.list
             apt update
             apt install -y nodejs
-            nodejs --version
+            node --version
 
       - checkout
       - run:
@@ -263,7 +263,7 @@ jobs:
             no_output_timeout: 30m
             command: |
               # run the GHC testsuite and copy the test artifact to `/tmp`
-              nodejs --version
+              node --version
 
 
               # run test cases that can fail.
@@ -309,7 +309,7 @@ jobs:
             echo "deb https://deb.nodesource.com/node_12.x sid main" > /etc/apt/sources.list.d/nodesource.list
             apt update
             apt install -y nodejs
-            nodejs --version
+            node --version
 
       - checkout
       - run:
@@ -330,7 +330,7 @@ jobs:
               cd /root/project
 
               # run the GHC testsuite and copy the test artifact to `/tmp`
-              nodejs --version
+              node --version
 
 
               # run test cases that can fail.
@@ -376,7 +376,7 @@ jobs:
             echo "deb https://deb.nodesource.com/node_12.x sid main" > /etc/apt/sources.list.d/nodesource.list
             apt update
             apt install -y nodejs
-            nodejs --version
+            node --version
 
       - checkout
       - run:
@@ -397,7 +397,7 @@ jobs:
               cd /root/project
 
               # run the GHC testsuite and copy the test artifact to `/tmp`
-              nodejs --version
+              node --version
 
 
               # run test cases that can fail.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 jobs:
-  asterius-test:
+  asterius-boot:
     docker:
       - image: debian:unstable
     environment:
@@ -10,8 +10,7 @@ jobs:
       - LANG: C.UTF-8
       - MAKEFLAGS: -j2
       - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-      - STACK_ROOT: /tmp/.stack
-    working_directory: /tmp/asterius
+      - WABT_BINDIR: /root/.local/bin
     steps:
       - run:
           name: Install dependencies
@@ -44,12 +43,68 @@ jobs:
       - checkout
 
       - run:
-          name: Build asterius
+          name: Boot
           command: |
             git submodule update --init --recursive
             stack --no-terminal -j2 build --test --no-run-tests
             stack --no-terminal exec ahc-boot
 
+      - persist_to_workspace:
+          root: /root
+          paths:
+            - .local
+            - .stack
+            - project/.stack-work
+            - project/asterius/.stack-work
+            - project/binaryen/.stack-work
+            - project/ghc-toolkit/.stack-work
+            - project/inline-js/inline-js-core/.stack-work
+            - project/npm-utils/.stack-work
+            - project/wabt/.stack-work
+            - project/wasm-toolkit/.stack-work
+            - project/stack.yaml.lock
+
+  asterius-test:
+    docker:
+      - image: debian:unstable
+    environment:
+      - DEBIAN_FRONTEND: noninteractive
+      - LANG: C.UTF-8
+      - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apt update
+            apt full-upgrade -y
+            apt install -y \
+              automake \
+              cmake \
+              curl \
+              g++ \
+              git \
+              gnupg \
+              libffi-dev \
+              libgmp-dev \
+              libncurses-dev \
+              libnuma-dev \
+              make \
+              openssh-client \
+              python-minimal \
+              python3-minimal \
+              xz-utils \
+              zlib1g-dev
+            curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+            echo "deb https://deb.nodesource.com/node_12.x sid main" > /etc/apt/sources.list.d/nodesource.list
+            apt update
+            apt install -y nodejs
+      - checkout
+      - run:
+          name: Initialize submodules
+          command: |
+            git submodule update --init --recursive
+      - attach_workspace:
+          at: /root
       - run:
           name: Test asterius
           command: |
@@ -97,13 +152,9 @@ jobs:
     docker:
       - image: debian:unstable
     environment:
-      - ASTERIUS_BUILD_OPTIONS: -j2
       - DEBIAN_FRONTEND: noninteractive
       - LANG: C.UTF-8
-      - MAKEFLAGS: -j2
       - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-      - STACK_ROOT: /tmp/.stack
-    working_directory: /tmp/asterius
     steps:
       - run:
           name: Install dependencies
@@ -133,16 +184,14 @@ jobs:
             apt update
             apt install -y nodejs
             nodejs --version
-            mkdir -p /root/.local/bin
-            curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C /root/.local/bin '*/stack'
 
       - checkout
       - run:
-            name: Build asterius
-            command: |
-              git submodule update --init --recursive
-              stack --no-terminal -j2 build asterius --test --no-run-tests
-              stack --no-terminal exec ahc-boot
+          name: Initialize submodules
+          command: |
+            git submodule update --init --recursive
+      - attach_workspace:
+          at: /root
 
       - run:
             name: Run GHC test suite on asterius
@@ -165,14 +214,10 @@ jobs:
     docker:
       - image: debian:unstable
     environment:
-      - ASTERIUS_BUILD_OPTIONS: -j2
       - ASTERIUS_GHC_TESTSUITE_OPTIONS: --yolo
       - DEBIAN_FRONTEND: noninteractive
       - LANG: C.UTF-8
-      - MAKEFLAGS: -j2
       - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-      - STACK_ROOT: /tmp/.stack
-    working_directory: /tmp/asterius
     steps:
       - run:
           name: Install dependencies
@@ -202,16 +247,14 @@ jobs:
             apt update
             apt install -y nodejs
             nodejs --version
-            mkdir -p /root/.local/bin
-            curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C /root/.local/bin '*/stack'
 
       - checkout
       - run:
-            name: Build asterius
-            command: |
-              git submodule update --init --recursive
-              stack --no-terminal -j2 build asterius --test --no-run-tests
-              stack --no-terminal exec ahc-boot
+          name: Initialize submodules
+          command: |
+            git submodule update --init --recursive
+      - attach_workspace:
+          at: /root
 
       - run:
             name: Run GHC test suite on asterius
@@ -234,14 +277,10 @@ jobs:
     docker:
       - image: debian:unstable
     environment:
-      - ASTERIUS_BUILD_OPTIONS: -j2
       - ASTERIUS_GHC_TESTSUITE_OPTIONS: --debug
       - DEBIAN_FRONTEND: noninteractive
       - LANG: C.UTF-8
-      - MAKEFLAGS: -j2
       - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-      - STACK_ROOT: /tmp/.stack
-    working_directory: /tmp/asterius
     steps:
       - run:
           name: Install dependencies
@@ -271,16 +310,14 @@ jobs:
             apt update
             apt install -y nodejs
             nodejs --version
-            mkdir -p /root/.local/bin
-            curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C /root/.local/bin '*/stack'
 
       - checkout
       - run:
-            name: Build asterius
-            command: |
-              git submodule update --init --recursive
-              stack --no-terminal -j2 build asterius --test --no-run-tests
-              stack --no-terminal exec ahc-boot
+          name: Initialize submodules
+          command: |
+            git submodule update --init --recursive
+      - attach_workspace:
+          at: /root
 
       - run:
             name: Run GHC test suite on asterius
@@ -307,14 +344,10 @@ jobs:
     docker:
       - image: debian:unstable
     environment:
-      - ASTERIUS_BUILD_OPTIONS: -j2
       - ASTERIUS_GHC_TESTSUITE_OPTIONS: --debug --yolo
       - DEBIAN_FRONTEND: noninteractive
       - LANG: C.UTF-8
-      - MAKEFLAGS: -j2
       - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-      - STACK_ROOT: /tmp/.stack
-    working_directory: /tmp/asterius
     steps:
       - run:
           name: Install dependencies
@@ -344,16 +377,14 @@ jobs:
             apt update
             apt install -y nodejs
             nodejs --version
-            mkdir -p /root/.local/bin
-            curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C /root/.local/bin '*/stack'
 
       - checkout
       - run:
-            name: Build asterius
-            command: |
-              git submodule update --init --recursive
-              stack --no-terminal -j2 build asterius --test --no-run-tests
-              stack --no-terminal exec ahc-boot
+          name: Initialize submodules
+          command: |
+            git submodule update --init --recursive
+      - attach_workspace:
+          at: /root
 
       - run:
             name: Run GHC test suite on asterius
@@ -405,6 +436,13 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
       LANG: C.UTF-8
     steps:
+      - run:
+          name: Ensure we are on `tweag/asterius`
+          command: |
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              echo "Nothing to do for forked PRs, so marking this step successful"
+              circleci step halt
+            fi
       - run:
           name: Install dependencies
           command: |
@@ -465,11 +503,22 @@ workflows:
   version: 2
   build:
     jobs:
-      - asterius-test
-      - asterius-test-ghc-testsuite
-      - asterius-test-ghc-testsuite-yolo
-      - asterius-test-ghc-testsuite-debug
-      - asterius-test-ghc-testsuite-debug-yolo
+      - asterius-boot
+      - asterius-test:
+          requires:
+            - asterius-boot
+      - asterius-test-ghc-testsuite:
+          requires:
+            - asterius-boot
+      - asterius-test-ghc-testsuite-yolo:
+          requires:
+            - asterius-boot
+      - asterius-test-ghc-testsuite-debug:
+          requires:
+            - asterius-boot
+      - asterius-test-ghc-testsuite-debug-yolo:
+          requires:
+            - asterius-boot
       - asterius-build-docker
       - asterius-build-docs
       - asterius-update-docker-tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
     environment:
       - ASTERIUS_BUILD_OPTIONS: -j2
       - DEBIAN_FRONTEND: noninteractive
+      - GHCRTS: -N2
       - LANG: C.UTF-8
       - MAKEFLAGS: -j2
       - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -69,6 +70,7 @@ jobs:
       - image: debian:unstable
     environment:
       - DEBIAN_FRONTEND: noninteractive
+      - GHCRTS: -N2
       - LANG: C.UTF-8
       - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
@@ -146,13 +148,14 @@ jobs:
 
             # Run parts of the ghc-testuite that we have enabled for
             # regression testing.
-            stack test asterius:ghc-testsuite --test-arguments="  --timeout=30s -l test/ghc-testsuite-filter";
+            stack test asterius:ghc-testsuite --test-arguments="--timeout=30s -l test/ghc-testsuite-filter";
 
   asterius-test-ghc-testsuite:
     docker:
       - image: debian:unstable
     environment:
       - DEBIAN_FRONTEND: noninteractive
+      - GHCRTS: -N2
       - LANG: C.UTF-8
       - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
@@ -216,6 +219,7 @@ jobs:
     environment:
       - ASTERIUS_GHC_TESTSUITE_OPTIONS: --yolo
       - DEBIAN_FRONTEND: noninteractive
+      - GHCRTS: -N2
       - LANG: C.UTF-8
       - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
@@ -279,6 +283,7 @@ jobs:
     environment:
       - ASTERIUS_GHC_TESTSUITE_OPTIONS: --debug
       - DEBIAN_FRONTEND: noninteractive
+      - GHCRTS: -N2
       - LANG: C.UTF-8
       - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
@@ -346,6 +351,7 @@ jobs:
     environment:
       - ASTERIUS_GHC_TESTSUITE_OPTIONS: --debug --yolo
       - DEBIAN_FRONTEND: noninteractive
+      - GHCRTS: -N2
       - LANG: C.UTF-8
       - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,9 +125,9 @@ jobs:
             stack --no-terminal test asterius:fib --test-arguments="--no-gc-sections"
             stack --no-terminal test asterius:fib --test-arguments="--binaryen --no-gc-sections"
 
-            cd ~/.local
-            $CIRCLE_WORKING_DIRECTORY/utils/v8-node.py
-            cd $CIRCLE_WORKING_DIRECTORY
+            cd /root/.local
+            /root/project/utils/v8-node.py
+            cd /root/project
             stack --no-terminal test asterius:fib --test-arguments="--debug" > /dev/null
             stack --no-terminal test asterius:jsffi --test-arguments="--debug" > /dev/null
             stack --no-terminal test asterius:array --test-arguments="--debug" > /dev/null
@@ -325,9 +325,9 @@ jobs:
             # CSV file.
             no_output_timeout: 30m
             command: |
-              cd ~/.local
-              $CIRCLE_WORKING_DIRECTORY/utils/v8-node.py
-              cd $CIRCLE_WORKING_DIRECTORY
+              cd /root/.local
+              /root/project/utils/v8-node.py
+              cd /root/project
 
               # run the GHC testsuite and copy the test artifact to `/tmp`
               nodejs --version
@@ -392,9 +392,9 @@ jobs:
             # CSV file.
             no_output_timeout: 30m
             command: |
-              cd ~/.local
-              $CIRCLE_WORKING_DIRECTORY/utils/v8-node.py
-              cd $CIRCLE_WORKING_DIRECTORY
+              cd /root/.local
+              /root/project/utils/v8-node.py
+              cd /root/project
 
               # run the GHC testsuite and copy the test artifact to `/tmp`
               nodejs --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,6 +230,152 @@ jobs:
       - store_artifacts:
           path: /tmp/test-report.csv
 
+  asterius-test-ghc-testsuite-debug:
+    docker:
+      - image: debian:unstable
+    environment:
+      - ASTERIUS_BUILD_OPTIONS: -j2
+      - ASTERIUS_GHC_TESTSUITE_OPTIONS: --debug
+      - DEBIAN_FRONTEND: noninteractive
+      - LANG: C.UTF-8
+      - MAKEFLAGS: -j2
+      - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - STACK_ROOT: /tmp/.stack
+    working_directory: /tmp/asterius
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apt update
+            apt full-upgrade -y
+            apt install -y python3-numpy python3-pandas python3-terminaltables
+            apt install -y \
+              automake \
+              cmake \
+              curl \
+              g++ \
+              git \
+              gnupg \
+              libffi-dev \
+              libgmp-dev \
+              libncurses-dev \
+              libnuma-dev \
+              make \
+              openssh-client \
+              python-minimal \
+              python3-minimal \
+              xz-utils \
+              zlib1g-dev
+            curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+            echo "deb https://deb.nodesource.com/node_12.x sid main" > /etc/apt/sources.list.d/nodesource.list
+            apt update
+            apt install -y nodejs
+            nodejs --version
+            mkdir -p /root/.local/bin
+            curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C /root/.local/bin '*/stack'
+
+      - checkout
+      - run:
+            name: Build asterius
+            command: |
+              git submodule update --init --recursive
+              stack --no-terminal -j2 build asterius --test --no-run-tests
+              stack --no-terminal exec ahc-boot
+
+      - run:
+            name: Run GHC test suite on asterius
+            # Allow a large timeout so we have enough time to write out the
+            # CSV file.
+            no_output_timeout: 30m
+            command: |
+              cd ~/.local
+              $CIRCLE_WORKING_DIRECTORY/utils/v8-node.py
+              cd $CIRCLE_WORKING_DIRECTORY
+
+              # run the GHC testsuite and copy the test artifact to `/tmp`
+              nodejs --version
+
+
+              # run test cases that can fail.
+              stack --no-terminal test asterius:ghc-testsuite --test-arguments="--timeout=30s" || true
+              cp asterius/test-report.csv /tmp
+
+      - store_artifacts:
+          path: /tmp/test-report.csv
+
+  asterius-test-ghc-testsuite-debug-yolo:
+    docker:
+      - image: debian:unstable
+    environment:
+      - ASTERIUS_BUILD_OPTIONS: -j2
+      - ASTERIUS_GHC_TESTSUITE_OPTIONS: --debug --yolo
+      - DEBIAN_FRONTEND: noninteractive
+      - LANG: C.UTF-8
+      - MAKEFLAGS: -j2
+      - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - STACK_ROOT: /tmp/.stack
+    working_directory: /tmp/asterius
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apt update
+            apt full-upgrade -y
+            apt install -y python3-numpy python3-pandas python3-terminaltables
+            apt install -y \
+              automake \
+              cmake \
+              curl \
+              g++ \
+              git \
+              gnupg \
+              libffi-dev \
+              libgmp-dev \
+              libncurses-dev \
+              libnuma-dev \
+              make \
+              openssh-client \
+              python-minimal \
+              python3-minimal \
+              xz-utils \
+              zlib1g-dev
+            curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+            echo "deb https://deb.nodesource.com/node_12.x sid main" > /etc/apt/sources.list.d/nodesource.list
+            apt update
+            apt install -y nodejs
+            nodejs --version
+            mkdir -p /root/.local/bin
+            curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C /root/.local/bin '*/stack'
+
+      - checkout
+      - run:
+            name: Build asterius
+            command: |
+              git submodule update --init --recursive
+              stack --no-terminal -j2 build asterius --test --no-run-tests
+              stack --no-terminal exec ahc-boot
+
+      - run:
+            name: Run GHC test suite on asterius
+            # Allow a large timeout so we have enough time to write out the
+            # CSV file.
+            no_output_timeout: 30m
+            command: |
+              cd ~/.local
+              $CIRCLE_WORKING_DIRECTORY/utils/v8-node.py
+              cd $CIRCLE_WORKING_DIRECTORY
+
+              # run the GHC testsuite and copy the test artifact to `/tmp`
+              nodejs --version
+
+
+              # run test cases that can fail.
+              stack --no-terminal test asterius:ghc-testsuite --test-arguments="--timeout=30s" || true
+              cp asterius/test-report.csv /tmp
+
+      - store_artifacts:
+          path: /tmp/test-report.csv
+
   asterius-build-docker:
     docker:
       - image: docker:edge-git
@@ -322,6 +468,8 @@ workflows:
       - asterius-test
       - asterius-test-ghc-testsuite
       - asterius-test-ghc-testsuite-yolo
+      - asterius-test-ghc-testsuite-debug
+      - asterius-test-ghc-testsuite-debug-yolo
       - asterius-build-docker
       - asterius-build-docs
       - asterius-update-docker-tag:

--- a/asterius/src/Asterius/Internals/Temp.hs
+++ b/asterius/src/Asterius/Internals/Temp.hs
@@ -4,6 +4,7 @@ module Asterius.Internals.Temp
   ) where
 
 import Distribution.Simple.Utils
+import Distribution.Verbosity
 import System.Directory
 import System.IO
 
@@ -17,5 +18,4 @@ temp p = do
 withTempDir :: String -> (FilePath -> IO r) -> IO r
 withTempDir t c = do
   tmpdir <- getTemporaryDirectory
-  p <- createTempDirectory tmpdir t
-  c p
+  withTempDirectory silent tmpdir t c


### PR DESCRIPTION
This PR improves our current CircleCI workflow: the building & booting process is now only run once, then the build data is persisted through a workspace, shared by all downstream testing jobs. This reduces the demand for concurrent CircleCI build slots and cuts down the project's carbon footprint for the sake of this planet.