### PR TITLE
Do not free heap pool in the mblockalloc

### DIFF
--- a/asterius/rts/rts.gc.mjs
+++ b/asterius/rts/rts.gc.mjs
@@ -550,7 +550,7 @@ export class GC {
 
     this.evacuateClosure(tso);
     this.scavengeWorkList();
-    this.mblockAlloc.preserveMegaGroups(this.liveMBlocks);
+    this.mblockAlloc.preserveMegaGroups(this.liveMBlocks, this.heapAlloc.getPoolBdescrs());
     this.stablePtrManager.preserveJSVals(this.liveJSVals);
     this.closureIndirects.clear();
     this.liveMBlocks.clear();

--- a/asterius/rts/rts.heapalloc.mjs
+++ b/asterius/rts/rts.heapalloc.mjs
@@ -55,4 +55,9 @@ export class HeapAlloc {
     return current_free;
   }
   allocatePinned(n) { return this.allocate(n, true); }
+
+  // return a set of heap pool block descriptors
+  getPoolBdescrs() {
+    return new Set([...this.currentPools]);
+  }
 }

--- a/asterius/rts/rts.mblockalloc.mjs
+++ b/asterius/rts/rts.mblockalloc.mjs
@@ -31,7 +31,6 @@ export class MBlockAlloc {
 
   allocMegaGroup(n) {
     const req_blocks = ((rtsConstants.mblock_size * n) - rtsConstants.offset_first_block) / rtsConstants.block_size;
-    /*
     for (let i = 0; i < this.freeList.length; ++i) {
       const bd = this.freeList[i],
             blocks = this.memory.i32Load(bd + rtsConstants.offset_bdescr_blocks);
@@ -56,7 +55,7 @@ export class MBlockAlloc {
         return bd;
       }
     }
-    */
+
     const mblock = this.getMBlocks(n),
           bd = mblock + rtsConstants.offset_first_bdescr,
           block_addr = mblock + rtsConstants.offset_first_block;
@@ -100,7 +99,8 @@ export class MBlockAlloc {
       // IVNARIANT: size of a heap pool is always a megablock, so we can
       // skip one megablock to reach the end of the pool
       if (heapPoolBdescrs.has(sorted_bds[i])) {
-        l_end = l_start - rtsConstants.offset_first_bdescr + rtsConstants.mblock_size;
+        continue;
+        // l_end = l_start - rtsConstants.offset_first_bdescr + rtsConstants.mblock_size;
       }
 
       const r = sorted_bds[i + 1] - rtsConstants.offset_first_bdescr;

--- a/asterius/rts/rts.mblockalloc.mjs
+++ b/asterius/rts/rts.mblockalloc.mjs
@@ -100,7 +100,7 @@ export class MBlockAlloc {
       // skip one megablock to reach the end of the pool
       if (heapPoolBdescrs.has(sorted_bds[i])) {
         continue;
-        // l_end = l_start - rtsConstants.offset_first_bdescr + rtsConstants.mblock_size;
+        // l_end = sorted_bds[i] + rtsConstants.mblock_size;
       }
 
       const r = sorted_bds[i + 1] - rtsConstants.offset_first_bdescr;

--- a/asterius/rts/rts.mblockalloc.mjs
+++ b/asterius/rts/rts.mblockalloc.mjs
@@ -96,11 +96,9 @@ export class MBlockAlloc {
           this.memory.i32Load(sorted_bds[i] + rtsConstants.offset_bdescr_blocks);
       let l_end = l_start + (rtsConstants.block_size * l_blocks);
 
-      // IVNARIANT: size of a heap pool is always a megablock, so we can
-      // skip one megablock to reach the end of the pool
+      // if we see a heap pool, we skip it entirely.
       if (heapPoolBdescrs.has(sorted_bds[i])) {
         continue;
-        // l_end = sorted_bds[i] + rtsConstants.mblock_size;
       }
 
       const r = sorted_bds[i + 1] - rtsConstants.offset_first_bdescr;

--- a/asterius/test/ghc-testsuite-filter
+++ b/asterius/test/ghc-testsuite-filter
@@ -2,7 +2,7 @@
 # !<regex> will blacklist stuff in <regex>. <regex> syntax given by whatever
 # is parsed by Regex.TDFA
 # Leading whitespace sensitive.
-numeric/|T9001
+numeric/|T9001|CmpWord8
 !CarryOverflow.hs
 !arith011
 !arith008


### PR DESCRIPTION
Do not free megablocks owned by the heap allocator. This fixes some flukey code that looks like it used to succeed by luck? 

We can now wipe the free region with `0x42` to mark them as used, and have our code continue to work.