### PR TITLE
Gen2 JSFFI part III

### DIFF
--- a/asterius/src/Asterius/Passes/SafeCCall.hs
+++ b/asterius/src/Asterius/Passes/SafeCCall.hs
@@ -4,7 +4,8 @@
 
 module Asterius.Passes.SafeCCall
   ( splitFunctionMap
-  ) where
+    )
+where
 
 import Asterius.Internals
 import Asterius.Types
@@ -16,45 +17,47 @@ import qualified Data.IntMap.Strict as IM
 import qualified Data.Map.Strict as M
 import Language.Haskell.GHC.Toolkit.Constants
 
-data SafeCCall =
-  SafeCCall AsteriusEntitySymbol
-            FFIImportDecl
-            Expression
+data SafeCCall
+  = SafeCCall
+      AsteriusEntitySymbol
+      FFIImportDecl
+      Expression
 
-data BlockChunk =
-  BlockChunk [Expression]
-             SafeCCall
+data BlockChunk
+  = BlockChunk
+      [Expression]
+      SafeCCall
 
-data BlockChunks =
-  BlockChunks [BlockChunk]
-              [Expression]
+data BlockChunks
+  = BlockChunks
+      [BlockChunk]
+      [Expression]
 
-data BSState = BSState
-  { bsId :: Int
-  , bsMap :: M.Map SBS.ShortByteString RelooperBlock
-  , bsHookMap :: IM.IntMap SBS.ShortByteString
-  , bsPreBlockInstrs :: [Expression]
-  }
+data BSState
+  = BSState
+      { bsId :: Int,
+        bsMap :: M.Map SBS.ShortByteString RelooperBlock,
+        bsHookMap :: IM.IntMap SBS.ShortByteString,
+        bsPreBlockInstrs :: [Expression]
+        }
 
-splitFunctionMap ::
-     FFIMarshalState
+splitFunctionMap
+  :: FFIMarshalState
   -> M.Map AsteriusEntitySymbol Function
   -> M.Map AsteriusEntitySymbol Function
 splitFunctionMap = M.mapWithKey . splitFunction
 
 splitFunction :: FFIMarshalState -> AsteriusEntitySymbol -> Function -> Function
-splitFunction ffi_state sym Function {..} =
-  Function
-    { functionType = functionType
-    , varTypes = varTypes
-    , body =
-        case body of
-          CFG g -> CFG $ splitAllBlocks ffi_state sym varTypes g
-          _ -> body
+splitFunction ffi_state sym Function {..} = Function
+  { functionType = functionType,
+    varTypes = varTypes,
+    body = case body of
+      CFG g -> CFG $ splitAllBlocks ffi_state sym varTypes g
+      _ -> body
     }
 
-splitAllBlocks ::
-     FFIMarshalState
+splitAllBlocks
+  :: FFIMarshalState
   -> AsteriusEntitySymbol
   -> [ValueType]
   -> RelooperRun
@@ -62,53 +65,54 @@ splitAllBlocks ::
 splitAllBlocks ffi_state sym vts r@RelooperRun {..}
   | has_safe_ccall =
     r
-      { entry = entry_hook_k
-      , blockMap = M.insert entry_hook_k entry_hook_block $ bsMap final_state
-      }
+      { entry = entry_hook_k,
+        blockMap = M.insert entry_hook_k entry_hook_block $ bsMap final_state
+        }
   | otherwise = r
   where
     init_state = initBSState entry
     final_state =
       execState
-        (M.foldlWithKey'
-           (\m k b -> splitSingleBlock ffi_state save_instrs k b *> m)
-           (pure ())
-           blockMap)
+        ( M.foldlWithKey'
+            (\m k b -> splitSingleBlock ffi_state save_instrs k b *> m)
+            (pure ())
+            blockMap
+          )
         init_state
     has_safe_ccall = M.size (bsMap final_state) /= M.size blockMap
     (entry_hook_k, entry_hook_block) = entryHookBlock final_state load_instrs
     (save_instrs, load_instrs) = genSaveLoad sym vts
 
 initBSState :: SBS.ShortByteString -> BSState
-initBSState entry_k =
-  BSState
-    { bsId = 1
-    , bsMap = M.empty
-    , bsHookMap = IM.singleton 0 entry_k
-    , bsPreBlockInstrs = []
+initBSState entry_k = BSState
+  { bsId = 1,
+    bsMap = M.empty,
+    bsHookMap = IM.singleton 0 entry_k,
+    bsPreBlockInstrs = []
     }
 
-entryHookBlock ::
-     BSState -> [Expression] -> (SBS.ShortByteString, RelooperBlock)
+entryHookBlock
+  :: BSState -> [Expression] -> (SBS.ShortByteString, RelooperBlock)
 entryHookBlock BSState {..} load_instrs =
-  ( "ci"
-  , RelooperBlock
-      { addBlock =
-          AddBlockWithSwitch
-            { code = concatExpressions load_instrs
-            , condition = GetLocal {index = 2, valueType = I32}
-            }
-      , addBranches =
-          [ AddBranchForSwitch {to = k, indexes = [fromIntegral i]}
-          | (i, k) <- IM.toList bsHookMap
-          ] <>
-          [ AddBranch
-              {to = "__asterius_unreachable", addBranchCondition = Nothing}
-          ]
-      })
+  ( "ci",
+    RelooperBlock
+      { addBlock = AddBlockWithSwitch
+          { code = concatExpressions load_instrs,
+            condition = GetLocal {index = 2, valueType = I32}
+            },
+        addBranches = [ AddBranchForSwitch {to = k, indexes = [fromIntegral i]}
+                        | (i, k) <- IM.toList bsHookMap
+                        ]
+          <> [ AddBranch
+                 { to = "__asterius_unreachable",
+                   addBranchCondition = Nothing
+                   }
+               ]
+        }
+    )
 
-splitSingleBlock ::
-     FFIMarshalState
+splitSingleBlock
+  :: FFIMarshalState
   -> [Expression]
   -> SBS.ShortByteString
   -> RelooperBlock
@@ -119,27 +123,26 @@ splitSingleBlock ffi_state save_instrs base_k base_block@RelooperBlock {..} =
     BlockChunks chunks rest_instrs -> do
       for_ (zip chunks (True : repeat False)) produce_block
       modify' w
-      where w s =
-              s
-                { bsId = next_id
-                , bsMap = M.insert this_k this_block $ bsMap s
-                , bsPreBlockInstrs = []
+      where
+        w s =
+          s
+            { bsId = next_id,
+              bsMap = M.insert this_k this_block $ bsMap s,
+              bsPreBlockInstrs = []
+              }
+          where
+            this_id = bsId s
+            next_id = succ this_id
+            this_k = "c" <> showSBS this_id
+            this_preblock_instrs = bsPreBlockInstrs s
+            this_block = RelooperBlock
+              { addBlock = addBlock
+                  { code = concatExpressions
+                      $ this_preblock_instrs
+                      <> rest_instrs
+                    },
+                addBranches = addBranches
                 }
-              where
-                this_id = bsId s
-                next_id = succ this_id
-                this_k = "c" <> showSBS this_id
-                this_preblock_instrs = bsPreBlockInstrs s
-                this_block =
-                  RelooperBlock
-                    { addBlock =
-                        addBlock
-                          { code =
-                              concatExpressions $
-                              this_preblock_instrs <> rest_instrs
-                          }
-                    , addBranches = addBranches
-                    }
   where
     insert_block :: SBS.ShortByteString -> RelooperBlock -> State BSState ()
     insert_block new_k new_block =
@@ -150,11 +153,11 @@ splitSingleBlock ffi_state save_instrs base_k base_block@RelooperBlock {..} =
       where
         w s =
           s
-            { bsId = next_id
-            , bsMap = M.insert this_k this_block $ bsMap s
-            , bsHookMap = IM.insert next_id next_k $ bsHookMap s
-            , bsPreBlockInstrs = next_preblock_instrs
-            }
+            { bsId = next_id,
+              bsMap = M.insert this_k this_block $ bsMap s,
+              bsHookMap = IM.insert next_id next_k $ bsHookMap s,
+              bsPreBlockInstrs = next_preblock_instrs
+              }
           where
             this_id = bsId s
             next_id
@@ -167,188 +170,181 @@ splitSingleBlock ffi_state save_instrs base_k base_block@RelooperBlock {..} =
             this_preblock_instrs = bsPreBlockInstrs s
             save_target_instr =
               SetLocal {index = 2, value = ConstI32 $ fromIntegral next_id}
-            reset_instr =
-              CallImport
-                { target' = "__asterius_resetPromise"
-                , operands = []
-                , callImportReturnTypes = []
+            reset_instr = CallImport
+              { target' = "__asterius_resetPromise",
+                operands = [],
+                callImportReturnTypes = []
                 }
-            (ccall_instr, next_preblock_instrs) =
-              case orig_instr of
-                Call {} -> (orig_instr {callReturnTypes = []}, [reset_instr])
-                SetLocal {value = c@Call {}} ->
-                  ( c {callReturnTypes = []}
-                  , [ orig_instr
-                        { value =
-                            Load
-                              { signed = False
-                              , bytes =
-                                  case ffiResultTypes of
-                                    [FFI_VAL {..}] ->
-                                      case ffiWasmValueType of
-                                        I32 -> 4
-                                        F32 -> 4
-                                        _ -> 8
-                                    [FFI_JSVAL] -> 8
-                                    _ ->
-                                      error
-                                        "Asterius.SafeCCall.splitSingleBlock: invalid ffi type"
-                              , offset = 0
-                              , valueType =
-                                  case ffiResultTypes of
-                                    [FFI_VAL {..}] -> ffiWasmValueType
-                                    [FFI_JSVAL] -> I64
-                                    _ ->
-                                      error
-                                        "Asterius.SafeCCall.splitSingleBlock: invalid ffi type"
-                              , ptr =
-                                  Unary
-                                    { unaryOp = WrapInt64
-                                    , operand0 =
-                                        Symbol
-                                          { unresolvedSymbol = "__asterius_ret"
-                                          , symbolOffset = 0
-                                          }
+            (ccall_instr, next_preblock_instrs) = case orig_instr of
+              Call {} -> (orig_instr {callReturnTypes = []}, [reset_instr])
+              SetLocal {value = c@Call {}} ->
+                ( c {callReturnTypes = []},
+                  [ orig_instr
+                      { value = Load
+                          { signed = False,
+                            bytes = case ffiResultTypes of
+                              [FFI_VAL {..}] -> case ffiWasmValueType of
+                                I32 -> 4
+                                F32 -> 4
+                                _ -> 8
+                              [FFI_JSVAL] -> 8
+                              _ ->
+                                error
+                                  "Asterius.SafeCCall.splitSingleBlock: invalid ffi type",
+                            offset = 0,
+                            valueType = case ffiResultTypes of
+                              [FFI_VAL {..}] -> ffiWasmValueType
+                              [FFI_JSVAL] -> I64
+                              _ ->
+                                error
+                                  "Asterius.SafeCCall.splitSingleBlock: invalid ffi type",
+                            ptr = Unary
+                              { unaryOp = WrapInt64,
+                                operand0 = Symbol
+                                  { unresolvedSymbol = "__asterius_ret",
+                                    symbolOffset = 0
                                     }
-                              }
-                        }
-                    , reset_instr
-                    ])
-                _ ->
-                  error
-                    "Asterius.Passes.SafeCCall.splitSingleBlock: invalid ccall instruction"
-            this_block =
-              RelooperBlock
-                { addBlock =
-                    AddBlock
-                      { code =
-                          concatExpressions $
-                          this_preblock_instrs <> block_instrs <>
-                          (ccall_instr : save_target_instr : save_instrs)
-                      }
-                , addBranches = []
+                                }
+                            }
+                        },
+                    reset_instr
+                    ]
+                  )
+              _ ->
+                error
+                  "Asterius.Passes.SafeCCall.splitSingleBlock: invalid ccall instruction"
+            this_block = RelooperBlock
+              { addBlock = AddBlock
+                  { code = concatExpressions
+                      $ this_preblock_instrs
+                      <> block_instrs
+                      <> ( ccall_instr
+                             : save_target_instr
+                             : save_instrs
+                           )
+                    },
+                addBranches = []
                 }
 
 splitBlockBody :: FFIMarshalState -> Expression -> BlockChunks
 splitBlockBody FFIMarshalState {..} instrs = foldr' w (BlockChunks [] []) es
   where
     get_safe t =
-      case AsteriusEntitySymbol . SBS.toShort <$>
-           BS.stripSuffix "_wrapper" (SBS.fromShort (entityName t)) of
+      case AsteriusEntitySymbol . SBS.toShort <$> BS.stripSuffix "_wrapper" bs_t of
         Just k
-          | ffiSafety imp_decl /= FFIUnsafe -> Just (k, imp_decl)
-          where imp_decl = ffiImportDecls ! k
+          | "__asterius_jsffi_async_" `BS.isPrefixOf` bs_t ->
+            Just
+              (k, imp_decl)
+          where
+            imp_decl = ffiImportDecls ! k
         _ -> Nothing
-    add_regular instr (BlockChunks (BlockChunk chunk_instrs ccall:cs) tail_instrs) =
+      where
+        bs_t = SBS.fromShort (entityName t)
+    add_regular instr (BlockChunks (BlockChunk chunk_instrs ccall : cs) tail_instrs) =
       BlockChunks (BlockChunk (instr : chunk_instrs) ccall : cs) tail_instrs
     add_regular instr (BlockChunks [] tail_instrs) =
       BlockChunks [] (instr : tail_instrs)
     add_ccall k imp_decl instr (BlockChunks cs tail_instrs) =
       BlockChunks (BlockChunk [] (SafeCCall k imp_decl instr) : cs) tail_instrs
-    w instr@Call {..} cs =
-      case get_safe target of
-        Just (k, imp_decl) -> add_ccall k imp_decl instr cs
-        _ -> add_regular instr cs
-    w orig_instr@SetLocal {value = Call {..}} cs =
-      case get_safe target of
-        Just (k, imp_decl) -> add_ccall k imp_decl orig_instr cs
-        _ -> add_regular orig_instr cs
+    w instr@Call {..} cs = case get_safe target of
+      Just (k, imp_decl) -> add_ccall k imp_decl instr cs
+      _ -> add_regular instr cs
+    w orig_instr@SetLocal {value = Call {..}} cs = case get_safe target of
+      Just (k, imp_decl) -> add_ccall k imp_decl orig_instr cs
+      _ -> add_regular orig_instr cs
     w instr cs = add_regular instr cs
-    es =
-      case instrs of
-        Block {..}
-          | SBS.null name && null blockReturnTypes -> bodys
-          | otherwise ->
-            error "Asterius.Passes.SafeCCall.splitBlockBody: invalid block"
-        Nop -> []
-        _ -> [instrs]
+    es = case instrs of
+      Block {..}
+        | SBS.null name && null blockReturnTypes -> bodys
+        | otherwise ->
+          error
+            "Asterius.Passes.SafeCCall.splitBlockBody: invalid block"
+      Nop -> []
+      _ -> [instrs]
 
-genSaveLoad ::
-     AsteriusEntitySymbol -> [ValueType] -> ([Expression], [Expression])
+genSaveLoad
+  :: AsteriusEntitySymbol -> [ValueType] -> ([Expression], [Expression])
 genSaveLoad sym vts
   | length vts > 128 =
-    error "Asterius.Passes.SafeCCall.genSaveLoad: too many local regs!"
+    error
+      "Asterius.Passes.SafeCCall.genSaveLoad: too many local regs!"
   | otherwise = (save_instrs, load_instrs)
   where
-    I32:I32:ctx_regs@(I32:_) = vts
+    I32 : I32 : ctx_regs@(I32 : _) = vts
     p_ctx_regs = zip [2 ..] ctx_regs
     pos i = (i - 2) * 8
-    bs vt =
-      case vt of
-        I32 -> 4
-        F32 -> 4
-        _ -> 8
+    bs vt = case vt of
+      I32 -> 4
+      F32 -> 4
+      _ -> 8
     save_instrs =
       [ Store
-        { bytes = bs vt
-        , offset = pos i
-        , ptr =
-            Unary
-              { unaryOp = WrapInt64
-              , operand0 =
-                  Symbol
-                    {unresolvedSymbol = "__asterius_regs", symbolOffset = 0}
-              }
-        , value = GetLocal {index = i, valueType = vt}
-        , valueType = vt
-        }
-      | (i, vt) <- p_ctx_regs
-      ] <>
-      [ Store
-          { bytes = 8
-          , offset = 0
-          , ptr =
-              Unary
-                { unaryOp = WrapInt64
-                , operand0 =
-                    Symbol
-                      {unresolvedSymbol = "__asterius_func", symbolOffset = 0}
-                }
-          , value = Symbol {unresolvedSymbol = sym, symbolOffset = 0}
-          , valueType = I64
-          }
-      , Store
-          { bytes = 8
-          , offset =
-              fromIntegral $ offset_Capability_r + offset_StgRegTable_rRet
-          , ptr =
-              Unary
-                { unaryOp = WrapInt64
-                , operand0 =
-                    Symbol
-                      {unresolvedSymbol = "MainCapability", symbolOffset = 0}
-                }
-          , value = ConstI64 $ fromIntegral ret_ThreadBlocked
-          , valueType = I64
-          }
-      , ReturnCall {returnCallTarget64 = "StgReturn"}
-      ]
+          { bytes = bs vt,
+            offset = pos i,
+            ptr = Unary
+              { unaryOp = WrapInt64,
+                operand0 = Symbol
+                  { unresolvedSymbol = "__asterius_regs",
+                    symbolOffset = 0
+                    }
+                },
+            value = GetLocal {index = i, valueType = vt},
+            valueType = vt
+            }
+        | (i, vt) <- p_ctx_regs
+        ]
+        <> [ Store
+               { bytes = 8,
+                 offset = 0,
+                 ptr = Unary
+                   { unaryOp = WrapInt64,
+                     operand0 = Symbol
+                       { unresolvedSymbol = "__asterius_func",
+                         symbolOffset = 0
+                         }
+                     },
+                 value = Symbol {unresolvedSymbol = sym, symbolOffset = 0},
+                 valueType = I64
+                 },
+             Store
+               { bytes = 8,
+                 offset = fromIntegral
+                   $ offset_Capability_r
+                   + offset_StgRegTable_rRet,
+                 ptr = Unary
+                   { unaryOp = WrapInt64,
+                     operand0 = Symbol
+                       { unresolvedSymbol = "MainCapability",
+                         symbolOffset = 0
+                         }
+                     },
+                 value = ConstI64 $ fromIntegral ret_ThreadBlocked,
+                 valueType = I64
+                 },
+             ReturnCall {returnCallTarget64 = "StgReturn"}
+             ]
     load_instrs =
       [ SetLocal
-        { index = i
-        , value =
-            Load
-              { signed = False
-              , bytes = bs vt
-              , offset = pos i
-              , valueType = vt
-              , ptr =
-                  Unary
-                    { unaryOp = WrapInt64
-                    , operand0 =
-                        Symbol
-                          { unresolvedSymbol = "__asterius_regs"
-                          , symbolOffset = 0
-                          }
+          { index = i,
+            value = Load
+              { signed = False,
+                bytes = bs vt,
+                offset = pos i,
+                valueType = vt,
+                ptr = Unary
+                  { unaryOp = WrapInt64,
+                    operand0 = Symbol
+                      { unresolvedSymbol = "__asterius_regs",
+                        symbolOffset = 0
+                        }
                     }
-              }
-        }
-      | (i, vt) <- p_ctx_regs
-      ]
+                }
+            }
+        | (i, vt) <- p_ctx_regs
+        ]
 
 concatExpressions :: [Expression] -> Expression
-concatExpressions es =
-  case es of
-    [] -> Nop
-    [e] -> e
-    _ -> Block {name = "", bodys = es, blockReturnTypes = []}
+concatExpressions es = case es of
+  [] -> Nop
+  [e] -> e
+  _ -> Block {name = "", bodys = es, blockReturnTypes = []}

--- a/asterius/src/Asterius/Passes/SafeCCall.hs
+++ b/asterius/src/Asterius/Passes/SafeCCall.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE StrictData #-}
 
 module Asterius.Passes.SafeCCall
-  ( splitFunctionMap
+  ( splitFunction
     )
 where
 
@@ -39,10 +39,6 @@ data BSState
         bsHookMap :: IM.IntMap SBS.ShortByteString,
         bsPreBlockInstrs :: [Expression]
         }
-
-splitFunctionMap
-  :: M.Map AsteriusEntitySymbol Function -> M.Map AsteriusEntitySymbol Function
-splitFunctionMap = M.mapWithKey splitFunction
 
 splitFunction :: AsteriusEntitySymbol -> Function -> Function
 splitFunction sym Function {..} = Function

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -6,10 +6,11 @@
 {-# LANGUAGE StrictData #-}
 
 module Asterius.Resolve
-  ( unresolvedGlobalRegType
-  , LinkReport(..)
-  , linkStart
-  ) where
+  ( unresolvedGlobalRegType,
+    LinkReport (..),
+    linkStart
+    )
+where
 
 import Asterius.Builtins
 import Asterius.Internals.MagicNumber
@@ -22,65 +23,75 @@ import Asterius.Types
 import Data.Binary
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Short as SBS
-import Data.Data (Data, gmapQl)
+import Data.Data
+  ( Data,
+    gmapQl
+    )
 import qualified Data.Map.Lazy as LM
 import qualified Data.Set as S
 import Data.String
 import Foreign
 import GHC.Generics
 import Language.Haskell.GHC.Toolkit.Constants
-import Prelude hiding (IO)
-import Type.Reflection ((:~~:)(..), TypeRep, eqTypeRep, typeOf, typeRep)
+import Type.Reflection
+  ( (:~~:) (..),
+    TypeRep,
+    eqTypeRep,
+    typeOf,
+    typeRep
+    )
 import Unsafe.Coerce
+import Prelude hiding (IO)
 
 unresolvedGlobalRegType :: UnresolvedGlobalReg -> ValueType
-unresolvedGlobalRegType gr =
-  case gr of
-    FloatReg _ -> F32
-    DoubleReg _ -> F64
-    _ -> I64
+unresolvedGlobalRegType gr = case gr of
+  FloatReg _ -> F32
+  DoubleReg _ -> F64
+  _ -> I64
 
-collectAsteriusEntitySymbols ::
-     Data a => a -> S.Set AsteriusEntitySymbol -> S.Set AsteriusEntitySymbol
+collectAsteriusEntitySymbols
+  :: Data a => a -> S.Set AsteriusEntitySymbol -> S.Set AsteriusEntitySymbol
 collectAsteriusEntitySymbols t acc =
   case eqTypeRep (typeOf t) (typeRep :: TypeRep AsteriusEntitySymbol) of
     Just HRefl -> S.insert t acc
     _ -> gmapQl (.) id collectAsteriusEntitySymbols t acc
 
-data LinkReport = LinkReport
-  { staticsSymbolMap, functionSymbolMap :: LM.Map AsteriusEntitySymbol Int64
-  , infoTableSet :: [Int64]
-  , tableSlots, staticMBlocks :: Int
-  , bundledFFIMarshalState :: FFIMarshalState
-  } deriving (Generic, Show)
+data LinkReport
+  = LinkReport
+      { staticsSymbolMap, functionSymbolMap :: LM.Map AsteriusEntitySymbol Int64,
+        infoTableSet :: [Int64],
+        tableSlots, staticMBlocks :: Int,
+        bundledFFIMarshalState :: FFIMarshalState
+        }
+  deriving (Generic, Show)
 
 instance Binary LinkReport
 
 instance Semigroup LinkReport where
-  r0 <> r1 =
-    LinkReport
-      { staticsSymbolMap = staticsSymbolMap r0 <> staticsSymbolMap r1
-      , functionSymbolMap = functionSymbolMap r0 <> functionSymbolMap r1
-      , infoTableSet = infoTableSet r0 <> infoTableSet r1
-      , tableSlots = 0
-      , staticMBlocks = 0
-      , bundledFFIMarshalState =
-          bundledFFIMarshalState r0 <> bundledFFIMarshalState r1
+
+  r0 <> r1 = LinkReport
+    { staticsSymbolMap = staticsSymbolMap r0 <> staticsSymbolMap r1,
+      functionSymbolMap = functionSymbolMap r0 <> functionSymbolMap r1,
+      infoTableSet = infoTableSet r0 <> infoTableSet r1,
+      tableSlots = 0,
+      staticMBlocks = 0,
+      bundledFFIMarshalState = bundledFFIMarshalState r0
+        <> bundledFFIMarshalState r1
       }
 
 instance Monoid LinkReport where
-  mempty =
-    LinkReport
-      { staticsSymbolMap = mempty
-      , functionSymbolMap = mempty
-      , infoTableSet = mempty
-      , tableSlots = 0
-      , staticMBlocks = 0
-      , bundledFFIMarshalState = mempty
+
+  mempty = LinkReport
+    { staticsSymbolMap = mempty,
+      functionSymbolMap = mempty,
+      infoTableSet = mempty,
+      tableSlots = 0,
+      staticMBlocks = 0,
+      bundledFFIMarshalState = mempty
       }
 
-mergeSymbols ::
-     Bool
+mergeSymbols
+  :: Bool
   -> Bool
   -> Bool
   -> AsteriusModule
@@ -94,19 +105,18 @@ mergeSymbols _ gc_sections verbose_err store_mod root_syms export_funcs
     ffi_all = ffiMarshalState store_mod
     ffi_this =
       ffi_all
-        { ffiImportDecls =
-            flip LM.filterWithKey (ffiImportDecls ffi_all) $ \k _ ->
-              (k <> "_wrapper") `LM.member` functionMap final_m
-        , ffiExportDecls = ffi_exports
-        }
+        { ffiImportDecls = flip LM.filterWithKey (ffiImportDecls ffi_all) $ \k _ ->
+            (k <> "_wrapper") `LM.member` functionMap final_m,
+          ffiExportDecls = ffi_exports
+          }
     ffi_exports
       | not gc_sections = ffiExportDecls (ffiMarshalState store_mod)
       | otherwise =
-        ffiExportDecls (ffiMarshalState store_mod) `LM.restrictKeys`
-        S.fromList export_funcs
+        ffiExportDecls (ffiMarshalState store_mod)
+          `LM.restrictKeys` S.fromList export_funcs
     root_syms' =
-      S.fromList [ffiExportClosure | FFIExportDecl {..} <- LM.elems ffi_exports] <>
-      root_syms
+      S.fromList [ffiExportClosure | FFIExportDecl {..} <- LM.elems ffi_exports]
+        <> root_syms
     (_, _, final_m) = go (root_syms', S.empty, mempty)
     go i@(i_staging_syms, _, _)
       | S.null i_staging_syms = i
@@ -116,72 +126,72 @@ mergeSymbols _ gc_sections verbose_err store_mod root_syms export_funcs
         o_acc_syms = i_staging_syms <> i_acc_syms
         (i_child_syms, o_m) =
           S.foldr'
-            (\i_staging_sym (i_child_syms_acc, o_m_acc) ->
-               case LM.lookup i_staging_sym (staticsMap store_mod) of
-                 Just ss ->
-                   ( collectAsteriusEntitySymbols ss i_child_syms_acc
-                   , o_m_acc
-                       { staticsMap =
-                           LM.insert i_staging_sym ss (staticsMap o_m_acc)
-                       })
-                 _ ->
-                   case LM.lookup i_staging_sym (functionMap store_mod) of
-                     Just func ->
-                       ( collectAsteriusEntitySymbols func i_child_syms_acc
-                       , o_m_acc
-                           { functionMap =
-                               LM.insert
-                                 i_staging_sym
-                                 func
-                                 (functionMap o_m_acc)
-                           })
-                     _
-                       | verbose_err ->
-                         ( i_child_syms_acc
-                         , o_m_acc
-                             { staticsMap =
-                                 LM.insert
-                                   ("__asterius_barf_" <> i_staging_sym)
-                                   AsteriusStatics
-                                     { staticsType = ConstBytes
-                                     , asteriusStatics =
-                                         [ Serialized $
-                                           entityName i_staging_sym <>
-                                           (case LM.lookup
-                                                   i_staging_sym
-                                                   (staticsErrorMap store_mod) of
-                                              Just err ->
-                                                fromString (": " <> show err)
-                                              _ -> mempty) <>
-                                           "\0"
-                                         ]
-                                     }
-                                   (staticsMap o_m_acc)
-                             })
-                       | otherwise -> (i_child_syms_acc, o_m_acc))
+            ( \i_staging_sym (i_child_syms_acc, o_m_acc) ->
+                case LM.lookup i_staging_sym (staticsMap store_mod) of
+                  Just ss ->
+                    ( collectAsteriusEntitySymbols ss i_child_syms_acc,
+                      o_m_acc
+                        { staticsMap = LM.insert i_staging_sym ss (staticsMap o_m_acc)
+                          }
+                      )
+                  _ -> case LM.lookup i_staging_sym (functionMap store_mod) of
+                    Just func ->
+                      ( collectAsteriusEntitySymbols func i_child_syms_acc,
+                        o_m_acc
+                          { functionMap = LM.insert i_staging_sym
+                                            func
+                                            (functionMap o_m_acc)
+                            }
+                        )
+                    _
+                      | verbose_err ->
+                        ( i_child_syms_acc,
+                          o_m_acc
+                            { staticsMap = LM.insert
+                                             ("__asterius_barf_" <> i_staging_sym)
+                                             AsteriusStatics
+                                               { staticsType = ConstBytes,
+                                                 asteriusStatics = [ Serialized
+                                                                       $ entityName i_staging_sym
+                                                                       <> ( case LM.lookup i_staging_sym
+                                                                                   (staticsErrorMap store_mod) of
+                                                                              Just err -> fromString (": " <> show err)
+                                                                              _ -> mempty
+                                                                            )
+                                                                       <> "\0"
+                                                                     ]
+                                                 }
+                                             (staticsMap o_m_acc)
+                              }
+                          )
+                      | otherwise ->
+                        (i_child_syms_acc, o_m_acc)
+              )
             (S.empty, i_m)
             i_staging_syms
         o_staging_syms = i_child_syms `S.difference` o_acc_syms
 
-makeInfoTableSet ::
-     AsteriusModule -> LM.Map AsteriusEntitySymbol Int64 -> [Int64]
+makeInfoTableSet
+  :: AsteriusModule -> LM.Map AsteriusEntitySymbol Int64 -> [Int64]
 makeInfoTableSet AsteriusModule {..} sym_map =
-  LM.elems $
-  LM.restrictKeys sym_map $
-  LM.keysSet $ LM.filter ((== InfoTable) . staticsType) staticsMap
+  LM.elems $ LM.restrictKeys sym_map $ LM.keysSet
+    $ LM.filter
+        ((== InfoTable) . staticsType)
+        staticsMap
 
-resolveAsteriusModule ::
-     Bool
+resolveAsteriusModule
+  :: Bool
   -> Bool
   -> FFIMarshalState
   -> AsteriusModule
   -> Int64
   -> Int64
-  -> ( Module
-     , LM.Map AsteriusEntitySymbol Int64
-     , LM.Map AsteriusEntitySymbol Int64
-     , Int
-     , Int)
+  -> ( Module,
+       LM.Map AsteriusEntitySymbol Int64,
+       LM.Map AsteriusEntitySymbol Int64,
+       Int,
+       Int
+       )
 resolveAsteriusModule debug _ bundled_ffi_state m_globals_resolved func_start_addr data_start_addr =
   (new_mod, ss_sym_map, func_sym_map, table_slots, initial_mblocks)
   where
@@ -199,27 +209,28 @@ resolveAsteriusModule debug _ bundled_ffi_state m_globals_resolved func_start_ad
       makeMemory m_globals_resolved all_sym_map last_data_addr
     initial_mblocks =
       fromIntegral initial_pages `quot` (mblock_size `quot` wasmPageSize)
-    new_mod =
-      Module
-        { functionMap' = new_function_map
-        , functionImports = func_imports
-        , functionExports = rtsFunctionExports debug
-        , functionTable = func_table
-        , tableImport =
-            TableImport
-              {externalModuleName = "WasmTable", externalBaseName = "table"}
-        , tableExport = TableExport {externalName = "table"}
-        , tableSlots = table_slots
-        , memorySegments = segs
-        , memoryImport =
-            MemoryImport
-              {externalModuleName = "WasmMemory", externalBaseName = "memory"}
-        , memoryExport = MemoryExport {externalName = "memory"}
-        , memoryMBlocks = initial_mblocks
+    new_mod = Module
+      { functionMap' = new_function_map,
+        functionImports = func_imports,
+        functionExports = rtsFunctionExports debug,
+        functionTable = func_table,
+        tableImport = TableImport
+          { externalModuleName = "WasmTable",
+            externalBaseName = "table"
+            },
+        tableExport = TableExport {externalName = "table"},
+        tableSlots = table_slots,
+        memorySegments = segs,
+        memoryImport = MemoryImport
+          { externalModuleName = "WasmMemory",
+            externalBaseName = "memory"
+            },
+        memoryExport = MemoryExport {externalName = "memory"},
+        memoryMBlocks = initial_mblocks
         }
 
-linkStart ::
-     Bool
+linkStart
+  :: Bool
   -> Bool
   -> Bool
   -> Bool
@@ -228,24 +239,21 @@ linkStart ::
   -> [AsteriusEntitySymbol]
   -> (AsteriusModule, Module, LinkReport)
 linkStart debug gc_sections binaryen verbose_err store root_syms export_funcs =
-  ( merged_m
-  , result_m
-  , report
-      { staticsSymbolMap = ss_sym_map
-      , functionSymbolMap = func_sym_map
-      , infoTableSet = makeInfoTableSet merged_m ss_sym_map
-      , Asterius.Resolve.tableSlots = tbl_slots
-      , staticMBlocks = static_mbs
-      })
+  ( merged_m,
+    result_m,
+    report
+      { staticsSymbolMap = ss_sym_map,
+        functionSymbolMap = func_sym_map,
+        infoTableSet = makeInfoTableSet merged_m ss_sym_map,
+        Asterius.Resolve.tableSlots = tbl_slots,
+        staticMBlocks = static_mbs
+        }
+    )
   where
     (merged_m0, report) =
       mergeSymbols debug gc_sections verbose_err store root_syms export_funcs
     merged_m1 =
-      merged_m0
-        { functionMap =
-            splitFunctionMap (bundledFFIMarshalState report) $
-            functionMap merged_m0
-        }
+      merged_m0 {functionMap = splitFunctionMap $ functionMap merged_m0}
     merged_m2
       | debug = addMemoryTrap merged_m1
       | otherwise = merged_m1
@@ -253,17 +261,17 @@ linkStart debug gc_sections binaryen verbose_err store root_syms export_funcs =
       | verbose_err = merged_m2
       | otherwise =
         merged_m2
-          { staticsMap =
-              LM.filterWithKey
-                (\sym _ ->
-                   not
-                     ("__asterius_barf_" `BS.isPrefixOf`
-                      SBS.fromShort (entityName sym))) $
-              staticsMap merged_m2
-          }
+          { staticsMap = LM.filterWithKey
+                           ( \sym _ ->
+                               not
+                                 ( "__asterius_barf_"
+                                     `BS.isPrefixOf` SBS.fromShort (entityName sym)
+                                   )
+                             )
+              $ staticsMap merged_m2
+            }
     (result_m, ss_sym_map, func_sym_map, tbl_slots, static_mbs) =
-      resolveAsteriusModule
-        debug
+      resolveAsteriusModule debug
         binaryen
         (bundledFFIMarshalState report)
         merged_m

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -18,7 +18,6 @@ import Asterius.JSFFI
 import Asterius.MemoryTrap
 import Asterius.Passes.DataSymbolTable
 import Asterius.Passes.FunctionSymbolTable
-import Asterius.Passes.SafeCCall
 import Asterius.Types
 import Data.Binary
 import qualified Data.ByteString as BS
@@ -252,15 +251,13 @@ linkStart debug gc_sections binaryen verbose_err store root_syms export_funcs =
   where
     (merged_m0, report) =
       mergeSymbols debug gc_sections verbose_err store root_syms export_funcs
-    merged_m1 =
-      merged_m0 {functionMap = splitFunctionMap $ functionMap merged_m0}
-    merged_m2
-      | debug = addMemoryTrap merged_m1
-      | otherwise = merged_m1
+    merged_m1
+      | debug = addMemoryTrap merged_m0
+      | otherwise = merged_m0
     merged_m
-      | verbose_err = merged_m2
+      | verbose_err = merged_m1
       | otherwise =
-        merged_m2
+        merged_m1
           { staticsMap = LM.filterWithKey
                            ( \sym _ ->
                                not
@@ -268,7 +265,7 @@ linkStart debug gc_sections binaryen verbose_err store root_syms export_funcs =
                                      `BS.isPrefixOf` SBS.fromShort (entityName sym)
                                    )
                              )
-              $ staticsMap merged_m2
+              $ staticsMap merged_m1
             }
     (result_m, ss_sym_map, func_sym_map, tbl_slots, static_mbs) =
       resolveAsteriusModule debug


### PR DESCRIPTION
Following #245 #246, this PR moves the link-time rewriting pass `SafeCCall` to compile-time. When processing a call to an async import, it no longer requires the `FFIMarshalState` containing the import's information, thus working around the non-main linking problem related to async imports.

Ideally, there should be no "rewriting" on the wasm level at all. When doing STG -> Cmm we should be smart enough to emit extra basic blocks and handle suspending/resuming logic, but I've run out of recent passion quota for diving deeper into ghc. Let's spare this kind of nice-to-haves to months later.