### PR TITLE
Gen2 JSFFI part II

### DIFF
--- a/asterius/src/Asterius/Foreign.hs
+++ b/asterius/src/Asterius/Foreign.hs
@@ -387,13 +387,14 @@ asteriusTcFExport
       (norm_co, norm_sig_ty, gres) <- normaliseFfiType sig_ty
       spec' <- asteriusTcCheckFEType norm_sig_ty spec
       id <- mkStableIdFromName nm sig_ty loc mkForeignExportOcc
+      spec'' <- processFFIExport globalFFIHookState sig_ty norm_sig_ty id spec'
       return
         ( mkVarBind id rhs,
           ForeignExport
             { fd_name = L loc id,
               fd_sig_ty = undefined,
               fd_e_ext = norm_co,
-              fd_fe = spec'
+              fd_fe = spec''
               },
           gres
           )

--- a/asterius/src/Asterius/JSFFI.hs
+++ b/asterius/src/Asterius/JSFFI.hs
@@ -4,10 +4,9 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StrictData #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Asterius.JSFFI
-  ( addFFIProcessor,
+  ( getFFIModule,
     generateFFIFunctionImports,
     generateFFIImportObjectFactory,
     generateFFIExportObject
@@ -15,168 +14,16 @@ module Asterius.JSFFI
 where
 
 import Asterius.Foreign.Internals
-import Asterius.Internals
 import Asterius.Types
-import Asterius.TypesConv
 import Control.Applicative
-import Control.Monad.State.Strict
 import Data.ByteString.Builder
-import qualified Data.ByteString.Short as SBS
 import Data.Coerce
-import Data.Data
-  ( Data,
-    gmapM,
-    gmapQ
-    )
-import Data.Functor.Identity
 import Data.IORef
 import Data.List
 import qualified Data.Map.Strict as M
 import Data.Monoid
-import Data.String
-import qualified ForeignCall as GHC
-import qualified GhcPlugins as GHC
-import qualified HsSyn as GHC
-import Language.Haskell.GHC.Toolkit.Compiler
-import qualified PrelNames as GHC
-import qualified TcRnTypes as GHC
-import Type.Reflection
-import qualified TysPrim as GHC
 import Prelude hiding (IO)
 import qualified Prelude
-
-marshalToFFIValueType
-  :: (GHC.HasOccName (GHC.IdP p)) => GHC.LHsType p -> Maybe FFIValueType
-marshalToFFIValueType (GHC.unLoc -> GHC.HsParTy _ t) = marshalToFFIValueType t
-marshalToFFIValueType (GHC.unLoc -> t) = case t of
-  GHC.HsAppTy _ (GHC.unLoc -> (GHC.HsTyVar _ _ (GHC.occName . GHC.unLoc -> c))) _
-    | c == GHC.occName GHC.ptrTyConName ->
-      pure
-        FFI_VAL
-          { ffiWasmValueType = I64,
-            ffiJSValueType = F64,
-            hsTyCon = "Ptr",
-            signed = False
-            }
-    | c == GHC.occName GHC.funPtrTyConName ->
-      pure
-        FFI_VAL
-          { ffiWasmValueType = I64,
-            ffiJSValueType = F64,
-            hsTyCon = "FunPtr",
-            signed = False
-            }
-    | c
-        `elem` map
-                 GHC.occName
-                 [ GHC.stablePtrTyConName,
-                   GHC.getName GHC.stablePtrPrimTyCon,
-                   GHC.getName GHC.mutableByteArrayPrimTyCon
-                   ] ->
-      pure
-        FFI_VAL
-          { ffiWasmValueType = I64,
-            ffiJSValueType = F64,
-            hsTyCon = "StablePtr",
-            signed = False
-            }
-  GHC.HsTyVar _ _ (GHC.occName . GHC.unLoc -> tv)
-    | tv
-        `elem` map
-                 GHC.occName
-                 [GHC.addrPrimTyConName, GHC.getName GHC.byteArrayPrimTyCon] ->
-      pure
-        FFI_VAL
-          { ffiWasmValueType = I64,
-            ffiJSValueType = F64,
-            hsTyCon = "Ptr",
-            signed = False
-            }
-    | tv `elem` map GHC.occName [GHC.charTyConName, GHC.charPrimTyConName] ->
-      pure
-        FFI_VAL
-          { ffiWasmValueType = I64,
-            ffiJSValueType = F64,
-            hsTyCon = "Char",
-            signed = False
-            }
-    | tv == GHC.occName GHC.boolTyConName ->
-      pure
-        FFI_VAL
-          { ffiWasmValueType = I64,
-            ffiJSValueType = F64,
-            hsTyCon = "Bool",
-            signed = False
-            }
-    | tv `elem` map GHC.occName [GHC.intTyConName, GHC.intPrimTyConName] ->
-      pure
-        FFI_VAL
-          { ffiWasmValueType = I64,
-            ffiJSValueType = F64,
-            hsTyCon = "Int",
-            signed = True
-            }
-    | tv `elem` map GHC.occName [GHC.wordTyConName, GHC.wordPrimTyConName] ->
-      pure
-        FFI_VAL
-          { ffiWasmValueType = I64,
-            ffiJSValueType = F64,
-            hsTyCon = "Word",
-            signed = False
-            }
-    | tv `elem` map GHC.occName [GHC.floatTyConName, GHC.floatPrimTyConName] ->
-      pure
-        FFI_VAL
-          { ffiWasmValueType = F32,
-            ffiJSValueType = F32,
-            hsTyCon = "Float",
-            signed = True
-            }
-    | tv `elem` map GHC.occName [GHC.doubleTyConName, GHC.doublePrimTyConName] ->
-      pure
-        FFI_VAL
-          { ffiWasmValueType = F64,
-            ffiJSValueType = F64,
-            hsTyCon = "Double",
-            signed = True
-            }
-    | take 2 (GHC.occNameString tv) == "JS" ->
-      pure FFI_JSVAL
-  _ -> empty
-
-marshalToFFIResultTypes
-  :: (GHC.HasOccName (GHC.IdP p)) => GHC.LHsType p -> Maybe [FFIValueType]
-marshalToFFIResultTypes (GHC.unLoc -> GHC.HsParTy _ t) =
-  marshalToFFIResultTypes t
-marshalToFFIResultTypes (GHC.unLoc -> GHC.HsTupleTy _ _ []) = pure []
-marshalToFFIResultTypes t = (: []) <$> marshalToFFIValueType t
-
-marshalToFFIFunctionType
-  :: (GHC.HasOccName (GHC.IdP p)) => GHC.LHsType p -> Maybe FFIFunctionType
-marshalToFFIFunctionType (GHC.unLoc -> GHC.HsParTy _ t) =
-  marshalToFFIFunctionType t
-marshalToFFIFunctionType (GHC.unLoc -> ty) = case ty of
-  GHC.HsFunTy _ t ts -> do
-    vt <- marshalToFFIValueType t
-    ft <- marshalToFFIFunctionType ts
-    pure ft {ffiParamTypes = vt : ffiParamTypes ft}
-  GHC.HsAppTy _ (GHC.unLoc -> (GHC.HsTyVar _ _ (GHC.occName . GHC.unLoc -> io))) t
-    | io == GHC.occName GHC.ioTyConName ->
-      do
-        r <- marshalToFFIResultTypes t
-        pure $ FFIFunctionType
-          { ffiParamTypes = [],
-            ffiResultTypes = r,
-            ffiInIO = True
-            }
-  _ -> do
-    r <- marshalToFFIResultTypes (GHC.noLoc ty)
-    pure
-      FFIFunctionType
-        { ffiParamTypes = [],
-          ffiResultTypes = r,
-          ffiInIO = False
-          }
 
 recoverWasmImportValueType :: FFIValueType -> ValueType
 recoverWasmImportValueType vt = case vt of
@@ -214,120 +61,16 @@ recoverWasmWrapperFunctionType ffi_safety FFIFunctionType {..}
     param_types = map recoverWasmWrapperValueType ffiParamTypes
     ret_types = map recoverWasmWrapperValueType ffiResultTypes
 
-processFFI :: Data a => a -> State FFIMarshalState a
-processFFI = w
-  where
-    w :: Data a => a -> State FFIMarshalState a
-    w t =
-      case eqTypeRep (typeOf t) (typeRep :: TypeRep (GHC.ForeignDecl GHC.GhcPs)) of
-        Just HRefl -> case t of
-          GHC.ForeignExport {GHC.fd_fe = GHC.CExport (GHC.unLoc -> GHC.CExportStatic src_txt lbl GHC.JavaScriptCallConv) loc_src, ..} ->
-            do
-              old_state@FFIMarshalState {..} <- get
-              let Just ffi_ftype =
-                    marshalToFFIFunctionType $ GHC.hsImplicitBody fd_sig_ty
-              put
-                old_state
-                  { ffiExportDecls = M.insert
-                                       AsteriusEntitySymbol
-                                         { entityName = SBS.toShort
-                                             $ GHC.fastStringToByteString lbl
-                                           }
-                                       FFIExportDecl
-                                         { ffiFunctionType = ffi_ftype,
-                                           ffiExportClosure = ""
-                                           }
-                                       ffiExportDecls
-                    }
-              pure
-                t
-                  { GHC.fd_fe = GHC.CExport
-                                  (GHC.noLoc $ GHC.CExportStatic src_txt lbl GHC.CCallConv)
-                                  loc_src
-                    }
-          _ -> pure t
-        _ -> gmapM w t
-
-collectFFISrc
-  :: Monad m
-  => GHC.HsParsedModule
-  -> FFIMarshalState
-  -> m (GHC.HsParsedModule, FFIMarshalState)
-collectFFISrc m ffi_state = pure (m {GHC.hpm_module = new_m}, st)
-  where
-    (new_m, st) = runState (processFFI (GHC.hpm_module m)) ffi_state
-
-addFFIProcessor
-  :: Compiler
-  -> IO (Compiler, AsteriusModuleSymbol -> Prelude.IO AsteriusModule)
-addFFIProcessor c = do
-  ffi_states_ref <- newIORef mempty
-  pure
-    ( c
-        { patchParsed = \mod_summary parsed_mod -> do
-            patched_mod <-
-              liftIO $ atomicModifyIORef' ffi_states_ref $ \ffi_states ->
-                let mod_sym = marshalToModuleSymbol $ GHC.ms_mod mod_summary
-                    (patched_mod, ffi_state) =
-                      runIdentity $ collectFFISrc parsed_mod mempty
-                 in (M.insert mod_sym ffi_state ffi_states, patched_mod)
-            patchParsed c mod_summary patched_mod,
-          patchTypechecked = \mod_summary tc_mod -> do
-            dflags <- GHC.getDynFlags
-            let mod_sym = marshalToModuleSymbol $ GHC.ms_mod mod_summary
-                f :: Data a => a -> Endo (M.Map AsteriusEntitySymbol FFIExportDecl)
-                f t =
-                  case eqTypeRep (typeOf t)
-                         (typeRep :: TypeRep (GHC.ForeignDecl GHC.GhcTc)) of
-                    Just HRefl -> case t of
-                      GHC.ForeignExport {..} ->
-                        Endo
-                          $ M.adjust
-                              ( \ffi_decl ->
-                                  ffi_decl {ffiExportClosure = export_closure}
-                                )
-                              export_func_name
-                        where
-                          GHC.CExport loc_spec _ = fd_fe
-                          GHC.CExportStatic _ lbl _ = GHC.unLoc loc_spec
-                          export_func_name = AsteriusEntitySymbol
-                            { entityName = SBS.toShort
-                                $ GHC.fastStringToByteString lbl
-                              }
-                          export_closure =
-                            fromString
-                              $ asmPpr dflags (GHC.unLoc fd_name)
-                              <> "_closure"
-                      _ -> mempty
-                    _ -> go
-                  where
-                    go = mconcat $ gmapQ f t
-            liftIO $ atomicModifyIORef' ffi_states_ref $ \ffi_states ->
-              ( M.adjust
-                  ( \ffi_state ->
-                      ffi_state
-                        { ffiExportDecls = appEndo (f $ GHC.tcg_fords tc_mod)
-                                             (ffiExportDecls ffi_state)
-                          }
-                    )
-                  mod_sym
-                  ffi_states,
-                tc_mod
-                )
-          },
-      \mod_sym -> do
-        ffi_state <-
-          atomicModifyIORef' ffi_states_ref
-            $ \ffi_states -> (M.delete mod_sym ffi_states, ffi_states ! mod_sym)
-        ffi_import_state <-
-          atomicModifyIORef' globalFFIHookState $ \ffi_hook_state ->
-            ( ffi_hook_state
-                { ffiHookState = M.delete mod_sym $ ffiHookState ffi_hook_state
-                  },
-              M.findWithDefault mempty mod_sym (ffiHookState ffi_hook_state)
-              )
-        pure $ generateFFIWrapperModule $ ffi_import_state <> ffi_state
-      )
+getFFIModule :: AsteriusModuleSymbol -> Prelude.IO AsteriusModule
+getFFIModule mod_sym = do
+  ffi_import_state <-
+    atomicModifyIORef' globalFFIHookState $ \ffi_hook_state ->
+      ( ffi_hook_state
+          { ffiHookState = M.delete mod_sym $ ffiHookState ffi_hook_state
+            },
+        M.findWithDefault mempty mod_sym (ffiHookState ffi_hook_state)
+        )
+  pure $ generateFFIWrapperModule ffi_import_state
 
 generateImplicitCastExpression
   :: Bool -> [ValueType] -> [ValueType] -> Expression -> Expression


### PR DESCRIPTION
Following #245, this PR migrates `foreign export javascript` handling to typechecker/desugarer.