### PR TITLE
Remove md5 hack in configure.ac of base

### DIFF
--- a/ghc-toolkit/boot-libs/base/GHC/Fingerprint.hs
+++ b/ghc-toolkit/boot-libs/base/GHC/Fingerprint.hs
@@ -33,23 +33,8 @@ import System.IO
 
 import GHC.Fingerprint.Type
 
+-- for SIZEOF_STRUCT_MD5CONTEXT:
 #include "HsBaseConfig.h"
-
--- for SIZEOF_STRUCT_MD5CONTEXT to be correct. For some reason,
--- configure.ac sets SIZEOF_STRUCT_MD5CONTEXT to be 0. Here, we hardcode
--- the correct value.
-{- Discovered by running:
-  {-# LANGUAGE CPP #-}
-
-  #include "HsBaseConfig.h"
-
-  main :: IO ()
-  main = print (SIZEOF_STRUCT_MD5CONTEXT :: Int)
--}
-#ifdef ASTERIUS
-#undef SIZEOF_STRUCT_MD5CONTEXT
-#define SIZEOF_STRUCT_MD5CONTEXT 88
-#endif
 
 -- XXX instance Storable Fingerprint
 -- defined in Foreign.Storable to avoid orphan instance

--- a/ghc-toolkit/boot-libs/base/configure.ac
+++ b/ghc-toolkit/boot-libs/base/configure.ac
@@ -234,10 +234,10 @@ AS_IF([test "x$with_libcharset" != xno],
 fi
 
 # Hack - md5.h needs HsFFI.h.  Is there a better way to do this?
-CFLAGS="-I../.. -I../../../../includes $CFLAGS"
+CFLAGS="-I$ASTERIUS_SANDBOX_GHC_LIBDIR/include -I$ASTERIUS_BOOT_LIBS_DIR/base $CFLAGS"
 dnl Calling AC_CHECK_TYPE(T) makes AC_CHECK_SIZEOF(T) abort on failure
 dnl instead of considering sizeof(T) as 0.
-AC_CHECK_TYPE([struct MD5Context], [], [], [#include "include/md5.h"])
+AC_CHECK_TYPE([struct MD5Context], [], [AC_MSG_ERROR([internal error])], [#include "include/md5.h"])
 AC_CHECK_SIZEOF([struct MD5Context], [], [#include "include/md5.h"])
 
 AC_SUBST(EXTRA_LIBS)


### PR DESCRIPTION
This PR removes a hack related to md5 in `configure.ac` of `base`. Previously the `AC_CHECK_TYPE` for `struct MD5Context` always failed since the include paths only work in a ghc build tree instead of asterius boot; we had to allow the failure and manually set the size via a CPP macro. Now we correct the include paths; as usual, the less hacks the better.