### PR TITLE
Get rid of `Handle` related hacks in `base`/`unix`

### DIFF
--- a/asterius/boot.sh
+++ b/asterius/boot.sh
@@ -75,7 +75,7 @@ $ASTERIUS_TMP_DIR/Setup-simple install --builddir=$ASTERIUS_TMP_DIR/dist/templat
 cd ..
 
 cd bytestring
-$ASTERIUS_TMP_DIR/Setup-simple configure --prefix=$ASTERIUS_LIB_DIR --package-db=clear --package-db=global --builddir=$ASTERIUS_TMP_DIR/dist/bytestring --with-ghc=$ASTERIUS_AHC --with-ghc-pkg=$ASTERIUS_AHCPKG -finteger-simple --ghc-option=-DASTERIUS $ASTERIUS_CONFIGURE_OPTIONS
+$ASTERIUS_TMP_DIR/Setup-simple configure --prefix=$ASTERIUS_LIB_DIR --package-db=clear --package-db=global --builddir=$ASTERIUS_TMP_DIR/dist/bytestring --with-ghc=$ASTERIUS_AHC --with-ghc-pkg=$ASTERIUS_AHCPKG -finteger-simple $ASTERIUS_CONFIGURE_OPTIONS
 $ASTERIUS_TMP_DIR/Setup-simple build --builddir=$ASTERIUS_TMP_DIR/dist/bytestring $ASTERIUS_BUILD_OPTIONS
 $ASTERIUS_TMP_DIR/Setup-simple install --builddir=$ASTERIUS_TMP_DIR/dist/bytestring $ASTERIUS_INSTALL_OPTIONS
 cd ..

--- a/asterius/boot.sh
+++ b/asterius/boot.sh
@@ -107,7 +107,7 @@ cd ..
 
 cd unix
 autoreconf -i
-$ASTERIUS_TMP_DIR/Setup-autoconf configure --prefix=$ASTERIUS_LIB_DIR --package-db=clear --package-db=global --builddir=$ASTERIUS_TMP_DIR/dist/unix --with-ghc=$ASTERIUS_AHC --with-ghc-pkg=$ASTERIUS_AHCPKG --hsc2hs-option=-DASTERIUS $ASTERIUS_CONFIGURE_OPTIONS
+$ASTERIUS_TMP_DIR/Setup-autoconf configure --prefix=$ASTERIUS_LIB_DIR --package-db=clear --package-db=global --builddir=$ASTERIUS_TMP_DIR/dist/unix --with-ghc=$ASTERIUS_AHC --with-ghc-pkg=$ASTERIUS_AHCPKG $ASTERIUS_CONFIGURE_OPTIONS
 $ASTERIUS_TMP_DIR/Setup-autoconf build --builddir=$ASTERIUS_TMP_DIR/dist/unix $ASTERIUS_BUILD_OPTIONS
 $ASTERIUS_TMP_DIR/Setup-autoconf install --builddir=$ASTERIUS_TMP_DIR/dist/unix $ASTERIUS_INSTALL_OPTIONS
 cd ..

--- a/asterius/rts/rts.messages.mjs
+++ b/asterius/rts/rts.messages.mjs
@@ -1,14 +1,12 @@
 export class Messages {
-    constructor(memory, fs) {
-        this.memory = memory;
-        this.fs = fs
-        Object.seal(this);
-    }
+  constructor(memory, fs) {
+    this.memory = memory;
+    this.fs = fs;
+    Object.freeze(this);
+  }
 
-    debugBelch2(fmt, arg) {
-        const s = `${this.memory.strLoad(arg)}\n`;
-        console.error(s);
-        this.fs.writeSync(this.fs.stderr(), s);
-    }
-
+  debugBelch2(fmt, arg) {
+    const s = `${this.memory.strLoad(arg)}\n`;
+    this.fs.writeSync(2, s);
+  }
 }

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -100,9 +100,8 @@ export function newAsteriusInstance(req) {
     Integer: __asterius_integer_manager,
     FloatCBits: __asterius_float_cbits,
     stdio: {
-      putChar: (h, c) => __asterius_fs.writeSync(h, String.fromCodePoint(c)),
-      stdout: () => __asterius_fs.root.get("/dev/stdout"),
-      stderr: () => __asterius_fs.root.get("/dev/stderr")
+      stdout: () => __asterius_fs.readSync(1),
+      stderr: () => __asterius_fs.readSync(2)
     },
     setPromise: (vt, p) => __asterius_tso_manager.setPromise(vt, p)
   };
@@ -133,9 +132,16 @@ export function newAsteriusInstance(req) {
         memory: __asterius_wasm_memory
       },
       rts: {
-        printI64: x => __asterius_fs.writeSync(__asterius_fs.stdout(), __asterius_show_I64(x) + "\n"),
+        printI64: x => __asterius_fs.writeSync(1, __asterius_show_I64(x) + "\n"),
         assertEqI64: function(x, y) { if(x != y) {   throw new WebAssembly.RuntimeError("unequal I64: " + x + ", " + y); } },
-        print: x => __asterius_fs.writeSync(__asterius_fs.stdout(), x + "\n")
+        print: x => __asterius_fs.writeSync(1, x + "\n")
+      },
+      fs: {
+        write: (fd, buf, count) => {
+          const p = Memory.unTag(buf);
+          __asterius_fs.writeSync(fd, __asterius_memory.i8View.subarray(p, p + count));
+          return count;
+        }
       },
       bytestring: modulify(__asterius_bytestring_cbits),
       // cannot name this float since float is a keyword.

--- a/ghc-toolkit/boot-libs/base/Asterius/TopHandler.hs
+++ b/ghc-toolkit/boot-libs/base/Asterius/TopHandler.hs
@@ -6,12 +6,13 @@ module Asterius.TopHandler
 
 import Control.Exception
 import Foreign.C
+import GHC.TopHandler (flushStdHandles)
 import Prelude
 import System.Exit
 import System.IO
 
 runMainIO :: IO a -> IO a
-runMainIO = (`catch` topHandler)
+runMainIO = (`finally` flushStdHandles) . (`catch` topHandler)
 
 topHandler :: SomeException -> IO a
 topHandler = throwExitCode realHandler

--- a/ghc-toolkit/boot-libs/base/GHC/IO/Handle/Internals.hs
+++ b/ghc-toolkit/boot-libs/base/GHC/IO/Handle/Internals.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE NoImplicitPrelude
            , RecordWildCards
@@ -8,7 +7,7 @@
   #-}
 {-# OPTIONS_GHC -Wno-unused-matches #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
-{-# OPTIONS_HADDOCK hide #-}
+{-# OPTIONS_HADDOCK not-home #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -27,14 +26,14 @@
 -----------------------------------------------------------------------------
 
 module GHC.IO.Handle.Internals (
-#if !defined(ASTERIUS)
   withHandle, withHandle', withHandle_,
   withHandle__', withHandle_', withAllHandles__,
   wantWritableHandle, wantReadableHandle, wantReadableHandle_,
   wantSeekableHandle,
 
   mkHandle, mkFileHandle, mkDuplexHandle,
-  closeTextCodecs,
+  openTextEncoding, closeTextCodecs, initBufferState,
+  dEFAULT_CHAR_BUFFER_SIZE,
 
   flushBuffer, flushWriteBuffer, flushCharReadBuffer,
   flushCharBuffer, flushByteReadBuffer, flushByteWriteBuffer,
@@ -42,20 +41,14 @@ module GHC.IO.Handle.Internals (
   readTextDevice, writeCharBuffer, readTextDeviceNonBlocking,
   decodeByteBuf,
 
-  ioe_finalizedHandle,
+  augmentIOError,
+  ioe_closedHandle, ioe_semiclosedHandle,
+  ioe_EOF, ioe_notReadable, ioe_notWritable,
+  ioe_finalizedHandle, ioe_bufsiz,
 
   hClose_help, hLookAhead_,
 
   HandleFinalizer, handleFinalizer,
-#endif
-
-  openTextEncoding, initBufferState,
-  dEFAULT_CHAR_BUFFER_SIZE,
-
-  augmentIOError,
-  ioe_closedHandle, ioe_semiclosedHandle,
-  ioe_EOF, ioe_notReadable, ioe_notWritable,
-  ioe_bufsiz,
 
   debugIO,
  ) where
@@ -93,8 +86,6 @@ c_DEBUG_DUMP = False
 -- ---------------------------------------------------------------------------
 -- Creating a new handle
 
-#if !defined(ASTERIUS)
-
 type HandleFinalizer = FilePath -> MVar Handle__ -> IO ()
 
 newFileHandle :: FilePath -> Maybe HandleFinalizer -> Handle__ -> IO Handle
@@ -104,8 +95,6 @@ newFileHandle filepath mb_finalizer hc = do
     Just finalizer -> addMVarFinalizer m (finalizer filepath m)
     Nothing        -> return ()
   return (FileHandle filepath m)
-
-#endif
 
 -- ---------------------------------------------------------------------------
 -- Working with Handles
@@ -130,8 +119,6 @@ possible combinations of:
 If the operation generates an error or an exception is raised, the
 original handle is always replaced.
 -}
-
-#if !defined(ASTERIUS)
 
 {-# INLINE withHandle #-}
 withHandle :: String -> Handle -> (Handle__ -> IO (Handle__,a)) -> IO a
@@ -191,8 +178,6 @@ do_operation fun h act m = do
         _otherwise ->
             throwIO e
 
-#endif
-
 -- Note [async]
 --
 -- If an asynchronous exception is raised during an I/O operation,
@@ -228,19 +213,13 @@ augmentIOError :: IOException -> String -> Handle -> IOException
 augmentIOError ioe@IOError{ ioe_filename = fp } fun h
   = ioe { ioe_handle = Just h, ioe_location = fun, ioe_filename = filepath }
   where filepath
-#if defined(ASTERIUS)
-                      = Just (show h)
-#else
           | Just _ <- fp = fp
           | otherwise = case h of
                           FileHandle path _     -> Just path
                           DuplexHandle path _ _ -> Just path
-#endif
 
 -- ---------------------------------------------------------------------------
 -- Wrapper for write operations.
-
-#if !defined(ASTERIUS)
 
 wantWritableHandle :: String -> Handle -> (Handle__ -> IO a) -> IO a
 wantWritableHandle fun h@(FileHandle _ m) act
@@ -335,8 +314,6 @@ checkSeekableHandle act handle_@Handle__{haDevice=dev} =
               if b then act handle_
                    else ioe_notSeekable
 
-#endif
-
 -- -----------------------------------------------------------------------------
 -- Handy IOErrors
 
@@ -366,14 +343,10 @@ ioe_cannotFlushNotSeekable = ioException
       "cannot flush the read buffer: underlying device is not seekable"
         Nothing Nothing)
 
-#if !defined(ASTERIUS)
-
 ioe_finalizedHandle :: FilePath -> Handle__
 ioe_finalizedHandle fp = throw
    (IOError Nothing IllegalOperation ""
         "handle is finalized" Nothing (Just fp))
-
-#endif
 
 ioe_bufsiz :: Int -> IO a
 ioe_bufsiz n = ioException
@@ -448,16 +421,12 @@ recoveringEncode codec from to = go from to
 -- will then report an error.  We'd rather this was not an error and
 -- the program just prints "<<loop>>".
 
-#if !defined(ASTERIUS)
-
 handleFinalizer :: FilePath -> MVar Handle__ -> IO ()
 handleFinalizer fp m = do
   handle_ <- takeMVar m
   (handle_', _) <- hClose_help handle_
   putMVar m handle_'
   return ()
-
-#endif
 
 -- ---------------------------------------------------------------------------
 -- Allocating buffers
@@ -493,9 +462,6 @@ mkUnBuffer state = do
 -- | syncs the file with the buffer, including moving the
 -- file pointer backwards in the case of a read buffer.  This can fail
 -- on a non-seekable read Handle.
-
-#if !defined(ASTERIUS)
-
 flushBuffer :: Handle__ -> IO ()
 flushBuffer h_@Handle__{..} = do
   buf <- readIORef haCharBuffer
@@ -643,12 +609,8 @@ flushByteReadBuffer h_@Handle__{..} = do
 
   writeIORef haByteBuffer bbuf{ bufL=0, bufR=0 }
 
-#endif
-
 -- ----------------------------------------------------------------------------
 -- Making Handles
-
-#if !defined(ASTERIUS)
 
 mkHandle :: (IODevice dev, BufferedIO dev, Typeable dev) => dev
             -> FilePath
@@ -729,8 +691,6 @@ mkDuplexHandle dev filepath mb_codec tr_newlines = do
 
   return (DuplexHandle filepath read_m write_m)
 
-#endif
-
 ioModeToHandleType :: IOMode -> HandleType
 ioModeToHandleType ReadMode      = ReadHandle
 ioModeToHandleType WriteMode     = WriteHandle
@@ -761,14 +721,10 @@ openTextEncoding (Just TextEncoding{..}) ha_type cont = do
                      return Nothing
     cont mb_encoder mb_decoder
 
-#if !defined(ASTERIUS)
-
 closeTextCodecs :: Handle__ -> IO ()
 closeTextCodecs Handle__{..} = do
   case haDecoder of Nothing -> return (); Just d -> Encoding.close d
   case haEncoder of Nothing -> return (); Just d -> Encoding.close d
-
-#endif
 
 -- ---------------------------------------------------------------------------
 -- closing Handles
@@ -779,9 +735,6 @@ closeTextCodecs Handle__{..} = do
 -- careful with DuplexHandles though: we have to leave the closing to
 -- the finalizer in that case, because the write side may still be in
 -- use.
-
-#if !defined(ASTERIUS)
-
 hClose_help :: Handle__ -> IO (Handle__, Maybe SomeException)
 hClose_help handle_ =
   case haType handle_ of
@@ -793,12 +746,9 @@ hClose_help handle_ =
               (h_, mb_exc2) <- hClose_handle_ handle_
               return (h_, if isJust mb_exc1 then mb_exc1 else mb_exc2)
 
-#endif
 
 trymaybe :: IO () -> IO (Maybe SomeException)
 trymaybe io = (do io; return Nothing) `catchException` \e -> return (Just e)
-
-#if !defined(ASTERIUS)
 
 hClose_handle_ :: Handle__ -> IO (Handle__, Maybe SomeException)
 hClose_handle_ h_@Handle__{..} = do
@@ -828,8 +778,6 @@ hClose_handle_ h_@Handle__{..} = do
     -- XXX GHC won't let us use record update here, hence wildcards
     return (Handle__{ haType = ClosedHandle, .. }, maybe_exception)
 
-#endif
-
 {-# NOINLINE noCharBuffer #-}
 noCharBuffer :: CharBuffer
 noCharBuffer = unsafePerformIO $ newCharBuffer 1 ReadBuffer
@@ -840,8 +788,6 @@ noByteBuffer = unsafePerformIO $ newByteBuffer 1 ReadBuffer
 
 -- ---------------------------------------------------------------------------
 -- Looking ahead
-
-#if !defined(ASTERIUS)
 
 hLookAhead_ :: Handle__ -> IO Char
 hLookAhead_ handle_@Handle__{..} = do
@@ -854,8 +800,6 @@ hLookAhead_ handle_@Handle__{..} = do
     writeIORef haCharBuffer new_buf
 
     peekCharBuf (bufRaw buf) (bufL buf)
-
-#endif
 
 -- ---------------------------------------------------------------------------
 -- debugging
@@ -884,9 +828,6 @@ debugIO s
 --
 -- Users of this function expect that the buffer returned contains
 -- at least 1 more character than the input buffer.
-
-#if !defined(ASTERIUS)
-
 readTextDevice :: Handle__ -> CharBuffer -> IO CharBuffer
 readTextDevice h_@Handle__{..} cbuf = do
   --
@@ -1006,4 +947,3 @@ decodeByteBuf h_@Handle__{..} cbuf = do
   writeIORef haByteBuffer bbuf2
   return cbuf'
 
-#endif

--- a/ghc-toolkit/boot-libs/base/GHC/IO/Handle/Text.hs
+++ b/ghc-toolkit/boot-libs/base/GHC/IO/Handle/Text.hs
@@ -8,7 +8,7 @@
   #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 {-# OPTIONS_GHC -Wno-unused-matches #-}
-{-# OPTIONS_HADDOCK hide #-}
+{-# OPTIONS_HADDOCK not-home #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -26,9 +26,7 @@
 
 module GHC.IO.Handle.Text (
         hWaitForInput, hGetChar, hGetLine, hGetContents, hPutChar, hPutStr,
-#if !defined(ASTERIUS)
         commitBuffer',       -- hack, see below
-#endif
         hGetBuf, hGetBufSome, hGetBufNonBlocking, hPutBuf, hPutBufNonBlocking,
         memcpy, hPutStrLn,
     ) where
@@ -58,10 +56,6 @@ import GHC.Real
 import GHC.Num
 import GHC.Show
 import GHC.List
-
-#if defined(ASTERIUS)
-import Asterius.Prim
-#endif
 
 -- ---------------------------------------------------------------------------
 -- Simple input operations
@@ -95,9 +89,6 @@ import Asterius.Prim
 --
 
 hWaitForInput :: Handle -> Int -> IO Bool
-#if defined(ASTERIUS)
-hWaitForInput = undefined
-#else
 hWaitForInput h msecs = do
   wantReadableHandle_ "hWaitForInput" h $ \ handle_@Handle__{..} -> do
   cbuf <- readIORef haCharBuffer
@@ -126,7 +117,6 @@ hWaitForInput h msecs = do
                 -- and re-running IODevice.ready if we don't have any full
                 -- characters; but we don't know how long we've waited
                 -- so far.
-#endif
 
 -- ---------------------------------------------------------------------------
 -- hGetChar
@@ -139,9 +129,6 @@ hWaitForInput h msecs = do
 --  * 'isEOFError' if the end of file has been reached.
 
 hGetChar :: Handle -> IO Char
-#if defined(ASTERIUS)
-hGetChar = undefined
-#else
 hGetChar handle =
   wantReadableHandle_ "hGetChar" handle $ \handle_@Handle__{..} -> do
 
@@ -182,7 +169,6 @@ hGetChar handle =
      else do
             writeIORef haCharBuffer buf2
             return c1
-#endif
 
 -- ---------------------------------------------------------------------------
 -- hGetLine
@@ -200,18 +186,11 @@ hGetChar handle =
 -- line is returned.
 
 hGetLine :: Handle -> IO String
-#if defined(ASTERIUS)
-hGetLine = undefined
-#else
 hGetLine h =
   wantReadableHandle_ "hGetLine" h $ \ handle_ -> do
      hGetLineBuffered handle_
-#endif
-
-#if !defined(ASTERIUS)
 
 hGetLineBuffered :: Handle__ -> IO String
-hGetLineBuffered = undefined
 hGetLineBuffered handle_@Handle__{..} = do
   buf <- readIORef haCharBuffer
   hGetLineBufferedLoop handle_ buf []
@@ -274,8 +253,6 @@ maybeFillReadBuffer handle_ buf
      (\e -> do if isEOFError e
                   then return Nothing
                   else ioError e)
-
-#endif
 
 -- See GHC.IO.Buffer
 #define CHARBUF_UTF32
@@ -398,20 +375,15 @@ unpack_nl !buf !r !w acc0
 --  * 'isEOFError' if the end of file has been reached.
 
 hGetContents :: Handle -> IO String
-#if defined(ASTERIUS)
-hGetContents = undefined
-#else
 hGetContents handle =
    wantReadableHandle "hGetContents" handle $ \handle_ -> do
       xs <- lazyRead handle
       return (handle_{ haType=SemiClosedHandle}, xs )
-#endif
 
 -- Note that someone may close the semi-closed handle (or change its
 -- buffering), so each time these lazy read functions are pulled on,
 -- they have to check whether the handle has indeed been closed.
 
-#if !defined(ASTERIUS)
 lazyRead :: Handle -> IO String
 lazyRead handle =
    unsafeInterleaveIO $
@@ -453,10 +425,8 @@ lazyReadBuffered h handle_@Handle__{..} = do
 
                   return (handle_', r)
         )
-#endif
 
 -- ensure we have some characters in the buffer
-#if !defined(ASTERIUS)
 getSomeCharacters :: Handle__ -> CharBuffer -> IO CharBuffer
 getSomeCharacters handle_@Handle__{..} buf@Buffer{..} =
   case bufferElems buf of
@@ -482,7 +452,6 @@ getSomeCharacters handle_@Handle__{..} buf@Buffer{..} =
     -- buffer has some chars in it already: just return it
     _otherwise ->
       return buf
-#endif
 
 -- ---------------------------------------------------------------------------
 -- hPutChar
@@ -498,16 +467,11 @@ getSomeCharacters handle_@Handle__{..} buf@Buffer{..} =
 --  * 'isPermissionError' if another system resource limit would be exceeded.
 
 hPutChar :: Handle -> Char -> IO ()
-#if defined(ASTERIUS)
-hPutChar (Handle h) c = js_putChar h c
-#else
 hPutChar handle c = do
     c `seq` return ()
     wantWritableHandle "hPutChar" handle $ \ handle_  -> do
      hPutcBuffered handle_ c
-#endif
 
-#if !defined(ASTERIUS)
 hPutcBuffered :: Handle__ -> Char -> IO ()
 hPutcBuffered handle_@Handle__{..} c = do
   buf <- readIORef haCharBuffer
@@ -533,7 +497,6 @@ hPutcBuffered handle_@Handle__{..} c = do
        debugIO ("putc: " ++ summaryBuffer buf)
        w'  <- writeCharBuf raw w c
        return buf{ bufR = w' }
-#endif
 
 -- ---------------------------------------------------------------------------
 -- hPutStr
@@ -576,12 +539,6 @@ hPutStrLn handle str = hPutStr' handle str True
 
 {-# NOINLINE hPutStr' #-}
 hPutStr' :: Handle -> String -> Bool -> IO ()
-#if defined(ASTERIUS)
-hPutStr' handle str add_nl =
-  do
-    hPutChars handle str
-    when add_nl $ hPutChar handle '\n'
-#else
 hPutStr' handle str add_nl =
   do
     (buffer_mode, nl) <-
@@ -597,13 +554,11 @@ hPutStr' handle str add_nl =
             writeBlocks handle True  add_nl nl buf str
        (BlockBuffering _, buf) -> do
             writeBlocks handle False add_nl nl buf str
-#endif
 
 hPutChars :: Handle -> [Char] -> IO ()
 hPutChars _      [] = return ()
 hPutChars handle (c:cs) = hPutChar handle c >> hPutChars handle cs
 
-#if !defined(ASTERIUS)
 getSpareBuffer :: Handle__ -> IO (BufferMode, CharBuffer)
 getSpareBuffer Handle__{haCharBuffer=ref,
                         haBuffers=spare_ref,
@@ -621,10 +576,9 @@ getSpareBuffer Handle__{haCharBuffer=ref,
             BufferListNil -> do
                 new_buf <- newCharBuffer (bufSize buf) WriteBuffer
                 return (mode, new_buf)
-#endif
+
 
 -- NB. performance-critical code: eyeball the Core.
-#if !defined(ASTERIUS)
 writeBlocks :: Handle -> Bool -> Bool -> Newline -> Buffer CharBufElem -> String -> IO ()
 writeBlocks hdl line_buffered add_nl nl
             buf@Buffer{ bufRaw=raw, bufSize=len } s =
@@ -658,14 +612,13 @@ writeBlocks hdl line_buffered add_nl nl
         shoveString n' cs rest
   in
   shoveString 0 s (if add_nl then "\n" else "")
-#endif
 
 -- -----------------------------------------------------------------------------
 -- commitBuffer handle buf sz count flush release
 --
 -- Write the contents of the buffer 'buf' ('sz' bytes long, containing
 -- 'count' bytes of data) to handle (handle must be block or line buffered).
-#if !defined(ASTERIUS)
+
 commitBuffer
         :: Handle                       -- handle to commit to
         -> RawCharBuffer -> Int         -- address and size (in bytes) of buffer
@@ -718,7 +671,6 @@ commitBuffer' raw sz@(I# _) count@(I# _) flush release h_@Handle__{..}
                writeIORef haBuffers (BufferListCons raw spare_bufs)
 
       return this_buf
-#endif
 
 -- ---------------------------------------------------------------------------
 -- Reading/writing sequences of bytes.
@@ -765,9 +717,6 @@ hPutBuf' handle ptr count can_block
   | count == 0 = return 0
   | count <  0 = illegalBufferSize handle "hPutBuf" count
   | otherwise =
-#if defined(ASTERIUS)
-    undefined
-#else
     wantWritableHandle "hPutBuf" handle $
       \ h_@Handle__{..} -> do
           debugIO ("hPutBuf count=" ++ show count)
@@ -781,9 +730,7 @@ hPutBuf' handle ptr count can_block
              BlockBuffering _      -> do return ()
              _line_or_no_buffering -> do flushWriteBuffer h_
           return r
-#endif
 
-#if !defined(ASTERIUS)
 bufWrite :: Handle__-> Ptr Word8 -> Int -> Bool -> IO Int
 bufWrite h_@Handle__{..} ptr count can_block =
   seq count $ do  -- strictness hack
@@ -841,7 +788,6 @@ writeChunkNonBlocking :: Handle__ -> Ptr Word8 -> Int -> IO Int
 writeChunkNonBlocking h_@Handle__{..} ptr bytes
   | Just fd <- cast haDevice  =  RawIO.writeNonBlocking (fd::FD) ptr bytes
   | otherwise = error "Todo: hPutBuf"
-#endif
 
 -- ---------------------------------------------------------------------------
 -- hGetBuf
@@ -862,9 +808,6 @@ writeChunkNonBlocking h_@Handle__{..} ptr bytes
 -- on the 'Handle', and reads bytes directly.
 
 hGetBuf :: Handle -> Ptr a -> Int -> IO Int
-#if defined(ASTERIUS)
-hGetBuf = undefined
-#else
 hGetBuf h !ptr count
   | count == 0 = return 0
   | count <  0 = illegalBufferSize h "hGetBuf" count
@@ -876,13 +819,11 @@ hGetBuf h !ptr count
          if isEmptyBuffer buf
             then bufReadEmpty    h_ buf (castPtr ptr) 0 count
             else bufReadNonEmpty h_ buf (castPtr ptr) 0 count
-#endif
 
 -- small reads go through the buffer, large reads are satisfied by
 -- taking data first from the buffer and then direct from the file
 -- descriptor.
 
-#if !defined(ASTERIUS)
 bufReadNonEmpty :: Handle__ -> Buffer Word8 -> Ptr Word8 -> Int -> Int -> IO Int
 bufReadNonEmpty h_@Handle__{..}
                 buf@Buffer{ bufRaw=raw, bufR=w, bufL=r, bufSize=sz }
@@ -927,7 +868,6 @@ bufReadEmpty h_@Handle__{..}
     if r == 0
         then return (so_far + off)
         else loop fd (off + r) (bytes - r)
-#endif
 
 -- ---------------------------------------------------------------------------
 -- hGetBufSome
@@ -950,9 +890,6 @@ bufReadEmpty h_@Handle__{..}
 -- 'NewlineMode' on the 'Handle', and reads bytes directly.
 
 hGetBufSome :: Handle -> Ptr a -> Int -> IO Int
-#if defined(ASTERIUS)
-hGetBufSome = undefined
-#else
 hGetBufSome h !ptr count
   | count == 0 = return 0
   | count <  0 = illegalBufferSize h "hGetBufSome" count
@@ -974,12 +911,9 @@ hGetBufSome h !ptr count
             else
               let count' = min count (bufferElems buf)
               in bufReadNBNonEmpty h_ buf (castPtr ptr) 0 count'
-#endif
 
-#if !defined(ASTERIUS)
 haFD :: Handle__ -> Maybe FD
 haFD h_@Handle__{..} = cast haDevice
-#endif
 
 -- | 'hGetBufNonBlocking' @hdl buf count@ reads data from the handle @hdl@
 -- into the buffer @buf@ until either EOF is reached, or
@@ -1001,9 +935,6 @@ haFD h_@Handle__{..} = cast haDevice
 -- behaves identically to 'hGetBuf'.
 
 hGetBufNonBlocking :: Handle -> Ptr a -> Int -> IO Int
-#if defined(ASTERIUS)
-hGetBufNonBlocking = undefined
-#else
 hGetBufNonBlocking h !ptr count
   | count == 0 = return 0
   | count <  0 = illegalBufferSize h "hGetBufNonBlocking" count
@@ -1015,9 +946,7 @@ hGetBufNonBlocking h !ptr count
          if isEmptyBuffer buf
             then bufReadNBEmpty    h_ buf (castPtr ptr) 0 count
             else bufReadNBNonEmpty h_ buf (castPtr ptr) 0 count
-#endif
 
-#if !defined(ASTERIUS)
 bufReadNBEmpty :: Handle__ -> Buffer Word8 -> Ptr Word8 -> Int -> Int -> IO Int
 bufReadNBEmpty   h_@Handle__{..}
                  buf@Buffer{ bufRaw=raw, bufR=w, bufL=r, bufSize=sz }
@@ -1067,7 +996,6 @@ bufReadNBNonEmpty h_@Handle__{..}
         if remaining == 0
            then return so_far'
            else bufReadNBEmpty h_ buf' ptr' so_far' remaining
-#endif
 
 -- ---------------------------------------------------------------------------
 -- memcpy wrappers
@@ -1096,3 +1024,4 @@ illegalBufferSize handle fn sz =
                             InvalidArgument  fn
                             ("illegal buffer size " ++ showsPrec 9 sz [])
                             Nothing Nothing)
+

--- a/ghc-toolkit/boot-libs/base/GHC/IO/Handle/Types.hs
+++ b/ghc-toolkit/boot-libs/base/GHC/IO/Handle/Types.hs
@@ -4,7 +4,7 @@
            , ExistentialQuantification
   #-}
 {-# OPTIONS_GHC -funbox-strict-fields #-}
-{-# OPTIONS_HADDOCK hide #-}
+{-# OPTIONS_HADDOCK not-home #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -21,12 +21,8 @@
 -----------------------------------------------------------------------------
 
 module GHC.IO.Handle.Types (
-#if !defined(ASTERIUS)
-      Handle__(..),
+      Handle(..), Handle__(..), showHandle,
       checkHandleInvariants,
-#endif
-      Handle(..),
-      showHandle,
       BufferList(..),
       HandleType(..),
       isReadableHandleType, isWritableHandleType, isReadWriteHandleType,
@@ -99,12 +95,6 @@ import Control.Monad
 -- equal according to '==' only to itself; no attempt
 -- is made to compare the internal state of different handles for equality.
 
-#if defined(ASTERIUS)
-
-newtype Handle = Handle Int
-
-#else
-
 data Handle
   = FileHandle                          -- A normal handle to a file
         FilePath                        -- the file (used for error messages
@@ -118,28 +108,15 @@ data Handle
         !(MVar Handle__)                -- The read side
         !(MVar Handle__)                -- The write side
 
-#endif
 -- NOTES:
 --    * A 'FileHandle' is seekable.  A 'DuplexHandle' may or may not be
 --      seekable.
 
 -- | @since 4.1.0.0
-
-#if defined(ASTERIUS)
-
-instance Eq Handle where
- Handle h1 == Handle h2 = h1 == h2
-
-#else
-
 instance Eq Handle where
  (FileHandle _ h1)     == (FileHandle _ h2)     = h1 == h2
  (DuplexHandle _ h1 _) == (DuplexHandle _ h2 _) = h1 == h2
  _ == _ = False
-
-#endif
-
-#if !defined(ASTERIUS)
 
 data Handle__
   = forall dev enc_state dec_state . (IODevice dev, BufferedIO dev, Typeable dev) =>
@@ -160,7 +137,6 @@ data Handle__
                                              -- duplex handle.
     }
 
-#endif
 -- we keep a few spare buffers around in a handle to avoid allocating
 -- a new one for each hPutStr.  These buffers are *guaranteed* to be the
 -- same size as the main buffer.
@@ -202,8 +178,6 @@ isReadWriteHandleType _                 = False
 --   * In a read Handle, the byte buffer is always empty (we decode when reading)
 --   * In a wriite Handle, the Char buffer is always empty (we encode when writing)
 --
-#if !defined(ASTERIUS)
-
 checkHandleInvariants :: Handle__ -> IO ()
 #if defined(DEBUG)
 checkHandleInvariants h_ = do
@@ -220,8 +194,6 @@ checkHandleInvariants h_ = do
 
 #else
 checkHandleInvariants _ = return ()
-#endif
-
 #endif
 
 -- ---------------------------------------------------------------------------
@@ -379,8 +351,8 @@ and hence it is only possible on a seekable Handle.
 -- Newline translation
 
 -- | The representation of a newline in the external file or stream.
-data Newline = LF    -- ^ '\n'
-             | CRLF  -- ^ '\r\n'
+data Newline = LF    -- ^ @\'\\n\'@
+             | CRLF  -- ^ @\'\\r\\n\'@
              deriving ( Eq   -- ^ @since 4.2.0.0
                       , Ord  -- ^ @since 4.3.0.0
                       , Read -- ^ @since 4.3.0.0
@@ -389,9 +361,9 @@ data Newline = LF    -- ^ '\n'
 
 -- | Specifies the translation, if any, of newline characters between
 -- internal Strings and the external file or stream.  Haskell Strings
--- are assumed to represent newlines with the '\n' character; the
--- newline mode specifies how to translate '\n' on output, and what to
--- translate into '\n' on input.
+-- are assumed to represent newlines with the @\'\\n\'@ character; the
+-- newline mode specifies how to translate @\'\\n\'@ on output, and what to
+-- translate into @\'\\n\'@ on input.
 data NewlineMode
   = NewlineMode { inputNL :: Newline,
                     -- ^ the representation of newlines on input
@@ -413,7 +385,7 @@ nativeNewline = CRLF
 nativeNewline = LF
 #endif
 
--- | Map '\r\n' into '\n' on input, and '\n' to the native newline
+-- | Map @\'\\r\\n\'@ into @\'\\n\'@ on input, and @\'\\n\'@ to the native newline
 -- represetnation on output.  This mode can be used on any platform, and
 -- works with text files using any newline convention.  The downside is
 -- that @readFile >>= writeFile@ might yield a different file.
@@ -460,18 +432,10 @@ instance Show HandleType where
       ReadWriteHandle   -> showString "read-writable"
 
 -- | @since 4.1.0.0
-#if defined(ASTERIUS)
-
-instance Show Handle where
-  showsPrec _ (Handle h) = showString "{handle: " . shows h . showString "}"
-
-#else
-
 instance Show Handle where
   showsPrec _ (FileHandle   file _)   = showHandle file
   showsPrec _ (DuplexHandle file _ _) = showHandle file
 
-#endif
-
 showHandle :: FilePath -> String -> String
 showHandle file = showString "{handle: " . showString file . showString "}"
+

--- a/ghc-toolkit/boot-libs/bytestring/Data/ByteString.hs
+++ b/ghc-toolkit/boot-libs/bytestring/Data/ByteString.hs
@@ -1598,9 +1598,6 @@ getLine = hGetLine stdin
 -- | Read a line from a handle
 
 hGetLine :: Handle -> IO ByteString
-#if defined(ASTERIUS)
-hGetLine = undefined
-#else
 hGetLine h =
   wantReadableHandle_ "Data.ByteString.hGetLine" h $
     \ h_@Handle__{haByteBuffer} -> do
@@ -1645,7 +1642,6 @@ hGetLine h =
             if c == fromIntegral (ord '\n')
                 then return r -- NB. not r+1: don't include the '\n'
                 else findEOL (r+1) w raw
-#endif
 
 mkPS :: RawBuffer Word8 -> Int -> Int -> IO ByteString
 mkPS buf start end =

--- a/ghc-toolkit/boot-libs/bytestring/Data/ByteString/Builder/Internal.hs
+++ b/ghc-toolkit/boot-libs/bytestring/Data/ByteString/Builder/Internal.hs
@@ -149,10 +149,8 @@ import qualified Data.ByteString.Short.Internal as Sh
 
 #if __GLASGOW_HASKELL__ >= 611
 import qualified GHC.IO.Buffer as IO (Buffer(..), newByteBuffer)
-#if !defined(ASTERIUS)
 import           GHC.IO.Handle.Internals (wantWritableHandle, flushWriteBuffer)
 import           GHC.IO.Handle.Types (Handle__, haByteBuffer, haBufferMode)
-#endif
 import           System.IO (hFlush, BufferMode(..))
 import           Data.IORef
 #else
@@ -614,9 +612,6 @@ putLiftIO io = put $ \k br -> io >>= (`k` br)
 -- buffer is too small to execute one step of the 'Put' action, then
 -- it is replaced with a large enough buffer.
 hPut :: forall a. Handle -> Put a -> IO a
-#if defined(ASTERIUS)
-hPut = undefined
-#else
 #if __GLASGOW_HASKELL__ >= 611
 hPut h p = do
     fillHandle 1 (runPut p)
@@ -726,7 +721,6 @@ hPut h p =
 
     go (Finished buf x) = S.hPut h (byteStringFromBuffer buf) >> return x
     go (Yield1 bs io)   = S.hPut h bs >> io >>= go
-#endif
 #endif
 
 -- | Execute a 'Put' and return the computed result and the bytes

--- a/ghc-toolkit/boot-libs/bytestring/Data/ByteString/Internal.hs
+++ b/ghc-toolkit/boot-libs/bytestring/Data/ByteString/Internal.hs
@@ -119,7 +119,6 @@ import GHC.Base                 (unpackCString#)
 #endif
 
 import GHC.Prim                 (Addr#)
-import GHC.Magic                (runRW#)
 
 #if __GLASGOW_HASKELL__ >= 611
 import GHC.IO                   (IO(IO),unsafeDupablePerformIO)
@@ -590,7 +589,7 @@ overflowError fun = error $ "Data.ByteString." ++ fun ++ ": size overflow"
 --
 {-# INLINE accursedUnutterablePerformIO #-}
 accursedUnutterablePerformIO :: IO a -> a
-accursedUnutterablePerformIO (IO m) = case runRW# m of (# _, r #) -> r
+accursedUnutterablePerformIO (IO m) = case m realWorld# of (# _, r #) -> r
 
 inlinePerformIO :: IO a -> a
 inlinePerformIO = accursedUnutterablePerformIO

--- a/ghc-toolkit/boot-libs/unix/System/Posix/IO/Common.hsc
+++ b/ghc-toolkit/boot-libs/unix/System/Posix/IO/Common.hsc
@@ -208,9 +208,6 @@ handleToFd :: Handle -> IO Fd
 fdToHandle :: Fd -> IO Handle
 fdToHandle fd = FD.fdToHandle (fromIntegral fd)
 
-#if defined(ASTERIUS)
-handleToFd (Handle h) = pure (Fd (fromIntegral h))
-#else
 handleToFd h@(FileHandle _ m) = do
   withHandle' "handleToFd" h m $ handleToFd' h
 handleToFd h@(DuplexHandle _ r w) = do
@@ -219,9 +216,7 @@ handleToFd h@(DuplexHandle _ r w) = do
   -- for a DuplexHandle, make sure we mark both sides as closed,
   -- otherwise a finalizer will come along later and close the other
   -- side. (#3914)
-#endif
 
-#if !defined(ASTERIUS)
 handleToFd' :: Handle -> Handle__ -> IO (Handle__, Fd)
 handleToFd' h h_@Handle__{haType=_,..} = do
   case cast haDevice of
@@ -235,7 +230,7 @@ handleToFd' h h_@Handle__{haType=_,..} = do
      flushWriteBuffer h_
      FD.release fd
      return (Handle__{haType=ClosedHandle,..}, Fd (FD.fdFD fd))
-#endif
+
 
 -- -----------------------------------------------------------------------------
 -- Fd options


### PR DESCRIPTION
As a part of the migration from using an ad hoc ghc-head revision to ghc-8.6.5, we're identifying and getting rid of legacy hacks in our boot libs. This PR removes all `Handle` related hacks in `base`/`unix`.

Now the original `Handle` type works out of the box at least for `stdout`/`stderr`, which is sufficient to support the tests. They are flushed by the top handler when `main` exits.