### PR TITLE
Remove hack of integerToString

### DIFF
--- a/asterius/rts/rts.integer.mjs
+++ b/asterius/rts/rts.integer.mjs
@@ -19,18 +19,14 @@ function popCount(a) {
 }
 
 export class IntegerManager {
-  constructor(jsvalManager, heap) {
+  constructor(jsvalManager) {
     this.jsvalManager = jsvalManager;
-    this.heap = heap;
 
     // buffer of 8 bytes to hold floats/doubles
     this.buffer = new ArrayBuffer(8);
     this.view = new DataView(this.buffer);
 
-    Object.seal(this);
-  }
-  integerToString(i, l) {
-    return this.heap.newHaskellString(this.decode(i).toString(), l);
+    Object.freeze(this);
   }
   newInteger(non_neg) {
     return this.jsvalManager.newTmpJSVal(

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -42,7 +42,7 @@ export function newAsteriusInstance(req) {
     __asterius_stablename_manager = new StableNameManager(__asterius_memory, __asterius_heapalloc, req.symbolTable),
     __asterius_tso_manager = new TSOManager(__asterius_memory, req.symbolTable, __asterius_stableptr_manager),
     __asterius_heap_builder = new HeapBuilder(req.symbolTable, __asterius_heapalloc, __asterius_memory, __asterius_stableptr_manager),
-    __asterius_integer_manager = new IntegerManager(__asterius_stableptr_manager, __asterius_heap_builder),
+    __asterius_integer_manager = new IntegerManager(__asterius_stableptr_manager),
     __asterius_fs = new MemoryFileSystem(__asterius_logger),
     __asterius_bytestring_cbits = new ByteStringCBits(null),
     __asterius_gc = new GC(__asterius_memory, __asterius_mblockalloc, __asterius_heapalloc, __asterius_stableptr_manager, __asterius_stablename_manager, __asterius_tso_manager, req.infoTables, req.pinnedStaticClosures, req.symbolTable, __asterius_reentrancy_guard, req.yolo),
@@ -170,7 +170,6 @@ export function newAsteriusInstance(req) {
       __asterius_memory.init(__asterius_wasm_memory, req.staticMBlocks);
       __asterius_mblockalloc.init(__asterius_memory);
       __asterius_heapalloc.init();
-      __asterius_integer_manager.heap = __asterius_heap_builder;
       __asterius_bytestring_cbits.memory = __asterius_memory;
       return Object.assign(__asterius_jsffi_instance, {
         wasmModule: req.module,

--- a/ghc-toolkit/boot-libs/base/GHC/Show.hs
+++ b/ghc-toolkit/boot-libs/base/GHC/Show.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE CPP, NoImplicitPrelude, BangPatterns, StandaloneDeriving,
-             MagicHash, UnboxedTuples, UnliftedFFITypes #-}
+             MagicHash, UnboxedTuples #-}
 {-# OPTIONS_HADDOCK not-home #-}
 
 #include "MachDeps.h"
@@ -53,13 +53,6 @@ import GHC.Base
 import GHC.List ((!!), foldr1, break)
 import GHC.Num
 import GHC.Stack.Types
-import GHC.Types (TypeLitSort (..))
-
-#if defined(ASTERIUS)
-import Asterius.Magic
-import GHC.Integer.Simple.Internals
-import GHC.Prim
-#endif
 
 
 -- | The @shows@ functions return a function that prepends the
@@ -494,16 +487,6 @@ instance Show Natural where
 
 -- Divide and conquer implementation of string conversion
 integerToString :: Integer -> String -> String
-#if defined(ASTERIUS)
-
-integerToString (Integer i) s =
-  accursedUnutterableAddrToAny
-    (js_integerToString i (accursedUnutterableAnyToAddr s))
-
-foreign import javascript "__asterius_jsffi.Integer.integerToString(${1},${2})" js_integerToString
-  :: Int# -> Addr# -> Addr#
-
-#else
 integerToString n0 cs0
     | n0 < 0    = '-' : integerToString' (- n0) cs0
     | otherwise = integerToString' n0 cs0
@@ -580,7 +563,6 @@ integerToString n0 cs0
              c@(C# _) -> jblock' (d - 1) q (c : cs)
         where
         (q, r) = n `quotRemInt` 10
-#endif
 
 instance Show KindRep where
   showsPrec d (KindRepVar v) = showParen (d > 10) $


### PR DESCRIPTION
This PR removes our custom `integerToString` implementation and re-enables the Haskell implementation in `base`. We disabled the Haskell implementation when we first landed the `BigInt`-based Integer library, but due to some heisenbug it outputs a wrong `String`, so we had to build the `String` on the heap on the JavaScript side. Now we can remove this hack.