### PR TITLE
Gen2 JSFFI part I

### DIFF
--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -62,6 +62,7 @@ dependencies:
   - directory
   - filepath
   - ghc
+  - ghc-boot
   - ghc-prim
   - ghc-toolkit
   - ghci

--- a/asterius/src/Asterius/Foreign.hs
+++ b/asterius/src/Asterius/Foreign.hs
@@ -1,0 +1,567 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+module Asterius.Foreign
+  ( asteriusDsForeigns
+    )
+where
+
+import BasicTypes
+import CmmExpr
+import CmmUtils
+import Coercion
+import Config
+import CoreSyn
+import CoreUnfold
+import Data.List
+import Data.Maybe
+import DataCon
+import DsCCall
+import DsMonad
+import DynFlags
+import Encoding
+import FastString
+import ForeignCall
+import HsSyn
+import HscTypes
+import Id
+import Literal
+import Module
+import Name
+import OrdList
+import Outputable
+import Pair
+import Platform
+import PrelNames
+import RepType
+import SrcLoc
+import TcEnv
+import TcRnMonad
+import TcType
+import TyCon
+import Type
+import TysPrim
+import TysWiredIn
+import Prelude hiding ((<>))
+
+type Binding = (Id, CoreExpr)
+
+asteriusDsForeigns
+  :: [LForeignDecl GhcTc] -> DsM (ForeignStubs, OrdList Binding)
+asteriusDsForeigns [] = return (NoStubs, nilOL)
+asteriusDsForeigns fos = do
+  fives <- mapM do_ldecl fos
+  let (hs, cs, idss, bindss) = unzip4 fives
+      fe_ids = concat idss
+      fe_init_code = map foreignExportInitialiser fe_ids
+  return
+    ( ForeignStubs (vcat hs) (vcat cs $$ vcat fe_init_code),
+      foldr (appOL . toOL) nilOL bindss
+      )
+  where
+    do_ldecl (L loc decl) = putSrcSpanDs loc (do_decl decl)
+    do_decl ForeignImport {fd_name = id, fd_i_ext = co, fd_fi = spec} = do
+      traceIf (text "fi start" <+> ppr id)
+      let id' = unLoc id
+      (bs, h, c) <- dsFImport id' co spec
+      traceIf (text "fi end" <+> ppr id)
+      return (h, c, [], bs)
+    do_decl
+      ForeignExport
+        { fd_name = L _ id,
+          fd_e_ext = co,
+          fd_fe = CExport (L _ (CExportStatic _ ext_nm cconv)) _
+          } = do
+        (h, c, _, _) <- dsFExport id co ext_nm cconv False
+        return (h, c, [id], [])
+    do_decl (XForeignDecl _) = panic "asteriusDsForeigns"
+
+dsFImport :: Id -> Coercion -> ForeignImport -> DsM ([Binding], SDoc, SDoc)
+dsFImport id co (CImport cconv safety mHeader spec _) =
+  dsCImport id co spec (unLoc cconv) (unLoc safety) mHeader
+
+dsCImport
+  :: Id
+  -> Coercion
+  -> CImportSpec
+  -> CCallConv
+  -> Safety
+  -> Maybe Header
+  -> DsM ([Binding], SDoc, SDoc)
+dsCImport id co (CLabel cid) cconv _ _ = do
+  dflags <- getDynFlags
+  let ty = pFst $ coercionKind co
+      fod =
+        case tyConAppTyCon_maybe (dropForAlls ty) of
+          Just tycon
+            | tyConUnique tycon == funPtrTyConKey -> IsFunction
+          _ -> IsData
+  (_, foRhs) <- resultWrapper ty
+  let rhs = foRhs (Lit (MachLabel cid stdcall_info fod))
+      rhs' = Cast rhs co
+      stdcall_info = funTypeArgStdcallInfo dflags cconv ty
+   in return ([(id, rhs')], empty, empty)
+dsCImport id co (CFunction target) cconv@PrimCallConv safety _ =
+  dsPrimCall id co (CCall (CCallSpec target cconv safety))
+dsCImport id co (CFunction target) cconv safety mHeader =
+  dsFCall id co (CCall (CCallSpec target cconv safety)) mHeader
+dsCImport id co CWrapper cconv _ _ = dsFExportDynamic id co cconv
+
+funTypeArgStdcallInfo :: DynFlags -> CCallConv -> Type -> Maybe Int
+funTypeArgStdcallInfo dflags StdCallConv ty
+  | Just (tc, [arg_ty]) <- splitTyConApp_maybe ty,
+    tyConUnique tc == funPtrTyConKey =
+    let (bndrs, _) = tcSplitPiTys arg_ty
+        fe_arg_tys = mapMaybe binderRelevantType_maybe bndrs
+     in Just
+          $ sum
+              ( map
+                  (widthInBytes . typeWidth . typeCmmType dflags . getPrimTyOf)
+                  fe_arg_tys
+                )
+funTypeArgStdcallInfo _ _other_conv _ = Nothing
+
+dsFCall
+  :: Id
+  -> Coercion
+  -> ForeignCall
+  -> Maybe Header
+  -> DsM ([(Id, Expr TyVar)], SDoc, SDoc)
+dsFCall fn_id co fcall mDeclHeader = do
+  let ty = pFst $ coercionKind co
+      (tv_bndrs, rho) = tcSplitForAllTyVarBndrs ty
+      (arg_tys, io_res_ty) = tcSplitFunTys rho
+  args <- newSysLocalsDs arg_tys
+  (val_args, arg_wrappers) <- mapAndUnzipM unboxArg (map Var args)
+  let work_arg_ids = [v | Var v <- val_args]
+  (ccall_result_ty, res_wrapper) <- boxResult io_res_ty
+  ccall_uniq <- newUnique
+  work_uniq <- newUnique
+  dflags <- getDynFlags
+  (fcall', cDoc) <-
+    case fcall of
+      CCall (CCallSpec (StaticTarget _ cName mUnitId isFun) CApiConv safety) -> do
+        wrapperName <- mkWrapperName "ghc_wrapper" (unpackFS cName)
+        let fcall' =
+              CCall
+                ( CCallSpec
+                    (StaticTarget NoSourceText wrapperName mUnitId True)
+                    CApiConv
+                    safety
+                  )
+            c = includes $$ fun_proto <+> braces (cRet <> semi)
+            includes =
+              vcat
+                [ text "#include \"" <> ftext h <> text "\""
+                  | Header _ h <- nub headers
+                  ]
+            fun_proto =
+              cResType <+> pprCconv <+> ppr wrapperName <> parens argTypes
+            cRet
+              | isVoidRes = cCall
+              | otherwise = text "return" <+> cCall
+            cCall
+              | isFun = ppr cName <> parens argVals
+              | null arg_tys = ppr cName
+              | otherwise =
+                panic "dsFCall: Unexpected arguments to FFI value import"
+            raw_res_ty =
+              case tcSplitIOType_maybe io_res_ty of
+                Just (_ioTyCon, res_ty) -> res_ty
+                Nothing -> io_res_ty
+            isVoidRes = raw_res_ty `eqType` unitTy
+            (mHeader, cResType)
+              | isVoidRes = (Nothing, text "void")
+              | otherwise = toCType raw_res_ty
+            pprCconv = ccallConvAttribute CApiConv
+            mHeadersArgTypeList =
+              [ (header, cType <+> char 'a' <> int n)
+                | (t, n) <- zip arg_tys [1 ..],
+                  let (header, cType) = toCType t
+                ]
+            (mHeaders, argTypeList) = unzip mHeadersArgTypeList
+            argTypes =
+              if null argTypeList
+              then text "void"
+              else hsep $ punctuate comma argTypeList
+            mHeaders' = mDeclHeader : mHeader : mHeaders
+            headers = catMaybes mHeaders'
+            argVals =
+              hsep
+                $ punctuate comma [char 'a' <> int n | (_, n) <- zip arg_tys [1 ..]]
+        return (fcall', c)
+      _ -> return (fcall, empty)
+  let worker_ty =
+        mkForAllTys
+          tv_bndrs
+          (mkFunTys (map idType work_arg_ids) ccall_result_ty)
+      tvs = map binderVar tv_bndrs
+      the_ccall_app = mkFCall dflags ccall_uniq fcall' val_args ccall_result_ty
+      work_rhs = mkLams tvs (mkLams work_arg_ids the_ccall_app)
+      work_id = mkSysLocal (fsLit "$wccall") work_uniq worker_ty
+      work_app = mkApps (mkVarApps (Var work_id) tvs) val_args
+      wrapper_body = foldr ($) (res_wrapper work_app) arg_wrappers
+      wrap_rhs = mkLams (tvs ++ args) wrapper_body
+      wrap_rhs' = Cast wrap_rhs co
+      fn_id_w_inl =
+        fn_id
+          `setIdUnfolding` mkInlineUnfoldingWithArity (length args) wrap_rhs'
+  return ([(work_id, work_rhs), (fn_id_w_inl, wrap_rhs')], empty, cDoc)
+
+dsPrimCall
+  :: Id -> Coercion -> ForeignCall -> DsM ([(Id, Expr TyVar)], SDoc, SDoc)
+dsPrimCall fn_id co fcall = do
+  let ty = pFst $ coercionKind co
+      (tvs, fun_ty) = tcSplitForAllTys ty
+      (arg_tys, io_res_ty) = tcSplitFunTys fun_ty
+  args <- newSysLocalsDs arg_tys
+  ccall_uniq <- newUnique
+  dflags <- getDynFlags
+  let call_app = mkFCall dflags ccall_uniq fcall (map Var args) io_res_ty
+      rhs = mkLams tvs (mkLams args call_app)
+      rhs' = Cast rhs co
+  return ([(fn_id, rhs')], empty, empty)
+
+dsFExport
+  :: Id
+  -> Coercion
+  -> CLabelString
+  -> CCallConv
+  -> Bool
+  -> DsM (SDoc, SDoc, String, Int)
+dsFExport fn_id co ext_name cconv isDyn = do
+  let ty = pSnd $ coercionKind co
+      (bndrs, orig_res_ty) = tcSplitPiTys ty
+      fe_arg_tys' = mapMaybe binderRelevantType_maybe bndrs
+      fe_arg_tys
+        | isDyn = tail fe_arg_tys'
+        | otherwise = fe_arg_tys'
+      (res_ty, is_IO_res_ty) =
+        case tcSplitIOType_maybe orig_res_ty of
+          Just (_ioTyCon, res_ty) -> (res_ty, True)
+          Nothing -> (orig_res_ty, False)
+  dflags <- getDynFlags
+  return
+    $ mkFExportCBits
+        dflags
+        ext_name
+        ( if isDyn
+          then Nothing
+          else Just fn_id
+          )
+        fe_arg_tys
+        res_ty
+        is_IO_res_ty
+        cconv
+
+dsFExportDynamic :: Id -> Coercion -> CCallConv -> DsM ([Binding], SDoc, SDoc)
+dsFExportDynamic id co0 cconv = do
+  mod <- getModule
+  dflags <- getDynFlags
+  let fe_nm =
+        mkFastString
+          $ zEncodeString (moduleStableString mod ++ "$" ++ toCName dflags id)
+  cback <- newSysLocalDs arg_ty
+  newStablePtrId <- dsLookupGlobalId newStablePtrName
+  stable_ptr_tycon <- dsLookupTyCon stablePtrTyConName
+  let stable_ptr_ty = mkTyConApp stable_ptr_tycon [arg_ty]
+      export_ty = mkFunTy stable_ptr_ty arg_ty
+  bindIOId <- dsLookupGlobalId bindIOName
+  stbl_value <- newSysLocalDs stable_ptr_ty
+  (h_code, c_code, typestring, args_size) <-
+    dsFExport id (mkRepReflCo export_ty) fe_nm cconv True
+  let adj_args =
+        [ mkIntLitInt dflags (ccallConvToInt cconv),
+          Var stbl_value,
+          Lit (MachLabel fe_nm mb_sz_args IsFunction),
+          Lit (mkMachString typestring)
+          ]
+      adjustor = fsLit "createAdjustor"
+      mb_sz_args =
+        case cconv of
+          StdCallConv -> Just args_size
+          _ -> Nothing
+  ccall_adj <- dsCCall adjustor adj_args PlayRisky (mkTyConApp io_tc [res_ty])
+  let io_app =
+        mkLams tvs
+          $ Lam cback
+          $ mkApps
+              (Var bindIOId)
+              [ Type stable_ptr_ty,
+                Type res_ty,
+                mkApps (Var newStablePtrId) [Type arg_ty, Var cback],
+                Lam stbl_value ccall_adj
+                ]
+      fed = (id `setInlineActivation` NeverActive, Cast io_app co0)
+  return ([fed], h_code, c_code)
+  where
+    ty = pFst (coercionKind co0)
+    (tvs, sans_foralls) = tcSplitForAllTys ty
+    ([arg_ty], fn_res_ty) = tcSplitFunTys sans_foralls
+    Just (io_tc, res_ty) = tcSplitIOType_maybe fn_res_ty
+
+toCName :: DynFlags -> Id -> String
+toCName dflags i = showSDoc dflags (pprCode CStyle (ppr (idName i)))
+
+mkFExportCBits
+  :: DynFlags
+  -> FastString
+  -> Maybe Id
+  -> [Type]
+  -> Type
+  -> Bool
+  -> CCallConv
+  -> (SDoc, SDoc, String, Int)
+mkFExportCBits dflags c_nm maybe_target arg_htys res_hty is_IO_res_ty cc =
+  ( header_bits,
+    c_bits,
+    type_string,
+    sum [widthInBytes (typeWidth rep) | (_, _, _, rep) <- aug_arg_info]
+    )
+  where
+    arg_info :: [(SDoc, SDoc, Type, CmmType)]
+    arg_info =
+      [ let stg_type = showStgType ty
+         in ( arg_cname n stg_type,
+              stg_type,
+              ty,
+              typeCmmType dflags (getPrimTyOf ty)
+              )
+        | (ty, n) <- zip arg_htys [1 :: Int ..]
+        ]
+    arg_cname n stg_ty
+      | libffi =
+        char '*'
+          <> parens (stg_ty <> char '*')
+          <> text "args"
+          <> brackets (int (n - 1))
+      | otherwise = text ('a' : show n)
+    libffi = cLibFFI && isNothing maybe_target
+    type_string
+      | libffi = primTyDescChar dflags res_hty : arg_type_string
+      | otherwise = arg_type_string
+    arg_type_string = [primTyDescChar dflags ty | (_, _, ty, _) <- arg_info]
+    aug_arg_info
+      | isNothing maybe_target =
+        stable_ptr_arg : insertRetAddr dflags cc arg_info
+      | otherwise = arg_info
+    stable_ptr_arg =
+      ( text "the_stableptr",
+        text "StgStablePtr",
+        undefined,
+        typeCmmType dflags (mkStablePtrPrimTy alphaTy)
+        )
+    res_hty_is_unit = res_hty `eqType` unitTy
+    cResType
+      | res_hty_is_unit = text "void"
+      | otherwise = showStgType res_hty
+    ffi_cResType
+      | is_ffi_arg_type = text "ffi_arg"
+      | otherwise = cResType
+      where
+        res_ty_key = getUnique (getName (typeTyCon res_hty))
+        is_ffi_arg_type =
+          res_ty_key
+            `notElem` [floatTyConKey, doubleTyConKey, int64TyConKey, word64TyConKey]
+    pprCconv = ccallConvAttribute cc
+    header_bits = text "extern" <+> fun_proto <> semi
+    fun_args
+      | null aug_arg_info = text "void"
+      | otherwise =
+        hsep $ punctuate comma $ map (\(nm, ty, _, _) -> ty <+> nm) aug_arg_info
+    fun_proto
+      | libffi =
+        text "void"
+          <+> ftext c_nm
+          <> parens
+               ( text
+                   "void *cif STG_UNUSED, void* resp, void** args, void* the_stableptr"
+                 )
+      | otherwise = cResType <+> pprCconv <+> ftext c_nm <> parens fun_args
+    the_cfun =
+      case maybe_target of
+        Nothing -> text "(StgClosure*)deRefStablePtr(the_stableptr)"
+        Just hs_fn -> char '&' <> ppr hs_fn <> text "_closure"
+    cap = text "cap" <> comma
+    expr_to_run = foldl appArg the_cfun arg_info
+      where
+        appArg acc (arg_cname, _, arg_hty, _) =
+          text "rts_apply"
+            <> parens
+                 (cap <> acc <> comma <> mkHObj arg_hty <> parens (cap <> arg_cname))
+    declareResult = text "HaskellObj ret;"
+    declareCResult
+      | res_hty_is_unit = empty
+      | otherwise = cResType <+> text "cret;"
+    assignCResult
+      | res_hty_is_unit = empty
+      | otherwise =
+        text "cret=" <> unpackHObj res_hty <> parens (text "ret") <> semi
+    extern_decl =
+      case maybe_target of
+        Nothing -> empty
+        Just hs_fn ->
+          text "extern StgClosure " <> ppr hs_fn <> text "_closure" <> semi
+    c_bits =
+      space $$ extern_decl $$ fun_proto
+        $$ vcat
+             [ lbrace,
+               text "Capability *cap;",
+               declareResult,
+               declareCResult,
+               text "cap = rts_lock();",
+               text "rts_evalIO"
+                 <> parens
+                      ( char '&'
+                          <> cap
+                          <> text "rts_apply"
+                          <> parens
+                               ( cap
+                                   <> text "(HaskellObj)"
+                                   <> ptext
+                                        ( if is_IO_res_ty
+                                          then sLit "runIO_closure"
+                                          else sLit "runNonIO_closure"
+                                          )
+                                   <> comma
+                                   <> expr_to_run
+                                 )
+                          <+> comma
+                          <> text "&ret"
+                        )
+                 <> semi,
+               text "rts_checkSchedStatus"
+                 <> parens (doubleQuotes (ftext c_nm) <> comma <> text "cap")
+                 <> semi,
+               assignCResult,
+               text "rts_unlock(cap);",
+               ppUnless res_hty_is_unit
+                 $ if libffi
+                 then
+                   char '*'
+                     <> parens (ffi_cResType <> char '*')
+                     <> text "resp = cret;"
+                 else text "return cret;",
+               rbrace
+               ]
+
+foreignExportInitialiser :: Id -> SDoc
+foreignExportInitialiser hs_fn =
+  vcat
+    [ text "static void stginit_export_"
+        <> ppr hs_fn
+        <> text "() __attribute__((constructor));",
+      text "static void stginit_export_" <> ppr hs_fn <> text "()",
+      braces
+        ( text "foreignExportStablePtr"
+            <> parens (text "(StgPtr) &" <> ppr hs_fn <> text "_closure")
+            <> semi
+          )
+      ]
+
+mkHObj :: Type -> SDoc
+mkHObj t = text "rts_mk" <> text (showFFIType t)
+
+unpackHObj :: Type -> SDoc
+unpackHObj t = text "rts_get" <> text (showFFIType t)
+
+showStgType :: Type -> SDoc
+showStgType t = text "Hs" <> text (showFFIType t)
+
+showFFIType :: Type -> String
+showFFIType t = getOccString (getName (typeTyCon t))
+
+toCType :: Type -> (Maybe Header, SDoc)
+toCType = f False
+  where
+    f voidOK t
+      | Just (ptr, [t']) <- splitTyConApp_maybe t,
+        tyConName ptr `elem` [ptrTyConName, funPtrTyConName] =
+        case f True t' of
+          (mh, cType') -> (mh, cType' <> char '*')
+      | Just tycon <- tyConAppTyConPicky_maybe t,
+        Just (CType _ mHeader (_, cType)) <- tyConCType_maybe tycon =
+        (mHeader, ftext cType)
+      | Just t' <- coreView t = f voidOK t'
+      | Just byteArrayPrimTyCon == tyConAppTyConPicky_maybe t =
+        (Nothing, text "const void*")
+      | Just mutableByteArrayPrimTyCon == tyConAppTyConPicky_maybe t =
+        (Nothing, text "void*")
+      | voidOK = (Nothing, text "void")
+      | otherwise = pprPanic "toCType" (ppr t)
+
+typeTyCon :: Type -> TyCon
+typeTyCon ty
+  | Just (tc, _) <- tcSplitTyConApp_maybe (unwrapType ty) = tc
+  | otherwise = pprPanic "DsForeign.typeTyCon" (ppr ty)
+
+insertRetAddr
+  :: DynFlags
+  -> CCallConv
+  -> [(SDoc, SDoc, Type, CmmType)]
+  -> [(SDoc, SDoc, Type, CmmType)]
+insertRetAddr dflags CCallConv args =
+  case platformArch platform of
+    ArchX86_64
+      | platformOS platform == OSMinGW32 ->
+        let go
+              :: Int
+              -> [(SDoc, SDoc, Type, CmmType)]
+              -> [(SDoc, SDoc, Type, CmmType)]
+            go 4 args = retAddrArg dflags : args
+            go n (arg : args) = arg : go (n + 1) args
+            go _ [] = []
+         in go 0 args
+      | otherwise ->
+        let go
+              :: Int
+              -> [(SDoc, SDoc, Type, CmmType)]
+              -> [(SDoc, SDoc, Type, CmmType)]
+            go 6 args = retAddrArg dflags : args
+            go n (arg@(_, _, _, rep) : args)
+              | cmmEqType_ignoring_ptrhood rep b64 = arg : go (n + 1) args
+              | otherwise = arg : go n args
+            go _ [] = []
+         in go 0 args
+    _ -> retAddrArg dflags : args
+  where
+    platform = targetPlatform dflags
+insertRetAddr _ _ args = args
+
+retAddrArg :: DynFlags -> (SDoc, SDoc, Type, CmmType)
+retAddrArg dflags =
+  ( text "original_return_addr",
+    text "void*",
+    undefined,
+    typeCmmType dflags addrPrimTy
+    )
+
+getPrimTyOf :: Type -> UnaryType
+getPrimTyOf ty
+  | isBoolTy rep_ty = intPrimTy
+  | otherwise =
+    case splitDataProductType_maybe rep_ty of
+      Just (_, _, _, [prim_ty]) -> prim_ty
+      _other -> pprPanic "DsForeign.getPrimTyOf" (ppr ty)
+  where
+    rep_ty = unwrapType ty
+
+primTyDescChar :: DynFlags -> Type -> Char
+primTyDescChar dflags ty
+  | ty `eqType` unitTy = 'v'
+  | otherwise =
+    case typePrimRep1 (getPrimTyOf ty) of
+      IntRep -> signed_word
+      WordRep -> unsigned_word
+      Int64Rep -> 'L'
+      Word64Rep -> 'l'
+      AddrRep -> 'p'
+      FloatRep -> 'f'
+      DoubleRep -> 'd'
+      _ -> pprPanic "primTyDescChar" (ppr ty)
+  where
+    (signed_word, unsigned_word)
+      | wORD_SIZE dflags == 4 = ('W', 'w')
+      | wORD_SIZE dflags == 8 = ('L', 'l')
+      | otherwise = panic "primTyDescChar"

--- a/asterius/src/Asterius/Foreign.hs
+++ b/asterius/src/Asterius/Foreign.hs
@@ -55,12 +55,7 @@ asteriusDsForeigns fos = do
       bs <- asteriusDsFImport id' co spec
       traceIf (text "fi end" <+> ppr id)
       return bs
-    do_decl
-      ForeignExport
-        { fd_name = L _ _,
-          fd_e_ext = _,
-          fd_fe = CExport (L _ CExportStatic {}) _
-          } = return []
+    do_decl ForeignExport {} = return []
     do_decl (XForeignDecl _) = panic "asteriusDsForeigns"
 
 asteriusDsFImport :: Id -> Coercion -> ForeignImport -> DsM [Binding]

--- a/asterius/src/Asterius/Foreign/Internals.hs
+++ b/asterius/src/Asterius/Foreign/Internals.hs
@@ -1,0 +1,142 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Asterius.Foreign.Internals
+  ( parseFFIFunctionType
+    )
+where
+
+import Asterius.Types
+import qualified GhcPlugins as GHC
+import qualified PrelNames as GHC
+import qualified TyCoRep as GHC
+
+ffiValueTypeMap0, ffiValueTypeMap1 :: GHC.NameEnv FFIValueType
+ffiValueTypeMap0 =
+  GHC.mkNameEnv
+    [ ( GHC.charTyConName,
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "Char",
+            signed = False
+            }
+        ),
+      ( GHC.boolTyConName,
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "Bool",
+            signed = False
+            }
+        ),
+      ( GHC.intTyConName,
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "Int",
+            signed = True
+            }
+        ),
+      ( GHC.wordTyConName,
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "Word",
+            signed = False
+            }
+        ),
+      ( GHC.floatTyConName,
+        FFI_VAL
+          { ffiWasmValueType = F32,
+            ffiJSValueType = F32,
+            hsTyCon = "Float",
+            signed = True
+            }
+        ),
+      ( GHC.doubleTyConName,
+        FFI_VAL
+          { ffiWasmValueType = F64,
+            ffiJSValueType = F64,
+            hsTyCon = "Double",
+            signed = True
+            }
+        )
+      ]
+
+ffiValueTypeMap1 =
+  GHC.mkNameEnv
+    [ ( GHC.ptrTyConName,
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "Ptr",
+            signed = False
+            }
+        ),
+      ( GHC.funPtrTyConName,
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "FunPtr",
+            signed = False
+            }
+        ),
+      ( GHC.stablePtrTyConName,
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "StablePtr",
+            signed = False
+            }
+        )
+      ]
+
+parseFFIValueType :: GHC.Type -> GHC.Type -> Maybe FFIValueType
+parseFFIValueType sig_ty norm_sig_ty = case (sig_ty, norm_sig_ty) of
+  (GHC.TyConApp _ _, GHC.TyConApp norm_tc []) ->
+    GHC.lookupNameEnv ffiValueTypeMap0 (GHC.getName norm_tc)
+  (GHC.TyConApp tc _, GHC.TyConApp norm_tc [_])
+    | take 2 (GHC.occNameString (GHC.getOccName tc))
+        == "JS"
+        && GHC.getName norm_tc
+        == GHC.stablePtrTyConName ->
+      pure FFI_JSVAL
+    | otherwise ->
+      GHC.lookupNameEnv ffiValueTypeMap1 (GHC.getName norm_tc)
+  _ -> Nothing
+
+parseFFIFunctionType :: GHC.Type -> GHC.Type -> Maybe FFIFunctionType
+parseFFIFunctionType sig_ty norm_sig_ty = case (sig_ty, norm_sig_ty) of
+  (GHC.FunTy t1 t2, GHC.FunTy norm_t1 norm_t2) -> do
+    vt <- parseFFIValueType t1 norm_t1
+    ft <- parseFFIFunctionType t2 norm_t2
+    pure ft {ffiParamTypes = vt : ffiParamTypes ft}
+  (GHC.TyConApp _ tys1, GHC.TyConApp norm_tc norm_tys1)
+    | GHC.getName norm_tc == GHC.ioTyConName ->
+      case (tys1, norm_tys1) of
+        (_, [GHC.TyConApp u []])
+          | u == GHC.unitTyCon ->
+            pure
+              FFIFunctionType
+                { ffiParamTypes = [],
+                  ffiResultTypes = [],
+                  ffiInIO = True
+                  }
+        ([t1], [norm_t1]) -> do
+          r <- parseFFIValueType t1 norm_t1
+          pure
+            FFIFunctionType
+              { ffiParamTypes = [],
+                ffiResultTypes = [r],
+                ffiInIO = True
+                }
+        _ -> Nothing
+  _ -> do
+    r <- parseFFIValueType sig_ty norm_sig_ty
+    pure
+      FFIFunctionType
+        { ffiParamTypes = [],
+          ffiResultTypes = [r],
+          ffiInIO = False
+          }

--- a/asterius/src/Asterius/Foreign/Internals.hs
+++ b/asterius/src/Asterius/Foreign/Internals.hs
@@ -33,9 +33,16 @@ import Text.Parsec
     )
 import Text.Parsec.String (Parser)
 import qualified TyCoRep as GHC
+import qualified TysPrim as GHC
 
-ffiValueTypeMap0, ffiValueTypeMap1 :: GHC.NameEnv FFIValueType
-ffiValueTypeMap0 =
+ffiBoxedValueTypeMap0,
+  ffiBoxedValueTypeMap1,
+  ffiPrimValueTypeMap0,
+  ffiPrimValueTypeMap1,
+  ffiValueTypeMap0,
+  ffiValueTypeMap1
+    :: GHC.NameEnv FFIValueType
+ffiBoxedValueTypeMap0 =
   GHC.mkNameEnv
     [ ( GHC.charTyConName,
         FFI_VAL
@@ -87,7 +94,7 @@ ffiValueTypeMap0 =
         )
       ]
 
-ffiValueTypeMap1 =
+ffiBoxedValueTypeMap1 =
   GHC.mkNameEnv
     [ ( GHC.ptrTyConName,
         FFI_VAL
@@ -115,54 +122,131 @@ ffiValueTypeMap1 =
         )
       ]
 
-parseFFIValueType :: GHC.Type -> GHC.Type -> Maybe FFIValueType
-parseFFIValueType sig_ty norm_sig_ty = case (sig_ty, norm_sig_ty) of
-  (GHC.TyConApp _ _, GHC.TyConApp norm_tc []) ->
-    GHC.lookupNameEnv ffiValueTypeMap0 (GHC.getName norm_tc)
-  (GHC.TyConApp tc _, GHC.TyConApp norm_tc [_])
-    | take 2 (GHC.occNameString (GHC.getOccName tc))
-        == "JS"
-        && GHC.getName norm_tc
-        == GHC.stablePtrTyConName ->
-      pure FFI_JSVAL
-    | otherwise ->
-      GHC.lookupNameEnv ffiValueTypeMap1 (GHC.getName norm_tc)
-  _ -> Nothing
+ffiPrimValueTypeMap0 =
+  GHC.mkNameEnv
+    [ ( GHC.charPrimTyConName,
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "",
+            signed = False
+            }
+        ),
+      ( GHC.intPrimTyConName,
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "",
+            signed = True
+            }
+        ),
+      ( GHC.wordPrimTyConName,
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "",
+            signed = False
+            }
+        ),
+      ( GHC.floatPrimTyConName,
+        FFI_VAL
+          { ffiWasmValueType = F32,
+            ffiJSValueType = F32,
+            hsTyCon = "",
+            signed = True
+            }
+        ),
+      ( GHC.doublePrimTyConName,
+        FFI_VAL
+          { ffiWasmValueType = F64,
+            ffiJSValueType = F64,
+            hsTyCon = "",
+            signed = True
+            }
+        )
+      ]
 
-parseFFIFunctionType :: GHC.Type -> GHC.Type -> Maybe FFIFunctionType
-parseFFIFunctionType sig_ty norm_sig_ty = case (sig_ty, norm_sig_ty) of
-  (GHC.FunTy t1 t2, GHC.FunTy norm_t1 norm_t2) -> do
-    vt <- parseFFIValueType t1 norm_t1
-    ft <- parseFFIFunctionType t2 norm_t2
-    pure ft {ffiParamTypes = vt : ffiParamTypes ft}
-  (GHC.TyConApp _ tys1, GHC.TyConApp norm_tc norm_tys1)
-    | GHC.getName norm_tc == GHC.ioTyConName ->
-      case (tys1, norm_tys1) of
-        (_, [GHC.TyConApp u []])
-          | u == GHC.unitTyCon ->
+ffiPrimValueTypeMap1 =
+  GHC.mkNameEnv
+    [ ( GHC.addrPrimTyConName,
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "",
+            signed = False
+            }
+        ),
+      ( GHC.getName GHC.stablePtrPrimTyCon,
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "",
+            signed = False
+            }
+        )
+      ]
+
+ffiValueTypeMap0 = ffiBoxedValueTypeMap0 `GHC.plusNameEnv` ffiPrimValueTypeMap0
+
+ffiValueTypeMap1 = ffiBoxedValueTypeMap1 `GHC.plusNameEnv` ffiPrimValueTypeMap1
+
+parseFFIValueType :: Bool -> GHC.Type -> GHC.Type -> Maybe FFIValueType
+parseFFIValueType accept_prim sig_ty norm_sig_ty =
+  case (sig_ty, norm_sig_ty) of
+    (GHC.TyConApp _ _, GHC.TyConApp norm_tc []) ->
+      GHC.lookupNameEnv ffi_valuetype_map0 (GHC.getName norm_tc)
+    (GHC.TyConApp tc _, GHC.TyConApp norm_tc [_])
+      | take 2 (GHC.occNameString (GHC.getOccName tc))
+          == "JS"
+          && GHC.getName norm_tc
+          == GHC.stablePtrTyConName ->
+        pure FFI_JSVAL
+      | otherwise ->
+        GHC.lookupNameEnv ffi_valuetype_map1 (GHC.getName norm_tc)
+    _ -> Nothing
+  where
+    ffi_valuetype_map0
+      | accept_prim = ffiValueTypeMap0
+      | otherwise = ffiBoxedValueTypeMap0
+    ffi_valuetype_map1
+      | accept_prim = ffiValueTypeMap1
+      | otherwise = ffiBoxedValueTypeMap1
+
+parseFFIFunctionType :: Bool -> GHC.Type -> GHC.Type -> Maybe FFIFunctionType
+parseFFIFunctionType accept_prim sig_ty norm_sig_ty =
+  case (sig_ty, norm_sig_ty) of
+    (GHC.FunTy t1 t2, GHC.FunTy norm_t1 norm_t2) -> do
+      vt <- parseFFIValueType accept_prim t1 norm_t1
+      ft <- parseFFIFunctionType accept_prim t2 norm_t2
+      pure ft {ffiParamTypes = vt : ffiParamTypes ft}
+    (GHC.TyConApp _ tys1, GHC.TyConApp norm_tc norm_tys1)
+      | GHC.getName norm_tc == GHC.ioTyConName ->
+        case (tys1, norm_tys1) of
+          (_, [GHC.TyConApp u []])
+            | u == GHC.unitTyCon ->
+              pure
+                FFIFunctionType
+                  { ffiParamTypes = [],
+                    ffiResultTypes = [],
+                    ffiInIO = True
+                    }
+          ([t1], [norm_t1]) -> do
+            r <- parseFFIValueType False t1 norm_t1
             pure
               FFIFunctionType
                 { ffiParamTypes = [],
-                  ffiResultTypes = [],
+                  ffiResultTypes = [r],
                   ffiInIO = True
                   }
-        ([t1], [norm_t1]) -> do
-          r <- parseFFIValueType t1 norm_t1
-          pure
-            FFIFunctionType
-              { ffiParamTypes = [],
-                ffiResultTypes = [r],
-                ffiInIO = True
-                }
-        _ -> Nothing
-  _ -> do
-    r <- parseFFIValueType sig_ty norm_sig_ty
-    pure
-      FFIFunctionType
-        { ffiParamTypes = [],
-          ffiResultTypes = [r],
-          ffiInIO = False
-          }
+          _ -> Nothing
+    _ -> do
+      r <- parseFFIValueType accept_prim sig_ty norm_sig_ty
+      pure
+        FFIFunctionType
+          { ffiParamTypes = [],
+            ffiResultTypes = [r],
+            ffiInIO = False
+            }
 
 parseField :: Parser a -> Parser (Chunk a)
 parseField f = do
@@ -211,7 +295,7 @@ processFFIImport hook_state_ref sig_ty norm_sig_ty (GHC.CImport (GHC.unLoc -> GH
     dflags <- GHC.getDynFlags
     mod_sym <- marshalToModuleSymbol <$> GHC.getModule
     u <- GHC.getUniqueM
-    let Just ffi_ftype = parseFFIFunctionType sig_ty norm_sig_ty
+    let Just ffi_ftype = parseFFIFunctionType True sig_ty norm_sig_ty
         Right chunks = parse parseFFIChunks src (read src)
         new_k =
           "__asterius_jsffi_"

--- a/asterius/src/Asterius/FrontendPlugin.hs
+++ b/asterius/src/Asterius/FrontendPlugin.hs
@@ -2,12 +2,13 @@
 
 module Asterius.FrontendPlugin
   ( frontendPlugin
-  ) where
+    )
+where
 
 import Asterius.CodeGen
+import Asterius.Foreign
 import Asterius.Internals
 import Asterius.JSFFI
-import Asterius.Types
 import Asterius.TypesConv
 import Control.Exception
 import Control.Monad
@@ -16,6 +17,7 @@ import Data.IORef
 import Data.Maybe
 import qualified GHC
 import qualified GhcPlugins as GHC
+import qualified Hooks as GHC
 import Language.Haskell.GHC.Toolkit.Compiler
 import Language.Haskell.GHC.Toolkit.FrontendPlugin
 import Language.Haskell.GHC.Toolkit.Orphans.Show
@@ -23,64 +25,75 @@ import System.Environment.Blank
 import System.FilePath
 
 frontendPlugin :: GHC.FrontendPlugin
-frontendPlugin =
-  makeFrontendPlugin $ do
-    is_debug <- liftIO $ isJust <$> getEnv "ASTERIUS_DEBUG"
-    when is_debug $ do
-      dflags <- GHC.getSessionDynFlags
-      void $
-        GHC.setSessionDynFlags $
-        dflags `GHC.gopt_set` GHC.Opt_DoCoreLinting `GHC.gopt_set`
-        GHC.Opt_DoStgLinting `GHC.gopt_set`
-        GHC.Opt_DoCmmLinting
-    liftIO $ do
-      get_ffi_mod_ref <- newIORef $ error "get_ffi_mod_ref not initialized"
-      (c, get_ffi_mod) <-
-        addFFIProcessor
-          mempty
-            { withHaskellIR =
-                \GHC.ModSummary {..} ir@HaskellIR {..} obj_path -> do
-                  dflags <- GHC.getDynFlags
-                  setDynFlagsRef dflags
-                  let mod_sym = marshalToModuleSymbol ms_mod
-                  liftIO $ do
-                    get_ffi_mod <- readIORef get_ffi_mod_ref
-                    ffi_mod <- get_ffi_mod mod_sym
-                    case runCodeGen (marshalHaskellIR ms_mod ir) dflags ms_mod of
-                      Left err -> throwIO err
-                      Right m' -> do
-                        let m = ffi_mod <> m'
-                        encodeFile obj_path m
-                        when is_debug $ do
-                          let p = (obj_path -<.>)
-                          writeFile (p "dump-wasm-ast") $ show m
-                          writeFile (p "dump-cmm-raw-ast") $ show cmmRaw
-                          asmPrint dflags (p "dump-cmm-raw") cmmRaw
-                          writeFile (p "dump-cmm-ast") $ show cmm
-                          asmPrint dflags (p "dump-cmm") cmm
-                          writeFile (p "dump-stg-ast") $ show stg
-                          asmPrint dflags (p "dump-stg") stg
-                          writeFile (p "dump-core-ast") $ show core
-                          asmPrint dflags (p "dump-core") $ GHC.cg_binds core
-            , withCmmIR =
-                \ir@CmmIR {..} obj_path -> do
-                  dflags <- GHC.getDynFlags
-                  setDynFlagsRef dflags
-                  let ms_mod =
-                        GHC.Module GHC.rtsUnitId $
-                        GHC.mkModuleName $ takeBaseName obj_path
-                  liftIO $
-                    case runCodeGen (marshalCmmIR ms_mod ir) dflags ms_mod of
-                      Left err -> throwIO err
-                      Right m -> do
-                        encodeFile obj_path m
-                        when is_debug $ do
-                          let p = (obj_path -<.>)
-                          writeFile (p "dump-wasm-ast") $ show m
-                          writeFile (p "dump-cmm-raw-ast") $ show cmmRaw
-                          asmPrint dflags (p "dump-cmm-raw") cmmRaw
-                          writeFile (p "dump-cmm-ast") $ show cmm
-                          asmPrint dflags (p "dump-cmm") cmm
+frontendPlugin = makeFrontendPlugin $ do
+  is_debug <- liftIO $ isJust <$> getEnv "ASTERIUS_DEBUG"
+  do
+    dflags <- GHC.getSessionDynFlags
+    void
+      $ GHC.setSessionDynFlags
+          dflags
+            { GHC.hooks = (GHC.hooks dflags)
+                { GHC.dsForeignsHook = Just asteriusDsForeigns,
+                  GHC.tcForeignImportsHook = Just
+                                               asteriusTcForeignImports,
+                  GHC.tcForeignExportsHook = Just
+                                               asteriusTcForeignExports
+                  }
+              }
+  when is_debug $ do
+    dflags <- GHC.getSessionDynFlags
+    void
+      $ GHC.setSessionDynFlags
+      $ dflags
+      `GHC.gopt_set` GHC.Opt_DoCoreLinting
+      `GHC.gopt_set` GHC.Opt_DoStgLinting
+      `GHC.gopt_set` GHC.Opt_DoCmmLinting
+  liftIO $ do
+    get_ffi_mod_ref <- newIORef $ error "get_ffi_mod_ref not initialized"
+    (c, get_ffi_mod) <-
+      addFFIProcessor
+        mempty
+          { withHaskellIR = \GHC.ModSummary {..} ir@HaskellIR {..} obj_path -> do
+              dflags <- GHC.getDynFlags
+              setDynFlagsRef dflags
+              let mod_sym = marshalToModuleSymbol ms_mod
+              liftIO $ do
+                get_ffi_mod <- readIORef get_ffi_mod_ref
+                ffi_mod <- get_ffi_mod mod_sym
+                case runCodeGen (marshalHaskellIR ms_mod ir) dflags ms_mod of
+                  Left err -> throwIO err
+                  Right m' -> do
+                    let m = ffi_mod <> m'
+                    encodeFile obj_path m
+                    when is_debug $ do
+                      let p = (obj_path -<.>)
+                      writeFile (p "dump-wasm-ast") $ show m
+                      writeFile (p "dump-cmm-raw-ast") $ show cmmRaw
+                      asmPrint dflags (p "dump-cmm-raw") cmmRaw
+                      writeFile (p "dump-cmm-ast") $ show cmm
+                      asmPrint dflags (p "dump-cmm") cmm
+                      writeFile (p "dump-stg-ast") $ show stg
+                      asmPrint dflags (p "dump-stg") stg
+                      writeFile (p "dump-core-ast") $ show core
+                      asmPrint dflags (p "dump-core") $ GHC.cg_binds core,
+            withCmmIR = \ir@CmmIR {..} obj_path -> do
+              dflags <- GHC.getDynFlags
+              setDynFlagsRef dflags
+              let ms_mod =
+                    GHC.Module GHC.rtsUnitId $ GHC.mkModuleName
+                      $ takeBaseName
+                          obj_path
+              liftIO $ case runCodeGen (marshalCmmIR ms_mod ir) dflags ms_mod of
+                Left err -> throwIO err
+                Right m -> do
+                  encodeFile obj_path m
+                  when is_debug $ do
+                    let p = (obj_path -<.>)
+                    writeFile (p "dump-wasm-ast") $ show m
+                    writeFile (p "dump-cmm-raw-ast") $ show cmmRaw
+                    asmPrint dflags (p "dump-cmm-raw") cmmRaw
+                    writeFile (p "dump-cmm-ast") $ show cmm
+                    asmPrint dflags (p "dump-cmm") cmm
             }
-      writeIORef get_ffi_mod_ref get_ffi_mod
-      pure c
+    writeIORef get_ffi_mod_ref get_ffi_mod
+    pure c

--- a/asterius/src/Asterius/JSFFI.hs
+++ b/asterius/src/Asterius/JSFFI.hs
@@ -8,11 +8,12 @@
 {-# LANGUAGE ViewPatterns #-}
 
 module Asterius.JSFFI
-  ( addFFIProcessor
-  , generateFFIFunctionImports
-  , generateFFIImportObjectFactory
-  , generateFFIExportObject
-  ) where
+  ( addFFIProcessor,
+    generateFFIFunctionImports,
+    generateFFIImportObjectFactory,
+    generateFFIExportObject
+    )
+where
 
 import Asterius.Internals
 import Asterius.Types
@@ -22,7 +23,11 @@ import Control.Monad.State.Strict
 import Data.ByteString.Builder
 import qualified Data.ByteString.Short as SBS
 import Data.Coerce
-import Data.Data (Data, gmapM, gmapQ)
+import Data.Data
+  ( Data,
+    gmapM,
+    gmapQ
+    )
 import Data.Functor.Identity
 import Data.IORef
 import Data.List
@@ -35,14 +40,20 @@ import qualified GhcPlugins as GHC
 import qualified HsSyn as GHC
 import Language.Haskell.GHC.Toolkit.Compiler
 import qualified PrelNames as GHC
-import Prelude hiding (IO)
-import qualified Prelude
 import qualified TcRnTypes as GHC
-import Text.Parsec (anyChar, char, digit, parse, try)
+import Text.Parsec
+  ( anyChar,
+    char,
+    digit,
+    parse,
+    try
+    )
 import Text.Parsec.String (Parser)
 import Type.Reflection
 import qualified TysPrim as GHC
 import qualified Unique as GHC
+import Prelude hiding (IO)
+import qualified Prelude
 
 parseField :: Parser a -> Parser (Chunk a)
 parseField f = do
@@ -53,10 +64,9 @@ parseField f = do
   pure $ Field v
 
 parseChunk :: Parser (Chunk a) -> Parser (Chunk a)
-parseChunk f =
-  try f <|> do
-    c <- anyChar
-    pure $ Lit [c]
+parseChunk f = try f <|> do
+  c <- anyChar
+  pure $ Lit [c]
 
 parseChunks :: Parser (Chunk a) -> Parser [Chunk a]
 parseChunks = many
@@ -64,158 +74,166 @@ parseChunks = many
 combineChunks :: [Chunk a] -> [Chunk a]
 combineChunks =
   foldr
-    (curry $ \case
-       (Lit l, Lit l':cs) -> Lit (l <> l') : cs
-       (c, cs) -> c : cs)
+    ( curry $ \case
+        (Lit l, Lit l' : cs) -> Lit (l <> l') : cs
+        (c, cs) -> c : cs
+      )
     []
 
 parseFFIChunks :: Parser [Chunk Int]
 parseFFIChunks =
   combineChunks <$> parseChunks (parseChunk (parseField (read <$> some digit)))
 
-marshalToFFIValueType ::
-     (GHC.HasOccName (GHC.IdP p)) => GHC.LHsType p -> Maybe FFIValueType
+marshalToFFIValueType
+  :: (GHC.HasOccName (GHC.IdP p)) => GHC.LHsType p -> Maybe FFIValueType
 marshalToFFIValueType (GHC.unLoc -> GHC.HsParTy _ t) = marshalToFFIValueType t
-marshalToFFIValueType (GHC.unLoc -> t) =
-  case t of
-    GHC.HsAppTy _ (GHC.unLoc -> (GHC.HsTyVar _ _ (GHC.occName . GHC.unLoc -> c))) _
-      | c == GHC.occName GHC.ptrTyConName ->
-        pure
-          FFI_VAL
-            { ffiWasmValueType = I64
-            , ffiJSValueType = F64
-            , hsTyCon = "Ptr"
-            , signed = False
+marshalToFFIValueType (GHC.unLoc -> t) = case t of
+  GHC.HsAppTy _ (GHC.unLoc -> (GHC.HsTyVar _ _ (GHC.occName . GHC.unLoc -> c))) _
+    | c == GHC.occName GHC.ptrTyConName ->
+      pure
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "Ptr",
+            signed = False
             }
-      | c == GHC.occName GHC.funPtrTyConName ->
-        pure
-          FFI_VAL
-            { ffiWasmValueType = I64
-            , ffiJSValueType = F64
-            , hsTyCon = "FunPtr"
-            , signed = False
+    | c == GHC.occName GHC.funPtrTyConName ->
+      pure
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "FunPtr",
+            signed = False
             }
-      | c `elem`
-          map
-            GHC.occName
-            [ GHC.stablePtrTyConName
-            , GHC.getName GHC.stablePtrPrimTyCon
-            , GHC.getName GHC.mutableByteArrayPrimTyCon
-            ] ->
-        pure
-          FFI_VAL
-            { ffiWasmValueType = I64
-            , ffiJSValueType = F64
-            , hsTyCon = "StablePtr"
-            , signed = False
+    | c
+        `elem` map
+                 GHC.occName
+                 [ GHC.stablePtrTyConName,
+                   GHC.getName GHC.stablePtrPrimTyCon,
+                   GHC.getName GHC.mutableByteArrayPrimTyCon
+                   ] ->
+      pure
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "StablePtr",
+            signed = False
             }
-    GHC.HsTyVar _ _ (GHC.occName . GHC.unLoc -> tv)
-      | tv `elem`
-          map
-            GHC.occName
-            [GHC.addrPrimTyConName, GHC.getName GHC.byteArrayPrimTyCon] ->
-        pure
-          FFI_VAL
-            { ffiWasmValueType = I64
-            , ffiJSValueType = F64
-            , hsTyCon = "Ptr"
-            , signed = False
+  GHC.HsTyVar _ _ (GHC.occName . GHC.unLoc -> tv)
+    | tv
+        `elem` map
+                 GHC.occName
+                 [GHC.addrPrimTyConName, GHC.getName GHC.byteArrayPrimTyCon] ->
+      pure
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "Ptr",
+            signed = False
             }
-      | tv `elem` map GHC.occName [GHC.charTyConName, GHC.charPrimTyConName] ->
-        pure
-          FFI_VAL
-            { ffiWasmValueType = I64
-            , ffiJSValueType = F64
-            , hsTyCon = "Char"
-            , signed = False
+    | tv `elem` map GHC.occName [GHC.charTyConName, GHC.charPrimTyConName] ->
+      pure
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "Char",
+            signed = False
             }
-      | tv == GHC.occName GHC.boolTyConName ->
-        pure
-          FFI_VAL
-            { ffiWasmValueType = I64
-            , ffiJSValueType = F64
-            , hsTyCon = "Bool"
-            , signed = False
+    | tv == GHC.occName GHC.boolTyConName ->
+      pure
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "Bool",
+            signed = False
             }
-      | tv `elem` map GHC.occName [GHC.intTyConName, GHC.intPrimTyConName] ->
-        pure
-          FFI_VAL
-            { ffiWasmValueType = I64
-            , ffiJSValueType = F64
-            , hsTyCon = "Int"
-            , signed = True
+    | tv `elem` map GHC.occName [GHC.intTyConName, GHC.intPrimTyConName] ->
+      pure
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "Int",
+            signed = True
             }
-      | tv `elem` map GHC.occName [GHC.wordTyConName, GHC.wordPrimTyConName] ->
-        pure
-          FFI_VAL
-            { ffiWasmValueType = I64
-            , ffiJSValueType = F64
-            , hsTyCon = "Word"
-            , signed = False
+    | tv `elem` map GHC.occName [GHC.wordTyConName, GHC.wordPrimTyConName] ->
+      pure
+        FFI_VAL
+          { ffiWasmValueType = I64,
+            ffiJSValueType = F64,
+            hsTyCon = "Word",
+            signed = False
             }
-      | tv `elem` map GHC.occName [GHC.floatTyConName, GHC.floatPrimTyConName] ->
-        pure
-          FFI_VAL
-            { ffiWasmValueType = F32
-            , ffiJSValueType = F32
-            , hsTyCon = "Float"
-            , signed = True
+    | tv `elem` map GHC.occName [GHC.floatTyConName, GHC.floatPrimTyConName] ->
+      pure
+        FFI_VAL
+          { ffiWasmValueType = F32,
+            ffiJSValueType = F32,
+            hsTyCon = "Float",
+            signed = True
             }
-      | tv `elem` map GHC.occName [GHC.doubleTyConName, GHC.doublePrimTyConName] ->
-        pure
-          FFI_VAL
-            { ffiWasmValueType = F64
-            , ffiJSValueType = F64
-            , hsTyCon = "Double"
-            , signed = True
+    | tv `elem` map GHC.occName [GHC.doubleTyConName, GHC.doublePrimTyConName] ->
+      pure
+        FFI_VAL
+          { ffiWasmValueType = F64,
+            ffiJSValueType = F64,
+            hsTyCon = "Double",
+            signed = True
             }
-      | take 2 (GHC.occNameString tv) == "JS" -> pure FFI_JSVAL
-    _ -> empty
+    | take 2 (GHC.occNameString tv) == "JS" ->
+      pure FFI_JSVAL
+  _ -> empty
 
-marshalToFFIResultTypes ::
-     (GHC.HasOccName (GHC.IdP p)) => GHC.LHsType p -> Maybe [FFIValueType]
+marshalToFFIResultTypes
+  :: (GHC.HasOccName (GHC.IdP p)) => GHC.LHsType p -> Maybe [FFIValueType]
 marshalToFFIResultTypes (GHC.unLoc -> GHC.HsParTy _ t) =
   marshalToFFIResultTypes t
 marshalToFFIResultTypes (GHC.unLoc -> GHC.HsTupleTy _ _ []) = pure []
 marshalToFFIResultTypes t = (: []) <$> marshalToFFIValueType t
 
-marshalToFFIFunctionType ::
-     (GHC.HasOccName (GHC.IdP p)) => GHC.LHsType p -> Maybe FFIFunctionType
+marshalToFFIFunctionType
+  :: (GHC.HasOccName (GHC.IdP p)) => GHC.LHsType p -> Maybe FFIFunctionType
 marshalToFFIFunctionType (GHC.unLoc -> GHC.HsParTy _ t) =
   marshalToFFIFunctionType t
-marshalToFFIFunctionType (GHC.unLoc -> ty) =
-  case ty of
-    GHC.HsFunTy _ t ts -> do
-      vt <- marshalToFFIValueType t
-      ft <- marshalToFFIFunctionType ts
-      pure ft {ffiParamTypes = vt : ffiParamTypes ft}
-    GHC.HsAppTy _ (GHC.unLoc -> (GHC.HsTyVar _ _ (GHC.occName . GHC.unLoc -> io))) t
-      | io == GHC.occName GHC.ioTyConName -> do
+marshalToFFIFunctionType (GHC.unLoc -> ty) = case ty of
+  GHC.HsFunTy _ t ts -> do
+    vt <- marshalToFFIValueType t
+    ft <- marshalToFFIFunctionType ts
+    pure ft {ffiParamTypes = vt : ffiParamTypes ft}
+  GHC.HsAppTy _ (GHC.unLoc -> (GHC.HsTyVar _ _ (GHC.occName . GHC.unLoc -> io))) t
+    | io == GHC.occName GHC.ioTyConName ->
+      do
         r <- marshalToFFIResultTypes t
-        pure $
-          FFIFunctionType
-            {ffiParamTypes = [], ffiResultTypes = r, ffiInIO = True}
-    _ -> do
-      r <- marshalToFFIResultTypes (GHC.noLoc ty)
-      pure
-        FFIFunctionType
-          {ffiParamTypes = [], ffiResultTypes = r, ffiInIO = False}
+        pure $ FFIFunctionType
+          { ffiParamTypes = [],
+            ffiResultTypes = r,
+            ffiInIO = True
+            }
+  _ -> do
+    r <- marshalToFFIResultTypes (GHC.noLoc ty)
+    pure
+      FFIFunctionType
+        { ffiParamTypes = [],
+          ffiResultTypes = r,
+          ffiInIO = False
+          }
 
 recoverWasmImportValueType :: FFIValueType -> ValueType
-recoverWasmImportValueType vt =
-  case vt of
-    FFI_VAL {..} -> ffiJSValueType
-    FFI_JSVAL -> F64
+recoverWasmImportValueType vt = case vt of
+  FFI_VAL {..} -> ffiJSValueType
+  FFI_JSVAL -> F64
 
 recoverWasmWrapperValueType :: FFIValueType -> ValueType
-recoverWasmWrapperValueType vt =
-  case vt of
-    FFI_VAL {..} -> ffiWasmValueType
-    FFI_JSVAL -> I64
+recoverWasmWrapperValueType vt = case vt of
+  FFI_VAL {..} -> ffiWasmValueType
+  FFI_JSVAL -> I64
 
 recoverWasmImportFunctionType :: FFISafety -> FFIFunctionType -> FunctionType
 recoverWasmImportFunctionType ffi_safety FFIFunctionType {..}
-  | is_unsafe = FunctionType {paramTypes = param_types, returnTypes = ret_types}
+  | is_unsafe =
+    FunctionType
+      { paramTypes = param_types,
+        returnTypes = ret_types
+        }
   | otherwise = FunctionType {paramTypes = param_types, returnTypes = []}
   where
     is_unsafe = ffi_safety == FFIUnsafe
@@ -224,15 +242,19 @@ recoverWasmImportFunctionType ffi_safety FFIFunctionType {..}
 
 recoverWasmWrapperFunctionType :: FFISafety -> FFIFunctionType -> FunctionType
 recoverWasmWrapperFunctionType ffi_safety FFIFunctionType {..}
-  | is_unsafe = FunctionType {paramTypes = param_types, returnTypes = ret_types}
+  | is_unsafe =
+    FunctionType
+      { paramTypes = param_types,
+        returnTypes = ret_types
+        }
   | otherwise = FunctionType {paramTypes = param_types, returnTypes = []}
   where
     is_unsafe = ffi_safety == FFIUnsafe
     param_types = map recoverWasmWrapperValueType ffiParamTypes
     ret_types = map recoverWasmWrapperValueType ffiResultTypes
 
-processFFI ::
-     Data a
+processFFI
+  :: Data a
   => AsteriusModuleSymbol
   -> a
   -> State (FFIMarshalState, GHC.UniqSupply) a
@@ -241,230 +263,231 @@ processFFI mod_sym = w
     w :: Data a => a -> State (FFIMarshalState, GHC.UniqSupply) a
     w t =
       case eqTypeRep (typeOf t) (typeRep :: TypeRep (GHC.ForeignDecl GHC.GhcPs)) of
-        Just HRefl ->
-          case t of
-            GHC.ForeignImport { GHC.fd_fi = GHC.CImport (GHC.unLoc -> GHC.JavaScriptCallConv) loc_safety _ _ loc_src
-                              , ..
-                              } -> do
+        Just HRefl -> case t of
+          GHC.ForeignImport {GHC.fd_fi = GHC.CImport (GHC.unLoc -> GHC.JavaScriptCallConv) loc_safety _ _ loc_src, ..} ->
+            do
               (old_state@FFIMarshalState {..}, old_us) <- get
               let (u, new_us) = GHC.takeUniqFromSupply old_us
                   new_k =
-                    "__asterius_jsffi_" <> zEncodeModuleSymbol mod_sym <> "_" <>
-                    GHC.toBase62 (fromIntegral (GHC.getKey u))
+                    "__asterius_jsffi_"
+                      <> zEncodeModuleSymbol mod_sym
+                      <> "_"
+                      <> GHC.toBase62 (fromIntegral (GHC.getKey u))
               put
                 ( old_state
-                    { ffiImportDecls =
-                        M.insert (fromString new_k) new_decl ffiImportDecls
-                    }
-                , new_us)
+                    { ffiImportDecls = M.insert (fromString new_k)
+                                         new_decl
+                                         ffiImportDecls
+                      },
+                  new_us
+                  )
               pure
                 t
-                  { GHC.fd_fi =
-                      GHC.CImport
-                        (GHC.noLoc GHC.CCallConv)
-                        (GHC.noLoc GHC.PlayRisky)
-                        Nothing
-                        (GHC.CFunction $
-                         GHC.StaticTarget
-                           GHC.NoSourceText
-                           (GHC.mkFastString $ new_k <> "_wrapper")
-                           Nothing
-                           True)
-                        (GHC.noLoc GHC.NoSourceText)
+                  { GHC.fd_fi = GHC.CImport
+                                  (GHC.noLoc GHC.CCallConv)
+                                  (GHC.noLoc GHC.PlayRisky)
+                                  Nothing
+                                  ( GHC.CFunction
+                                      $ GHC.StaticTarget
+                                          GHC.NoSourceText
+                                          (GHC.mkFastString $ new_k <> "_wrapper")
+                                          Nothing
+                                          True
+                                    )
+                                  (GHC.noLoc GHC.NoSourceText)
+                    }
+            where
+              GHC.SourceText src = GHC.unLoc loc_src
+              Just ffi_ftype =
+                marshalToFFIFunctionType $ GHC.hsImplicitBody fd_sig_ty
+              Right chunks = parse parseFFIChunks src (read src)
+              new_decl = FFIImportDecl
+                { ffiFunctionType = ffi_ftype,
+                  ffiSafety = case GHC.unLoc loc_safety of
+                    GHC.PlaySafe | has_safety -> FFISafe
+                    GHC.PlayInterruptible -> FFIInterruptible
+                    _ -> FFIUnsafe,
+                  ffiSourceChunks = chunks
                   }
-              where GHC.SourceText src = GHC.unLoc loc_src
-                    Just ffi_ftype =
-                      marshalToFFIFunctionType $ GHC.hsImplicitBody fd_sig_ty
-                    Right chunks = parse parseFFIChunks src (read src)
-                    new_decl =
-                      FFIImportDecl
-                        { ffiFunctionType = ffi_ftype
-                        , ffiSafety =
-                            case GHC.unLoc loc_safety of
-                              GHC.PlaySafe
-                                | has_safety -> FFISafe
-                              GHC.PlayInterruptible -> FFIInterruptible
-                              _ -> FFIUnsafe
-                        , ffiSourceChunks = chunks
-                        }
-                    has_safety = GHC.isGoodSrcSpan $ GHC.getLoc loc_safety
-            GHC.ForeignExport { GHC.fd_fe = GHC.CExport (GHC.unLoc -> GHC.CExportStatic src_txt lbl GHC.JavaScriptCallConv) loc_src
-                              , ..
-                              } -> do
+              has_safety = GHC.isGoodSrcSpan $ GHC.getLoc loc_safety
+          GHC.ForeignExport {GHC.fd_fe = GHC.CExport (GHC.unLoc -> GHC.CExportStatic src_txt lbl GHC.JavaScriptCallConv) loc_src, ..} ->
+            do
               (old_state@FFIMarshalState {..}, old_us) <- get
               let Just ffi_ftype =
                     marshalToFFIFunctionType $ GHC.hsImplicitBody fd_sig_ty
               put
                 ( old_state
-                    { ffiExportDecls =
-                        M.insert
-                          AsteriusEntitySymbol
-                            {entityName = SBS.toShort $ GHC.fastStringToByteString lbl}
-                          FFIExportDecl
-                            {ffiFunctionType = ffi_ftype, ffiExportClosure = ""}
-                          ffiExportDecls
-                    }
-                , old_us)
+                    { ffiExportDecls = M.insert
+                                         AsteriusEntitySymbol
+                                           { entityName = SBS.toShort
+                                               $ GHC.fastStringToByteString lbl
+                                             }
+                                         FFIExportDecl
+                                           { ffiFunctionType = ffi_ftype,
+                                             ffiExportClosure = ""
+                                             }
+                                         ffiExportDecls
+                      },
+                  old_us
+                  )
               pure
                 t
-                  { GHC.fd_fe =
-                      GHC.CExport
-                        (GHC.noLoc $ GHC.CExportStatic src_txt lbl GHC.CCallConv)
-                        loc_src
-                  }
-            _ -> pure t
+                  { GHC.fd_fe = GHC.CExport
+                                  (GHC.noLoc $ GHC.CExportStatic src_txt lbl GHC.CCallConv)
+                                  loc_src
+                    }
+          _ -> pure t
         _ -> gmapM w t
 
-collectFFISrc ::
-     Monad m
+collectFFISrc
+  :: Monad m
   => AsteriusModuleSymbol
   -> GHC.HsParsedModule
   -> FFIMarshalState
   -> GHC.UniqSupply
   -> m (GHC.HsParsedModule, FFIMarshalState, GHC.UniqSupply)
 collectFFISrc mod_sym m ffi_state old_us =
-  pure (m {GHC.hpm_module = new_m}, st, new_us)
+  pure
+    (m {GHC.hpm_module = new_m}, st, new_us)
   where
     (new_m, (st, new_us)) =
       runState (processFFI mod_sym (GHC.hpm_module m)) (ffi_state, old_us)
 
-addFFIProcessor ::
-     Compiler
+addFFIProcessor
+  :: Compiler
   -> IO (Compiler, AsteriusModuleSymbol -> Prelude.IO AsteriusModule)
 addFFIProcessor c = do
   us <- GHC.mkSplitUniqSupply 'J'
   ffi_states_ref <- newIORef (mempty, us)
   pure
     ( c
-        { patchParsed =
-            \mod_summary parsed_mod -> do
-              patched_mod <-
-                liftIO $
-                atomicModifyIORef' ffi_states_ref $ \(ffi_states, old_us) ->
+        { patchParsed = \mod_summary parsed_mod -> do
+            patched_mod <-
+              liftIO
+                $ atomicModifyIORef' ffi_states_ref
+                $ \(ffi_states, old_us) ->
                   let mod_sym = marshalToModuleSymbol $ GHC.ms_mod mod_summary
                       (patched_mod, ffi_state, new_us) =
-                        runIdentity $
-                        collectFFISrc
-                          mod_sym
-                          parsed_mod
-                          FFIMarshalState
-                            {ffiImportDecls = M.empty, ffiExportDecls = M.empty}
-                          old_us
-                   in ( (M.insert mod_sym ffi_state ffi_states, new_us)
-                      , patched_mod)
-              patchParsed c mod_summary patched_mod
-        , patchTypechecked =
-            \mod_summary tc_mod -> do
-              dflags <- GHC.getDynFlags
-              let mod_sym = marshalToModuleSymbol $ GHC.ms_mod mod_summary
-                  f :: Data a
-                    => a
-                    -> Endo (M.Map AsteriusEntitySymbol FFIExportDecl)
-                  f t =
-                    case eqTypeRep
-                           (typeOf t)
-                           (typeRep :: TypeRep (GHC.ForeignDecl GHC.GhcTc)) of
-                      Just HRefl ->
-                        case t of
-                          GHC.ForeignExport {..} ->
-                            Endo $
-                            M.adjust
-                              (\ffi_decl ->
-                                 ffi_decl {ffiExportClosure = export_closure})
+                        runIdentity
+                          $ collectFFISrc
+                              mod_sym
+                              parsed_mod
+                              FFIMarshalState
+                                { ffiImportDecls = M.empty,
+                                  ffiExportDecls = M.empty
+                                  }
+                              old_us
+                   in ( (M.insert mod_sym ffi_state ffi_states, new_us),
+                        patched_mod
+                        )
+            patchParsed c mod_summary patched_mod,
+          patchTypechecked = \mod_summary tc_mod -> do
+            dflags <- GHC.getDynFlags
+            let mod_sym = marshalToModuleSymbol $ GHC.ms_mod mod_summary
+                f :: Data a => a -> Endo (M.Map AsteriusEntitySymbol FFIExportDecl)
+                f t =
+                  case eqTypeRep (typeOf t)
+                         (typeRep :: TypeRep (GHC.ForeignDecl GHC.GhcTc)) of
+                    Just HRefl -> case t of
+                      GHC.ForeignExport {..} ->
+                        Endo
+                          $ M.adjust
+                              ( \ffi_decl ->
+                                  ffi_decl {ffiExportClosure = export_closure}
+                                )
                               export_func_name
-                            where GHC.CExport loc_spec _ = fd_fe
-                                  GHC.CExportStatic _ lbl _ = GHC.unLoc loc_spec
-                                  export_func_name =
-                                    AsteriusEntitySymbol
-                                      { entityName =
-                                          SBS.toShort $ GHC.fastStringToByteString lbl
-                                      }
-                                  export_closure =
-                                    fromString $
-                                    asmPpr dflags (GHC.unLoc fd_name) <>
-                                    "_closure"
-                          _ -> mempty
-                      _ -> go
-                    where
-                      go = mconcat $ gmapQ f t
-              liftIO $
-                atomicModifyIORef' ffi_states_ref $ \(ffi_states, old_us) ->
-                  ( ( M.adjust
-                        (\ffi_state ->
-                           ffi_state
-                             { ffiExportDecls =
-                                 appEndo
-                                   (f $ GHC.tcg_fords tc_mod)
-                                   (ffiExportDecls ffi_state)
-                             })
-                        mod_sym
-                        ffi_states
-                    , old_us)
-                  , tc_mod)
-        }
-    , \mod_sym ->
-        atomicModifyIORef' ffi_states_ref $ \(ffi_states, old_us) ->
-          ( (M.delete mod_sym ffi_states, old_us)
-          , generateFFIWrapperModule $ ffi_states ! mod_sym))
+                        where
+                          GHC.CExport loc_spec _ = fd_fe
+                          GHC.CExportStatic _ lbl _ = GHC.unLoc loc_spec
+                          export_func_name = AsteriusEntitySymbol
+                            { entityName = SBS.toShort
+                                $ GHC.fastStringToByteString lbl
+                              }
+                          export_closure =
+                            fromString
+                              $ asmPpr dflags (GHC.unLoc fd_name)
+                              <> "_closure"
+                      _ -> mempty
+                    _ -> go
+                  where
+                    go = mconcat $ gmapQ f t
+            liftIO $ atomicModifyIORef' ffi_states_ref $ \(ffi_states, old_us) ->
+              ( ( M.adjust
+                    ( \ffi_state ->
+                        ffi_state
+                          { ffiExportDecls = appEndo (f $ GHC.tcg_fords tc_mod)
+                                               (ffiExportDecls ffi_state)
+                            }
+                      )
+                    mod_sym
+                    ffi_states,
+                  old_us
+                  ),
+                tc_mod
+                )
+          },
+      \mod_sym -> atomicModifyIORef' ffi_states_ref $ \(ffi_states, old_us) ->
+        ( (M.delete mod_sym ffi_states, old_us),
+          generateFFIWrapperModule $ ffi_states ! mod_sym
+          )
+      )
 
-generateImplicitCastExpression ::
-     Bool -> [ValueType] -> [ValueType] -> Expression -> Expression
+generateImplicitCastExpression
+  :: Bool -> [ValueType] -> [ValueType] -> Expression -> Expression
 generateImplicitCastExpression signed src_ts dest_ts src_expr =
   case (src_ts, dest_ts) of
-    ([I64], [F64]) ->
-      Unary
-        { unaryOp =
-            if signed
-              then ConvertSInt64ToFloat64
-              else ConvertUInt64ToFloat64
-        , operand0 = src_expr
+    ([I64], [F64]) -> Unary
+      { unaryOp = if signed
+        then ConvertSInt64ToFloat64
+        else ConvertUInt64ToFloat64,
+        operand0 = src_expr
         }
-    ([F64], [I64]) ->
-      Unary
-        { unaryOp =
-            if signed
-              then TruncSFloat64ToInt64
-              else TruncUFloat64ToInt64
-        , operand0 = src_expr
+    ([F64], [I64]) -> Unary
+      { unaryOp = if signed then TruncSFloat64ToInt64 else TruncUFloat64ToInt64,
+        operand0 = src_expr
         }
     _
-      | src_ts == dest_ts -> src_expr
+      | src_ts == dest_ts ->
+        src_expr
       | otherwise ->
-        error $
-        "Unsupported implicit cast from " <> show src_ts <> " to " <>
-        show dest_ts
+        error
+          $ "Unsupported implicit cast from "
+          <> show src_ts
+          <> " to "
+          <> show dest_ts
 
-generateFFIImportWrapperFunction ::
-     AsteriusEntitySymbol -> FFIImportDecl -> Function
-generateFFIImportWrapperFunction k FFIImportDecl {..} =
-  Function
-    { functionType = wrapper_func_type
-    , varTypes = []
-    , body =
-        generateImplicitCastExpression
-          (case ffiResultTypes ffiFunctionType of
-             [FFI_VAL {..}] -> signed
-             _ -> False)
-          (returnTypes import_func_type)
-          (returnTypes wrapper_func_type) $
-        CallImport
-          { target' = coerce k
-          , operands =
-              [ generateImplicitCastExpression
-                (case param_t of
-                   FFI_VAL {..} -> signed
-                   _ -> False)
-                [wrapper_param_t]
-                [import_param_t]
-                GetLocal {index = i, valueType = wrapper_param_t}
-              | (i, param_t, wrapper_param_t, import_param_t) <-
-                  zip4
-                    [0 ..]
-                    (ffiParamTypes ffiFunctionType)
-                    (paramTypes wrapper_func_type)
-                    (paramTypes import_func_type)
-              ]
-          , callImportReturnTypes = returnTypes import_func_type
+generateFFIImportWrapperFunction
+  :: AsteriusEntitySymbol -> FFIImportDecl -> Function
+generateFFIImportWrapperFunction k FFIImportDecl {..} = Function
+  { functionType = wrapper_func_type,
+    varTypes = [],
+    body = generateImplicitCastExpression
+             ( case ffiResultTypes ffiFunctionType of
+                 [FFI_VAL {..}] -> signed
+                 _ -> False
+               )
+             (returnTypes import_func_type)
+             (returnTypes wrapper_func_type)
+      $ CallImport
+        { target' = coerce k,
+          operands = [ generateImplicitCastExpression
+                         ( case param_t of
+                             FFI_VAL {..} -> signed
+                             _ -> False
+                           )
+                         [wrapper_param_t]
+                         [import_param_t]
+                         GetLocal
+                           { index = i,
+                             valueType = wrapper_param_t
+                             }
+                       | (i, param_t, wrapper_param_t, import_param_t) <-
+                           zip4 [0 ..]
+                             (ffiParamTypes ffiFunctionType)
+                             (paramTypes wrapper_func_type)
+                             (paramTypes import_func_type)
+                       ],
+          callImportReturnTypes = returnTypes import_func_type
           }
     }
   where
@@ -474,116 +497,119 @@ generateFFIImportWrapperFunction k FFIImportDecl {..} =
 generateFFIWrapperModule :: FFIMarshalState -> AsteriusModule
 generateFFIWrapperModule mod_ffi_state@FFIMarshalState {..} =
   mempty
-    { functionMap =
-        M.fromList
-          [ (k <> "_wrapper", wrapper_func)
-          | (k, wrapper_func) <- import_wrapper_funcs
-          ]
-    , ffiMarshalState = mod_ffi_state
-    }
+    { functionMap = M.fromList
+                      [ (k <> "_wrapper", wrapper_func)
+                        | (k, wrapper_func) <- import_wrapper_funcs
+                        ],
+      ffiMarshalState = mod_ffi_state
+      }
   where
     import_wrapper_funcs =
       [ (k, generateFFIImportWrapperFunction k ffi_decl)
-      | (k, ffi_decl) <- M.toList ffiImportDecls
-      ]
+        | (k, ffi_decl) <- M.toList ffiImportDecls
+        ]
 
 generateFFIFunctionImports :: FFIMarshalState -> [FunctionImport]
 generateFFIFunctionImports FFIMarshalState {..} =
   [ FunctionImport
-    { internalName = coerce k
-    , externalModuleName = "jsffi"
-    , externalBaseName = coerce k
-    , functionType = recoverWasmImportFunctionType ffiSafety ffiFunctionType
-    }
-  | (k, FFIImportDecl {..}) <- M.toList ffiImportDecls
-  ]
+      { internalName = coerce k,
+        externalModuleName = "jsffi",
+        externalBaseName = coerce k,
+        functionType = recoverWasmImportFunctionType ffiSafety ffiFunctionType
+        }
+    | (k, FFIImportDecl {..}) <- M.toList ffiImportDecls
+    ]
 
 generateFFIImportLambda :: FFIImportDecl -> Builder
-generateFFIImportLambda FFIImportDecl { ffiFunctionType = FFIFunctionType {..}
-                                      , ..
-                                      }
+generateFFIImportLambda FFIImportDecl {ffiFunctionType = FFIFunctionType {..}, ..}
   | is_unsafe =
-    lamb <>
-    (case ffiResultTypes of
-       [FFI_JSVAL] -> "__asterius_jsffi.newJSVal("
-       _ -> "(") <>
-    code <>
-    ")"
+    lamb
+      <> ( case ffiResultTypes of
+             [FFI_JSVAL] -> "__asterius_jsffi.newJSVal("
+             _ -> "("
+           )
+      <> code
+      <> ")"
   | otherwise =
-    lamb <> "__asterius_jsffi.setPromise(" <>
-    intDec
-      (case ffiResultTypes of
-         [r] -> succ $ fromEnum $ recoverWasmWrapperValueType r
-         _ -> 0) <>
-    ",Promise.resolve(" <>
-    code <>
-    ")" <>
-    (case ffiResultTypes of
-       [FFI_JSVAL] -> ".then(v => __asterius_jsffi.newJSVal(v))"
-       _ -> mempty) <>
-    ")"
+    lamb
+      <> "__asterius_jsffi.setPromise("
+      <> intDec
+           ( case ffiResultTypes of
+               [r] -> succ $ fromEnum $ recoverWasmWrapperValueType r
+               _ -> 0
+             )
+      <> ",Promise.resolve("
+      <> code
+      <> ")"
+      <> ( case ffiResultTypes of
+             [FFI_JSVAL] -> ".then(v => __asterius_jsffi.newJSVal(v))"
+             _ -> mempty
+           )
+      <> ")"
   where
     is_unsafe = ffiSafety == FFIUnsafe
     lamb =
-      "(" <>
-      mconcat
-        (intersperse "," ["_" <> intDec i | i <- [1 .. length ffiParamTypes]]) <>
-      ")=>"
+      "("
+        <> mconcat
+             ( intersperse ","
+                 ["_" <> intDec i | i <- [1 .. length ffiParamTypes]]
+               )
+        <> ")=>"
     code =
       mconcat
         [ case chunk of
-          Lit s -> stringUtf8 s
-          Field i ->
-            case ffiParamTypes !! (i - 1) of
+            Lit s -> stringUtf8 s
+            Field i -> case ffiParamTypes !! (i - 1) of
               FFI_JSVAL -> "__asterius_jsffi.getJSVal(_" <> intDec i <> ")"
               _ -> "_" <> intDec i
-        | chunk <- ffiSourceChunks
-        ]
+          | chunk <- ffiSourceChunks
+          ]
 
 generateFFIImportObjectFactory :: FFIMarshalState -> Builder
 generateFFIImportObjectFactory FFIMarshalState {..} =
-  "__asterius_jsffi=>({jsffi: {" <>
-  mconcat
-    (intersperse
-       ","
-       [ shortByteString (coerce k) <> ":" <> generateFFIImportLambda ffi_decl
-       | (k, ffi_decl) <- M.toList ffiImportDecls
-       ]) <>
-  "}})"
+  "__asterius_jsffi=>({jsffi: {"
+    <> mconcat
+         ( intersperse
+             ","
+             [ shortByteString (coerce k)
+                 <> ":"
+                 <> generateFFIImportLambda ffi_decl
+               | (k, ffi_decl) <- M.toList ffiImportDecls
+               ]
+           )
+    <> "}})"
 
 generateFFIExportObject :: FFIMarshalState -> Builder
 generateFFIExportObject FFIMarshalState {..} =
-  "{" <>
-  mconcat
-    (intersperse
-       ","
-       [ shortByteString (coerce k) <> ":" <>
-       generateFFIExportLambda export_decl
-       | (k, export_decl) <- M.toList ffiExportDecls
-       ]) <>
-  "}"
+  "{"
+    <> mconcat
+         ( intersperse
+             ","
+             [ shortByteString (coerce k)
+                 <> ":"
+                 <> generateFFIExportLambda export_decl
+               | (k, export_decl) <- M.toList ffiExportDecls
+               ]
+           )
+    <> "}"
 
 generateFFIExportLambda :: FFIExportDecl -> Builder
-generateFFIExportLambda FFIExportDecl { ffiFunctionType = FFIFunctionType {..}
-                                      , ..
-                                      } =
-  "async function(" <>
-  mconcat (intersperse "," ["_" <> intDec i | i <- [1 .. length ffiParamTypes]]) <>
-  "){" <>
-  (if null ffiResultTypes
-     then tid
-     else "return " <> ret) <>
-  "}"
+generateFFIExportLambda FFIExportDecl {ffiFunctionType = FFIFunctionType {..}, ..} =
+  "async function("
+    <> mconcat
+         ( intersperse "," ["_" <> intDec i | i <- [1 .. length ffiParamTypes]]
+           )
+    <> "){"
+    <> (if null ffiResultTypes then tid else "return " <> ret)
+    <> "}"
   where
-    ret =
-      case ffiResultTypes of
-        [t] ->
-          let r = "this.rts_get" <> getHsTyCon t <> "(" <> ret_closure <> ")"
-           in case t of
-                FFI_JSVAL ->
-                  "this.context.stablePtrManager.getJSVal(" <> r <> ")"
-                _ -> r
-        _ -> error "Asterius.JSFFI.generateFFIExportLambda"
+    ret = case ffiResultTypes of
+      [t] ->
+        let r = "this.rts_get" <> getHsTyCon t <> "(" <> ret_closure <> ")"
+         in case t of
+              FFI_JSVAL -> "this.context.stablePtrManager.getJSVal(" <> r <> ")"
+              _ -> r
+      _ -> error "Asterius.JSFFI.generateFFIExportLambda"
     ret_closure = "this.context.tsoManager.getTSOret(" <> tid <> ")"
     tid = "await this." <> eval_func <> "(" <> eval_closure <> ")"
     eval_func
@@ -591,16 +617,21 @@ generateFFIExportLambda FFIExportDecl { ffiFunctionType = FFIFunctionType {..}
       | otherwise = "rts_eval"
     eval_closure =
       foldl'
-        (\acc (i, t) ->
-           "this.rts_apply(" <> acc <> ",this.rts_mk" <> getHsTyCon t <> "(" <>
-           (let _i = "_" <> intDec i
-             in case t of
-                  FFI_JSVAL ->
-                    "this.context.stablePtrManager.newJSVal(" <> _i <> ")"
-                  _ -> _i) <>
-           "))")
-        ("this.context.symbolTable." <>
-         shortByteString (coerce ffiExportClosure))
+        ( \acc (i, t) ->
+            "this.rts_apply("
+              <> acc
+              <> ",this.rts_mk"
+              <> getHsTyCon t
+              <> "("
+              <> ( let _i = "_" <> intDec i
+                    in case t of
+                         FFI_JSVAL ->
+                           "this.context.stablePtrManager.newJSVal(" <> _i <> ")"
+                         _ -> _i
+                   )
+              <> "))"
+          )
+        ("this.context.symbolTable." <> shortByteString (coerce ffiExportClosure))
         (zip [1 ..] ffiParamTypes)
     getHsTyCon FFI_VAL {..} = shortByteString hsTyCon
     getHsTyCon FFI_JSVAL = "StablePtr"

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/FrontendPlugin.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/FrontendPlugin.hs
@@ -1,6 +1,7 @@
 module Language.Haskell.GHC.Toolkit.FrontendPlugin
   ( makeFrontendPlugin
-  ) where
+    )
+where
 
 import Config
 import Control.Monad
@@ -16,48 +17,45 @@ import Panic
 makeFrontendPlugin :: Ghc Compiler -> FrontendPlugin
 makeFrontendPlugin init_c =
   defaultFrontendPlugin
-    { frontend =
-        \_ targets -> do
-          c <- init_c
-          flip gfinally (finalize c) $ do
-            h <- liftIO $ hooksFromCompiler c
-            let (hs_targets, non_hs_targets) =
-                  partition isHaskellishTarget targets
-            if null hs_targets
-              then do
-                dflags <- getSessionDynFlags
-                void $
-                  setSessionDynFlags
+    { frontend = \_ targets -> do
+        c <- init_c
+        flip gfinally (finalize c) $ do
+          dflags <- getSessionDynFlags
+          h <- liftIO $ hooksFromCompiler c (hooks dflags)
+          let (hs_targets, non_hs_targets) = partition isHaskellishTarget targets
+          if null hs_targets
+          then
+            do
+              void
+                $ setSessionDynFlags
                     dflags
-                      { integerLibrary = IntegerSimple
-                      , tablesNextToCode = False
-                      , hooks = h
-                      }
-                env <- getSession
-                liftIO $ oneShot env StopLn targets
-              else do
-                do dflags <- getSessionDynFlags
-                   void $
-                     setSessionDynFlags
-                       dflags
-                         { integerLibrary = IntegerSimple
-                         , tablesNextToCode = False
-                         , hooks = h
-                         }
-                env <- getSession
-                o_files <-
-                  liftIO $ traverse (compileFile env StopLn) non_hs_targets
-                dflags <- getSessionDynFlags
-                void $
-                  setSessionDynFlags
+                      { integerLibrary = IntegerSimple,
+                        tablesNextToCode = False,
+                        hooks = h
+                        }
+              env <- getSession
+              liftIO $ oneShot env StopLn targets
+          else
+            do
+              void
+                $ setSessionDynFlags
                     dflags
-                      { ghcMode = CompManager
-                      , ldInputs =
-                          map (FileOption "") o_files ++ ldInputs dflags
-                      }
-                traverse (uncurry GHC.guessTarget) hs_targets >>= setTargets
-                ok_flag <- load LoadAllTargets
-                when (failed ok_flag) $
-                  liftIO $
-                  throwGhcExceptionIO $ Panic "GHC.load returned Failed."
-    }
+                      { integerLibrary = IntegerSimple,
+                        tablesNextToCode = False,
+                        hooks = h
+                        }
+              env <- getSession
+              o_files <- liftIO $ traverse (compileFile env StopLn) non_hs_targets
+              dflags' <- getSessionDynFlags
+              void
+                $ setSessionDynFlags
+                    dflags'
+                      { ghcMode = CompManager,
+                        ldInputs = map (FileOption "") o_files ++ ldInputs dflags'
+                        }
+              traverse (uncurry GHC.guessTarget) hs_targets >>= setTargets
+              ok_flag <- load LoadAllTargets
+              when (failed ok_flag) $ liftIO $ throwGhcExceptionIO
+                $ Panic
+                    "GHC.load returned Failed."
+      }

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/FrontendPlugin.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/FrontendPlugin.hs
@@ -12,6 +12,7 @@ import GHC
 import GhcPlugins hiding ((<>))
 import Language.Haskell.GHC.Toolkit.Compiler
 import Language.Haskell.GHC.Toolkit.Hooks
+import Language.Haskell.GHC.Toolkit.Orphans.Show
 import Panic
 
 makeFrontendPlugin :: Ghc Compiler -> FrontendPlugin
@@ -33,6 +34,7 @@ makeFrontendPlugin init_c =
                         tablesNextToCode = False,
                         hooks = h
                         }
+              getSessionDynFlags >>= setDynFlagsRef
               env <- getSession
               liftIO $ oneShot env StopLn targets
           else
@@ -54,6 +56,7 @@ makeFrontendPlugin init_c =
                         ldInputs = map (FileOption "") o_files ++ ldInputs dflags'
                         }
               traverse (uncurry GHC.guessTarget) hs_targets >>= setTargets
+              getSessionDynFlags >>= setDynFlagsRef
               ok_flag <- load LoadAllTargets
               when (failed ok_flag) $ liftIO $ throwGhcExceptionIO
                 $ Panic

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Hooks.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Hooks.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Language.Haskell.GHC.Toolkit.Hooks
   ( hooksFromCompiler
-  ) where
+    )
+where
 
 import qualified CmmInfo as GHC
 import Control.Concurrent
@@ -24,8 +24,8 @@ import qualified PipelineMonad as GHC
 import qualified StgCmm as GHC
 import qualified Stream
 
-hooksFromCompiler :: Compiler -> IO GHC.Hooks
-hooksFromCompiler Compiler {..} = do
+hooksFromCompiler :: Compiler -> GHC.Hooks -> IO GHC.Hooks
+hooksFromCompiler Compiler {..} h = do
   mods_set_ref <- newMVar Set.empty
   parsed_map_ref <- newMVar Map.empty
   typechecked_map_ref <- newMVar Map.empty
@@ -35,103 +35,111 @@ hooksFromCompiler Compiler {..} = do
   cmm_ref <- newEmptyMVar
   cmm_raw_ref <- newEmptyMVar
   pure
-    GHC.emptyHooks
-      { GHC.tcRnModuleHook =
-          Just $ \mod_summary@GHC.ModSummary {..} save_rn_syntax parsed_module_orig -> do
-            parsed_module <- patchParsed mod_summary parsed_module_orig
-            typechecked_module <-
-              GHC.tcRnModule' mod_summary save_rn_syntax parsed_module >>=
-              patchTypechecked mod_summary
-            let store :: MVar (Map.Map GHC.Module v) -> v -> IO ()
-                store ref v = modifyMVar_ ref $ pure . Map.insert ms_mod v
-            liftIO $ do
-              store parsed_map_ref parsed_module
-              store typechecked_map_ref typechecked_module
-            pure typechecked_module
-      , GHC.stgCmmHook =
-          Just $ \dflags this_mod data_tycons cost_centre_info stg_binds hpc_info -> do
-            Stream.liftIO $
-              modifyMVar_ stg_map_ref $ pure . Map.insert this_mod stg_binds
-            GHC.codeGen
-              dflags
+    h
+      { GHC.tcRnModuleHook = Just
+          $ \mod_summary@GHC.ModSummary {..} save_rn_syntax parsed_module_orig ->
+            do
+              parsed_module <- patchParsed mod_summary parsed_module_orig
+              typechecked_module <-
+                GHC.tcRnModule' mod_summary save_rn_syntax parsed_module
+                  >>= patchTypechecked mod_summary
+              let store :: MVar (Map.Map GHC.Module v) -> v -> IO ()
+                  store ref v = modifyMVar_ ref $ pure . Map.insert ms_mod v
+              liftIO $ do
+                store parsed_map_ref parsed_module
+                store typechecked_map_ref typechecked_module
+              pure typechecked_module,
+        GHC.stgCmmHook = Just
+          $ \dflags this_mod data_tycons cost_centre_info stg_binds hpc_info -> do
+            Stream.liftIO
+              $ modifyMVar_ stg_map_ref
+              $ pure
+              . Map.insert this_mod stg_binds
+            GHC.codeGen dflags
               this_mod
               data_tycons
               cost_centre_info
               stg_binds
-              hpc_info
-      , GHC.cmmToRawCmmHook =
-          Just $ \dflags maybe_ms_mod cmms -> do
-            rawcmms <- GHC.cmmToRawCmm dflags maybe_ms_mod cmms
-            case maybe_ms_mod of
-              Just ms_mod -> do
-                let store :: MVar (Map.Map GHC.Module v) -> v -> IO ()
-                    store ref v = modifyMVar_ ref $ pure . Map.insert ms_mod v
-                store cmm_map_ref cmms
-                store cmm_raw_map_ref rawcmms
-              _ -> do
-                putMVar cmm_ref cmms
-                putMVar cmm_raw_ref rawcmms
-            pure rawcmms
-      , GHC.hscCompileCoreExprHook = compileCoreExpr
-      , GHC.runPhaseHook =
-          Just $ \phase input_fn dflags ->
-            case phase of
-              GHC.HscOut src_flavour _ (GHC.HscRecomp cgguts mod_summary@GHC.ModSummary {..}) -> do
-                r@(_, obj_output_fn) <-
-                  do output_fn <-
-                       GHC.phaseOutputFilename $
-                       GHC.hscPostBackendPhase dflags src_flavour $
-                       GHC.hscTarget dflags
-                     GHC.PipeState {GHC.hsc_env = hsc_env'} <- GHC.getPipeState
-                     void $
-                       liftIO $
-                       GHC.hscGenHardCode hsc_env' cgguts mod_summary output_fn
-                     GHC.setForeignOs []
-                     obj_output_fn <- GHC.phaseOutputFilename GHC.StopLn
-                     pure (GHC.RealPhase GHC.StopLn, obj_output_fn)
-                f <-
-                  liftIO $
-                  modifyMVar mods_set_ref $ \s ->
-                    pure (Set.insert ms_mod s, Set.member ms_mod s)
-                if f
-                  then liftIO $ do
-                         let clean :: MVar (Map.Map GHC.Module a) -> IO ()
-                             clean ref =
-                               modifyMVar_ ref $ pure . Map.delete ms_mod
-                         clean parsed_map_ref
-                         clean typechecked_map_ref
-                         clean stg_map_ref
-                         clean cmm_map_ref
-                         clean cmm_raw_map_ref
-                  else (do let fetch :: MVar (Map.Map GHC.Module v) -> IO v
-                               fetch ref =
-                                 modifyMVar
-                                   ref
-                                   (\m ->
-                                      let (Just v, m') =
-                                            Map.updateLookupWithKey
-                                              (\_ _ -> Nothing)
-                                              ms_mod
-                                              m
-                                       in pure (m', v))
-                           ir <-
-                             liftIO $
-                             HaskellIR <$> fetch parsed_map_ref <*>
-                             fetch typechecked_map_ref <*>
-                             pure cgguts <*>
-                             fetch stg_map_ref <*>
-                             (fetch cmm_map_ref >>= Stream.collect) <*>
-                             (fetch cmm_raw_map_ref >>= Stream.collect)
-                           withHaskellIR mod_summary ir obj_output_fn)
-                pure r
-              GHC.RealPhase GHC.Cmm -> do
-                void $ GHC.runPhase phase input_fn dflags
-                ir <-
-                  liftIO $
-                  CmmIR <$> (takeMVar cmm_ref >>= Stream.collect) <*>
-                  (takeMVar cmm_raw_ref >>= Stream.collect)
-                obj_output_fn <- GHC.phaseOutputFilename GHC.StopLn
-                withCmmIR ir obj_output_fn
-                pure (GHC.RealPhase GHC.StopLn, obj_output_fn)
-              _ -> GHC.runPhase phase input_fn dflags
-      }
+              hpc_info,
+        GHC.cmmToRawCmmHook = Just $ \dflags maybe_ms_mod cmms -> do
+          rawcmms <- GHC.cmmToRawCmm dflags maybe_ms_mod cmms
+          case maybe_ms_mod of
+            Just ms_mod -> do
+              let store :: MVar (Map.Map GHC.Module v) -> v -> IO ()
+                  store ref v = modifyMVar_ ref $ pure . Map.insert ms_mod v
+              store cmm_map_ref cmms
+              store cmm_raw_map_ref rawcmms
+            _ -> do
+              putMVar cmm_ref cmms
+              putMVar cmm_raw_ref rawcmms
+          pure rawcmms,
+        GHC.hscCompileCoreExprHook = compileCoreExpr,
+        GHC.runPhaseHook = Just $ \phase input_fn dflags -> case phase of
+          GHC.HscOut src_flavour _ (GHC.HscRecomp cgguts mod_summary@GHC.ModSummary {..}) ->
+            do
+              r@(_, obj_output_fn) <-
+                do
+                  output_fn <-
+                    GHC.phaseOutputFilename
+                      $ GHC.hscPostBackendPhase dflags src_flavour
+                      $ GHC.hscTarget dflags
+                  GHC.PipeState {GHC.hsc_env = hsc_env'} <- GHC.getPipeState
+                  void $ liftIO
+                    $ GHC.hscGenHardCode hsc_env'
+                        cgguts
+                        mod_summary
+                        output_fn
+                  GHC.setForeignOs []
+                  obj_output_fn <- GHC.phaseOutputFilename GHC.StopLn
+                  pure (GHC.RealPhase GHC.StopLn, obj_output_fn)
+              f <-
+                liftIO $ modifyMVar mods_set_ref $ \s ->
+                  pure (Set.insert ms_mod s, Set.member ms_mod s)
+              if f
+              then
+                liftIO $ do
+                  let clean :: MVar (Map.Map GHC.Module a) -> IO ()
+                      clean ref = modifyMVar_ ref $ pure . Map.delete ms_mod
+                  clean parsed_map_ref
+                  clean typechecked_map_ref
+                  clean stg_map_ref
+                  clean cmm_map_ref
+                  clean cmm_raw_map_ref
+              else
+                ( do
+                    let fetch :: MVar (Map.Map GHC.Module v) -> IO v
+                        fetch ref =
+                          modifyMVar
+                            ref
+                            ( \m ->
+                                let (Just v, m') =
+                                      Map.updateLookupWithKey
+                                        (\_ _ -> Nothing)
+                                        ms_mod
+                                        m
+                                 in pure (m', v)
+                              )
+                    ir <-
+                      liftIO
+                        $ HaskellIR
+                        <$> fetch parsed_map_ref
+                        <*> fetch typechecked_map_ref
+                        <*> pure cgguts
+                        <*> fetch stg_map_ref
+                        <*> (fetch cmm_map_ref >>= Stream.collect)
+                        <*> (fetch cmm_raw_map_ref >>= Stream.collect)
+                    withHaskellIR mod_summary ir obj_output_fn
+                  )
+              pure r
+          GHC.RealPhase GHC.Cmm -> do
+            void $ GHC.runPhase phase input_fn dflags
+            ir <-
+              liftIO
+                $ CmmIR
+                <$> (takeMVar cmm_ref >>= Stream.collect)
+                <*> (takeMVar cmm_raw_ref >>= Stream.collect)
+            obj_output_fn <- GHC.phaseOutputFilename GHC.StopLn
+            withCmmIR ir obj_output_fn
+            pure (GHC.RealPhase GHC.StopLn, obj_output_fn)
+          _ -> GHC.runPhase phase input_fn dflags
+        }

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Orphans/Show.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Orphans/Show.hs
@@ -6,36 +6,27 @@
 
 module Language.Haskell.GHC.Toolkit.Orphans.Show
   ( setDynFlagsRef
-  ) where
+    )
+where
 
-import BasicTypes
 import CLabel
 import Cmm
 import CoAxiom
 import Control.Monad.IO.Class
-import CoreSyn
 import CostCentre
 import CostCentreState
 import Data.IORef
-import DataCon
-import DynFlags
 import ForeignCall
+import GhcPlugins
 import Hoopl.Block
 import Hoopl.Graph
-import HscTypes
-import Literal
-import Module
-import Name
-import Outputable
 import PrimOp
 import SMRep
 import StgSyn
 import System.IO.Unsafe
 import Text.Show.Functions ()
 import TyCoRep
-import TyCon
 import UniqDSet
-import Var
 
 {-# NOINLINE dynFlagsRef #-}
 dynFlagsRef :: IORef DynFlags
@@ -45,17 +36,21 @@ setDynFlagsRef :: MonadIO m => DynFlags -> m ()
 setDynFlagsRef = liftIO . atomicWriteIORef dynFlagsRef
 
 fakeShow :: Outputable a => String -> a -> String
-fakeShow tag val =
-  unsafePerformIO $ do
-    dflags <- readIORef dynFlagsRef
-    pure $
-      "(" ++
-      tag ++ " " ++ show (showSDoc dflags $ pprCode AsmStyle $ ppr val) ++ ")"
+fakeShow tag val = unsafePerformIO $ do
+  dflags <- readIORef dynFlagsRef
+  pure
+    $ "("
+    ++ tag
+    ++ " "
+    ++ show (showSDoc dflags $ pprCode AsmStyle $ ppr val)
+    ++ ")"
 
 instance Outputable SDoc where
+
   ppr = id
 
 instance Show SDoc where
+
   show = fakeShow "SDoc"
 
 deriving instance Show ForeignStubs
@@ -65,6 +60,7 @@ deriving instance Show InstalledUnitId
 deriving instance Show HpcInfo
 
 instance Show ModBreaks where
+
   show = const "ModBreaks"
 
 deriving instance Show SptEntry
@@ -78,9 +74,11 @@ deriving instance Show b => Show (Bind b)
 deriving instance Show FunctionOrData
 
 instance Show Var where
+
   show = fakeShow "Var"
 
 instance Show TyCon where
+
   show = fakeShow "TyCon"
 
 deriving instance Show ArgFlag
@@ -92,6 +90,7 @@ deriving instance Show Role
 deriving instance Show CoAxBranch
 
 instance Show (Branches br) where
+
   show = show . fromBranches
 
 deriving instance Show (CoAxiom br)
@@ -103,6 +102,7 @@ deriving instance Show CoAxiomRule
 deriving instance Show LeftOrRight
 
 instance Show a => Show (IORef a) where
+
   show = show . unsafePerformIO . readIORef
 
 deriving instance Show CoercionHole
@@ -110,7 +110,7 @@ deriving instance Show CoercionHole
 deriving instance Show Coercion
 
 deriving instance
-         (Show tyvar, Show argf) => Show (TyVarBndr tyvar argf)
+  (Show tyvar, Show argf) => Show (TyVarBndr tyvar argf)
 
 deriving instance Show Type
 
@@ -119,6 +119,7 @@ deriving instance Show LitNumType
 deriving instance Show Literal
 
 instance Show DataCon where
+
   show = fakeShow "DataCon"
 
 deriving instance Show PrimOpVecCat
@@ -142,31 +143,35 @@ deriving instance Show AltCon
 deriving instance Show occ => Show (GenStgArg occ)
 
 deriving instance
-         (Show bndr, Show occ) => Show (GenStgExpr bndr occ)
+  (Show bndr, Show occ) => Show (GenStgExpr bndr occ)
 
 instance Show CostCentreStack where
+
   show = fakeShow "CostCentreStack"
 
 deriving instance Show UpdateFlag
 
 instance Show StgBinderInfo where
+
   show binder_info
     | satCallsOnly binder_info = "SatCallsOnly"
     | otherwise = "NoStgBinderInfo"
 
 deriving instance
-         (Show bndr, Show occ) => Show (GenStgRhs bndr occ)
+  (Show bndr, Show occ) => Show (GenStgRhs bndr occ)
 
 deriving instance
-         (Show bndr, Show occ) => Show (GenStgBinding bndr occ)
+  (Show bndr, Show occ) => Show (GenStgBinding bndr occ)
 
 deriving instance
-         (Show bndr, Show occ) => Show (GenStgTopBinding bndr occ)
+  (Show bndr, Show occ) => Show (GenStgTopBinding bndr occ)
 
 instance Show Name where
+
   show = fakeShow "Name"
 
 instance Show CLabel where
+
   show = fakeShow "CLabel"
 
 deriving instance Show Section
@@ -180,29 +185,37 @@ deriving instance Show CmmStatics
 deriving instance Show t => Show (MaybeO ex t)
 
 instance Show (n O O) => Show (Block n O O) where
+
   show = show . blockToList
 
 instance (Show (n C O), Show (n O O), Show (n O C)) => Show (Block n C C) where
+
   show (BlockCC h b t) =
     "BlockCC (" ++ show h ++ ") (" ++ show b ++ ") (" ++ show t ++ ")"
 
-instance (Show (block n C C), Show (n C O), Show (n O O), Show (n O C)) =>
-         Show (Graph' block n C C) where
+instance
+  (Show (block n C C), Show (n C O), Show (n O O), Show (n O C))
+  => Show (Graph' block n C C)
+  where
+
   show (GMany NothingO lm NothingO) = show $ bodyList lm
 
 deriving instance
-         (Show (n C O), Show (n O O), Show (n O C)) => Show (GenCmmGraph n)
+  (Show (n C O), Show (n O O), Show (n O C)) => Show (GenCmmGraph n)
 
 deriving instance Show CmmTickScope
 
 instance Show ModuleName where
+
   show = show . moduleNameString
 
 instance Show Module where
+
   show (Module u m) =
     "Module \"" ++ unitIdString u ++ "\" \"" ++ moduleNameString m ++ "\""
 
 instance Show CostCentreIndex where
+
   show = show . unCostCentreIndex
 
 deriving instance Show CCFlavour
@@ -212,6 +225,7 @@ deriving instance Show CostCentre
 deriving instance Show id => Show (Tickish id)
 
 instance Show CmmType where
+
   show = fakeShow "CmmType"
 
 deriving instance Show LocalReg
@@ -235,7 +249,7 @@ deriving instance Show ForeignTarget
 deriving instance Show (CmmNode e x)
 
 deriving instance
-         (Show d, Show h, Show g) => Show (GenCmmDecl d h g)
+  (Show d, Show h, Show g) => Show (GenCmmDecl d h g)
 
 deriving instance Show ArgDescr
 
@@ -246,6 +260,7 @@ deriving instance Show SMRep
 deriving instance Show ProfilingInfo
 
 instance Show StgHalfWord where
+
   show = show . fromStgHalfWord
 
 deriving instance Show CmmInfoTable
@@ -255,4 +270,5 @@ deriving instance Show CmmStackInfo
 deriving instance Show CmmTopInfo
 
 instance Show a => Show (UniqDSet a) where
+
   showsPrec p = showsPrec p . uniqDSetToList

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Run.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Run.hs
@@ -2,13 +2,14 @@
 {-# LANGUAGE StrictData #-}
 
 module Language.Haskell.GHC.Toolkit.Run
-  ( Config
-  , ghcFlags
-  , ghcLibDir
-  , compiler
-  , defaultConfig
-  , runCmm
-  ) where
+  ( Config,
+    ghcFlags,
+    ghcLibDir,
+    compiler,
+    defaultConfig,
+    runCmm
+    )
+where
 
 import Config
 import Control.Monad.IO.Class
@@ -21,37 +22,44 @@ import qualified Language.Haskell.GHC.Toolkit.BuildInfo as BI
 import Language.Haskell.GHC.Toolkit.Compiler
 import Language.Haskell.GHC.Toolkit.Hooks
 
-data Config = Config
-  { ghcFlags :: [String]
-  , ghcLibDir :: FilePath
-  , compiler :: Compiler
-  }
+data Config
+  = Config
+      { ghcFlags :: [String],
+        ghcLibDir :: FilePath,
+        compiler :: Compiler
+        }
 
 defaultConfig :: Config
-defaultConfig =
-  Config
-    {ghcFlags = ["-Wall", "-O"], ghcLibDir = BI.ghcLibDir, compiler = mempty}
+defaultConfig = Config
+  { ghcFlags = ["-Wall", "-O"],
+    ghcLibDir = BI.ghcLibDir,
+    compiler = mempty
+    }
 
 runCmm :: Config -> [FilePath] -> (FilePath -> CmmIR -> IO ()) -> GHC.Ghc ()
 runCmm Config {..} cmm_fns write_obj_cont = do
   dflags <- getSessionDynFlags
   (dflags', _, _) <-
     parseDynamicFlags
-      (dflags `gopt_set` Opt_ForceRecomp `gopt_unset` Opt_KeepOFiles) $
-    map noLoc ghcFlags
+      (dflags `gopt_set` Opt_ForceRecomp `gopt_unset` Opt_KeepOFiles)
+      $ map noLoc ghcFlags
   h <-
-    liftIO $
-    hooksFromCompiler
-      (compiler <>
-       mempty {withCmmIR = \ir obj_path -> liftIO $ write_obj_cont obj_path ir})
-  void $
-    setSessionDynFlags
-      dflags'
-        { ghcMode = OneShot
-        , ghcLink = NoLink
-        , integerLibrary = IntegerSimple
-        , tablesNextToCode = False
-        , hooks = h
-        }
+    liftIO
+      $ hooksFromCompiler
+          ( compiler
+              <> mempty
+                { withCmmIR = \ir obj_path -> liftIO $ write_obj_cont obj_path ir
+                  }
+            )
+          (hooks dflags')
+  void
+    $ setSessionDynFlags
+        dflags'
+          { ghcMode = OneShot,
+            ghcLink = NoLink,
+            integerLibrary = IntegerSimple,
+            tablesNextToCode = False,
+            hooks = h
+            }
   env <- getSession
   liftIO $ oneShot env StopLn [(cmm_fn, Just CmmCpp) | cmm_fn <- cmm_fns]


### PR DESCRIPTION
This PR is intermediate work of gen2 JSFFI: instead of working with parsed AST, we do the work during typechecking/desugaring, hopefully solving the following problems of gen1 JSFFI:

* Not supporting type synonyms & `newtype`s of argument & return types in foreign declarations
* Needing a link-time rewriting pass to handle async imports, which is slow and fragile, and chokes non-main linking as spotted in our ongoing effort to implement TH

The approach now is much closer to what ghcjs does. This PR migrates only import-related logic and doesn't affect the link-time rewriting yet. If it works well subsequent PRs will remove all gen1 logic.