### PR TITLE
CPP macros to build ghc-toolkit with ghc 8.8

### DIFF
--- a/ghc-toolkit/Setup.hs
+++ b/ghc-toolkit/Setup.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wall #-}
 
@@ -25,6 +26,9 @@ main =
                                } <- confHook simpleUserHooks t f
             let [clbi@LibComponentLocalBuildInfo {componentUnitId = uid}] =
                   componentNameMap lbi M.! CLibName
+#if MIN_VERSION_Cabal (2,5,0)
+                    LMainLibName
+#endif
                 amp = autogenComponentModulesDir lbi clbi
                 self_installdirs =
                   absoluteComponentInstallDirs pkg_descr lbi uid NoCopyDest

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Compiler.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Compiler.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE StrictData #-}
 
@@ -20,7 +21,11 @@ data HaskellIR = HaskellIR
   { parsed :: HsParsedModule
   , typechecked :: TcGblEnv
   , core :: CgGuts
+#if MIN_VERSION_ghc(8,7,0)
+  , stg :: [CgStgTopBinding]
+#else
   , stg :: [StgTopBinding]
+#endif
   , cmm :: [[CmmDecl]]
   , cmmRaw :: [[RawCmmDecl]]
   }

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/GenPaths.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/GenPaths.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StrictData #-}
 
@@ -6,6 +7,7 @@ module Language.Haskell.GHC.Toolkit.GenPaths
   , genPaths
   ) where
 
+import Data.Maybe (fromMaybe)
 import qualified Data.Map as M
 import Distribution.ModuleName
 import Distribution.Simple
@@ -22,6 +24,11 @@ newtype GenPathsOptions = GenPathsOptions
   { targetModuleName :: String
   }
 
+cLibName = CLibName
+#if MIN_VERSION_Cabal (2,5,0)
+  LMainLibName
+#endif
+
 genPaths :: GenPathsOptions -> UserHooks -> UserHooks
 genPaths GenPathsOptions {..} h =
   h
@@ -29,56 +36,43 @@ genPaths GenPathsOptions {..} h =
         \t f -> do
           lbi@LocalBuildInfo {localPkgDescr = pkg_descr@PackageDescription {library = Just lib@Library {libBuildInfo = lib_bi}}} <-
             confHook h t f
-          let [clbi] = componentNameMap lbi M.! CLibName
-              mod_path = autogenComponentModulesDir lbi clbi
-              mod_name = fromString targetModuleName
-              ghc_libdir = compilerProperties (compiler lbi) M.! "LibDir"
-          createDirectoryIfMissing True mod_path
-          writeFile (mod_path </> targetModuleName <.> "hs") $
-            "module " ++
-            targetModuleName ++
-            " where\n\n" ++
-            concat
-              [ let Just conf_prog = lookupProgram prog (withPrograms lbi)
-                 in prog_name ++
-                    " :: FilePath\n" ++
-                    prog_name ++ " = " ++ show (programPath conf_prog) ++ "\n\n"
-              | (prog_name, prog) <-
-                  [("ghc", ghcProgram), ("ghcPkg", ghcPkgProgram)]
-              ] ++
-            "ghcLibDir :: FilePath\nghcLibDir = " ++
-            show ghc_libdir ++
-            "\n\n" ++
-            concat
-              [ k ++
-              " :: FilePath\n" ++
-              k ++
-              " = " ++
-              show
-                (d $
-                 absoluteComponentInstallDirs
-                   pkg_descr
-                   lbi
-                   (componentUnitId clbi)
-                   NoCopyDest) ++
-              "\n\n"
-              | (k, d) <- [("binDir", bindir), ("dataDir", datadir)]
-              ]
-          pure
-            lbi
-              { localPkgDescr =
-                  pkg_descr
-                    { library =
-                        Just
-                          lib
-                            { libBuildInfo =
-                                lib_bi
-                                  { otherModules =
-                                      mod_name : otherModules lib_bi
-                                  , autogenModules =
-                                      mod_name : autogenModules lib_bi
-                                  }
-                            }
-                    }
-              }
+
+          case M.lookup cLibName $ componentNameMap lbi of
+            Nothing -> pure lbi
+            Just [clbi] -> do
+              let mod_path = autogenComponentModulesDir lbi clbi
+                  mod_name = fromString targetModuleName
+                  ghc_libdir = compilerProperties (compiler lbi) M.! "LibDir"
+              createDirectoryIfMissing True mod_path
+              writeFile (mod_path </> targetModuleName <.> "hs") $
+                "module " ++
+                targetModuleName ++
+                " where\n\n" ++
+                concat
+                  [ let Just conf_prog = lookupProgram prog (withPrograms lbi)
+                     in prog_name ++
+                        " :: FilePath\n" ++
+                        prog_name ++ " = " ++ show (programPath conf_prog) ++ "\n\n"
+                  | (prog_name, prog) <-
+                      [("ghc", ghcProgram), ("ghcPkg", ghcPkgProgram)]
+                  ] ++
+                "ghcLibDir :: FilePath\nghcLibDir = " ++
+                show ghc_libdir
+              pure
+                lbi
+                  { localPkgDescr =
+                      pkg_descr
+                        { library =
+                            Just
+                              lib
+                                { libBuildInfo =
+                                    lib_bi
+                                      { otherModules =
+                                          mod_name : otherModules lib_bi
+                                      , autogenModules =
+                                          mod_name : autogenModules lib_bi
+                                      }
+                                }
+                        }
+                  }
     }

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Hooks.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Hooks.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -80,7 +81,11 @@ hooksFromCompiler Compiler {..} = do
                 r@(_, obj_output_fn) <-
                   do output_fn <-
                        GHC.phaseOutputFilename $
-                       GHC.hscPostBackendPhase dflags src_flavour $
+                       GHC.hscPostBackendPhase
+#if !MIN_VERSION_ghc(8,7,0)
+                         dflags
+#endif
+                         src_flavour $
                        GHC.hscTarget dflags
                      GHC.PipeState {GHC.hsc_env = hsc_env'} <- GHC.getPipeState
                      void $

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Orphans/Show.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Orphans/Show.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -34,7 +35,9 @@ import System.IO.Unsafe
 import Text.Show.Functions ()
 import TyCoRep
 import TyCon
+#if MIN_VERSION_ghc(8,7,0)
 import UniqDSet
+#endif
 import Var
 
 {-# NOINLINE dynFlagsRef #-}
@@ -107,16 +110,32 @@ instance Show a => Show (IORef a) where
 
 deriving instance Show CoercionHole
 
+#if MIN_VERSION_ghc(8,7,0)
+deriving instance Show MCoercionN
+#endif
+
 deriving instance Show Coercion
 
+#if MIN_VERSION_ghc(8,7,0)
+deriving instance Show TyCoVarBinder
+#else
 deriving instance
          (Show tyvar, Show argf) => Show (TyVarBndr tyvar argf)
+#endif
+
+#if MIN_VERSION_ghc(8,7,0)
+deriving instance Show AnonArgFlag
+#endif
 
 deriving instance Show Type
 
 deriving instance Show LitNumType
 
 deriving instance Show Literal
+
+#if !MIN_VERSION_ghc(8,7,0)
+deriving instance Show occ => Show (GenStgArg occ)
+#endif
 
 instance Show DataCon where
   show = fakeShow "DataCon"
@@ -139,6 +158,37 @@ deriving instance Show AltType
 
 deriving instance Show AltCon
 
+#if MIN_VERSION_ghc(8,7,0)
+deriving instance Show StgArg
+
+instance Show NoExtSilent where
+  show = fakeShow "NoExtSilent"
+
+deriving instance
+         (Show (BinderP pass), Show (XLet pass), Show (XLetNoEscape pass),
+          Show (XRhsClosure pass)) =>
+         Show (GenStgExpr pass)
+
+instance Show CostCentreStack where
+  show = fakeShow "CostCentreStack"
+
+deriving instance Show UpdateFlag
+
+deriving instance
+         (Show (BinderP pass), Show (XLet pass), Show (XLetNoEscape pass),
+          Show (XRhsClosure pass)) =>
+         Show (GenStgRhs pass)
+
+deriving instance
+         (Show (BinderP pass), Show (XLet pass), Show (XLetNoEscape pass),
+          Show (XRhsClosure pass)) =>
+         Show (GenStgBinding pass)
+
+deriving instance
+         (Show (BinderP pass), Show (XLet pass), Show (XLetNoEscape pass),
+          Show (XRhsClosure pass)) =>
+         Show (GenStgTopBinding pass)
+#else
 deriving instance Show occ => Show (GenStgArg occ)
 
 deriving instance
@@ -162,6 +212,7 @@ deriving instance
 
 deriving instance
          (Show bndr, Show occ) => Show (GenStgTopBinding bndr occ)
+#endif
 
 instance Show Name where
   show = fakeShow "Name"
@@ -254,5 +305,7 @@ deriving instance Show CmmStackInfo
 
 deriving instance Show CmmTopInfo
 
+#if MIN_VERSION_ghc(8,7,0)
 instance Show a => Show (UniqDSet a) where
   showsPrec p = showsPrec p . uniqDSetToList
+#endif


### PR DESCRIPTION
Split out from the nix-tools-3 branch and re-based on current master.
We don't need this in nix-tools any more (now that master is 8.6.5
based), but it might be nice to have if we need to support 8.8 in
the future.