### PR TITLE
Cleanup some unused code

### DIFF
--- a/asterius/src/Asterius/Boot.hs
+++ b/asterius/src/Asterius/Boot.hs
@@ -4,10 +4,11 @@
 {-# LANGUAGE StrictData #-}
 
 module Asterius.Boot
-  ( BootArgs(..)
-  , defaultBootArgs
-  , boot
-  ) where
+  ( BootArgs (..),
+    defaultBootArgs,
+    boot
+    )
+where
 
 import Asterius.BuildInfo
 import Asterius.Builtins
@@ -22,34 +23,40 @@ import Data.IORef
 import Data.Maybe
 import qualified DynFlags as GHC
 import qualified GHC
-import Language.Haskell.GHC.Toolkit.BuildInfo (bootLibsPath, sandboxGhcLibDir)
+import Language.Haskell.GHC.Toolkit.BuildInfo
+  ( bootLibsPath,
+    sandboxGhcLibDir
+    )
 import Language.Haskell.GHC.Toolkit.Compiler
 import Language.Haskell.GHC.Toolkit.Orphans.Show
-import Language.Haskell.GHC.Toolkit.Run (defaultConfig, ghcFlags, runCmm)
+import Language.Haskell.GHC.Toolkit.Run
+  ( defaultConfig,
+    ghcFlags,
+    runCmm
+    )
 import qualified Module as GHC
-import Prelude hiding (IO)
 import System.Directory
 import System.Environment
 import System.Exit
 import System.FilePath
 import System.IO hiding (IO)
 import System.Process
+import Prelude hiding (IO)
 
-data BootArgs = BootArgs
-  { bootDir :: FilePath
-  , configureOptions, buildOptions, installOptions :: String
-  , builtinsOptions :: BuiltinsOptions
-  }
+data BootArgs
+  = BootArgs
+      { bootDir :: FilePath,
+        configureOptions, buildOptions, installOptions :: String,
+        builtinsOptions :: BuiltinsOptions
+        }
 
 defaultBootArgs :: BootArgs
-defaultBootArgs =
-  BootArgs
-    { bootDir = dataDir </> ".boot"
-    , configureOptions =
-        "--disable-shared --disable-profiling --disable-debug-info --disable-library-for-ghci --disable-split-objs --disable-split-sections --disable-library-stripping -O2 --ghc-option=-v1 --ghc-option=-dsuppress-ticks"
-    , buildOptions = ""
-    , installOptions = ""
-    , builtinsOptions = defaultBuiltinsOptions
+defaultBootArgs = BootArgs
+  { bootDir = dataDir </> ".boot",
+    configureOptions = "--disable-shared --disable-profiling --disable-debug-info --disable-library-for-ghci --disable-split-objs --disable-split-sections --disable-library-stripping -O2 --ghc-option=-v1 --ghc-option=-dsuppress-ticks",
+    buildOptions = "",
+    installOptions = "",
+    builtinsOptions = defaultBuiltinsOptions
     }
 
 bootTmpDir :: BootArgs -> FilePath
@@ -60,93 +67,96 @@ bootCreateProcess args@BootArgs {..} = do
   e <- getEnvironment
   pure
     (proc "sh" ["-e", "boot.sh"])
-      { cwd = Just dataDir
-      , env =
-          Just $
-          ("ASTERIUS_BOOT_LIBS_DIR", bootLibsPath) :
-          ("ASTERIUS_SANDBOX_GHC_LIBDIR", sandboxGhcLibDir) :
-          ("ASTERIUS_LIB_DIR", bootDir </> "asterius_lib") :
-          ("ASTERIUS_TMP_DIR", bootTmpDir args) :
-          ("ASTERIUS_GHC", ghc) :
-          ("ASTERIUS_GHCLIBDIR", ghcLibDir) :
-          ("ASTERIUS_AHC", ahc) :
-          ("ASTERIUS_AHCPKG", ahcPkg) :
-          ("ASTERIUS_CONFIGURE_OPTIONS", configureOptions) :
-          ("ASTERIUS_BUILD_OPTIONS", buildOptions) :
-          ("ASTERIUS_INSTALL_OPTIONS", installOptions) :
-          [(k, v) | (k, v) <- e, k /= "GHC_PACKAGE_PATH"]
-      , delegate_ctlc = True
-      }
+      { cwd = Just dataDir,
+        env = Just
+          $ ("ASTERIUS_BOOT_LIBS_DIR", bootLibsPath)
+          : ("ASTERIUS_SANDBOX_GHC_LIBDIR", sandboxGhcLibDir)
+          : ("ASTERIUS_LIB_DIR", bootDir </> "asterius_lib")
+          : ("ASTERIUS_TMP_DIR", bootTmpDir args)
+          : ("ASTERIUS_GHC", ghc)
+          : ("ASTERIUS_GHCLIBDIR", ghcLibDir)
+          : ("ASTERIUS_AHC", ahc)
+          : ("ASTERIUS_AHCPKG", ahcPkg)
+          : ("ASTERIUS_CONFIGURE_OPTIONS", configureOptions)
+          : ("ASTERIUS_BUILD_OPTIONS", buildOptions)
+          : ("ASTERIUS_INSTALL_OPTIONS", installOptions)
+          : [(k, v) | (k, v) <- e, k /= "GHC_PACKAGE_PATH"],
+        delegate_ctlc = True
+        }
 
 bootRTSCmm :: BootArgs -> IO ()
 bootRTSCmm BootArgs {..} =
-  GHC.defaultErrorHandler GHC.defaultFatalMessager GHC.defaultFlushOut $
-  GHC.runGhc (Just obj_topdir) $ do
-    dflags0 <- GHC.getSessionDynFlags
-    _ <-
-      GHC.setSessionDynFlags $ GHC.setGeneralFlag' GHC.Opt_SuppressTicks dflags0
-    dflags <- GHC.getSessionDynFlags
-    setDynFlagsRef dflags
-    is_debug <- isJust <$> liftIO (lookupEnv "ASTERIUS_DEBUG")
-    obj_paths_ref <- liftIO $ newIORef []
-    cmm_files <-
-      liftIO $
-      fmap (filter ((== ".cmm") . takeExtension)) $
-      listFilesRecursive $ takeDirectory rts_path
-    runCmm
-      defaultConfig
-        { ghcFlags =
-            [ "-this-unit-id"
-            , "rts"
-            , "-dcmm-lint"
-            , "-O2"
-            , "-I" <> obj_topdir </> "include"
-            ]
-        }
-      cmm_files
-      (\obj_path ir@CmmIR {..} ->
-         let ms_mod =
-               (GHC.Module GHC.rtsUnitId $
-                GHC.mkModuleName $ takeBaseName obj_path)
-          in case runCodeGen (marshalCmmIR ms_mod ir) dflags ms_mod of
-               Left err -> throwIO err
-               Right m -> do
-                 encodeFile obj_path m
-                 modifyIORef' obj_paths_ref (obj_path :)
-                 when is_debug $ do
-                   let p = (obj_path -<.>)
-                   writeFile (p "dump-wasm-ast") $ show m
-                   writeFile (p "dump-cmm-raw-ast") $ show cmmRaw
-                   asmPrint dflags (p "dump-cmm-raw") cmmRaw
-                   writeFile (p "dump-cmm-ast") $ show cmm
-                   asmPrint dflags (p "dump-cmm") cmm)
-    liftIO $ do
-      obj_paths <- readIORef obj_paths_ref
-      tmpdir <- getTemporaryDirectory
-      (rsp_path, rsp_h) <- openTempFile tmpdir "ar.rsp"
-      hPutStr rsp_h $ unlines obj_paths
-      hClose rsp_h
-      callProcess
-        "ar"
-        ["-r", "-c", obj_topdir </> "rts" </> "libHSrts.a", '@' : rsp_path]
-      removeFile rsp_path
+  GHC.defaultErrorHandler GHC.defaultFatalMessager GHC.defaultFlushOut
+    $ GHC.runGhc (Just obj_topdir)
+    $ do
+      dflags0 <- GHC.getSessionDynFlags
+      _ <-
+        GHC.setSessionDynFlags
+          $ GHC.setGeneralFlag' GHC.Opt_SuppressTicks dflags0
+      dflags <- GHC.getSessionDynFlags
+      setDynFlagsRef dflags
+      is_debug <- isJust <$> liftIO (lookupEnv "ASTERIUS_DEBUG")
+      obj_paths_ref <- liftIO $ newIORef []
+      cmm_files <-
+        liftIO
+          $ fmap (filter ((== ".cmm") . takeExtension))
+          $ listFilesRecursive
+          $ takeDirectory rts_path
+      runCmm
+        defaultConfig
+          { ghcFlags = [ "-this-unit-id",
+                         "rts",
+                         "-dcmm-lint",
+                         "-O2",
+                         "-I" <> obj_topdir </> "include"
+                         ]
+            }
+        cmm_files
+        ( \obj_path ir@CmmIR {..} ->
+            let ms_mod =
+                  ( GHC.Module GHC.rtsUnitId $ GHC.mkModuleName
+                      $ takeBaseName
+                          obj_path
+                    )
+             in case runCodeGen (marshalCmmIR ms_mod ir) dflags ms_mod of
+                  Left err -> throwIO err
+                  Right m -> do
+                    encodeFile obj_path m
+                    modifyIORef' obj_paths_ref (obj_path :)
+                    when is_debug $ do
+                      let p = (obj_path -<.>)
+                      writeFile (p "dump-wasm-ast") $ show m
+                      writeFile (p "dump-cmm-raw-ast") $ show cmmRaw
+                      asmPrint dflags (p "dump-cmm-raw") cmmRaw
+          )
+      liftIO $ do
+        obj_paths <- readIORef obj_paths_ref
+        tmpdir <- getTemporaryDirectory
+        (rsp_path, rsp_h) <- openTempFile tmpdir "ar.rsp"
+        hPutStr rsp_h $ unlines obj_paths
+        hClose rsp_h
+        callProcess
+          "ar"
+          ["-r", "-c", obj_topdir </> "rts" </> "libHSrts.a", '@' : rsp_path]
+        removeFile rsp_path
   where
     rts_path = bootLibsPath </> "rts"
     obj_topdir = bootDir </> "asterius_lib"
 
 runBootCreateProcess :: CreateProcess -> IO ()
-runBootCreateProcess =
-  flip withCreateProcess $ \_ _ _ ph -> do
-    ec <- waitForProcess ph
-    case ec of
-      ExitFailure _ -> fail "boot failure"
-      _ -> pure ()
+runBootCreateProcess = flip withCreateProcess $ \_ _ _ ph -> do
+  ec <- waitForProcess ph
+  case ec of
+    ExitFailure _ -> fail "boot failure"
+    _ -> pure ()
 
 boot :: BootArgs -> IO ()
 boot args = do
   cp_boot <- bootCreateProcess args
   runBootCreateProcess
-    cp_boot {cmdspec = RawCommand "sh" ["-e", "boot-init.sh"]}
+    cp_boot
+      { cmdspec = RawCommand "sh" ["-e", "boot-init.sh"]
+        }
   bootRTSCmm args
   runBootCreateProcess cp_boot
   is_debug <- isJust <$> lookupEnv "ASTERIUS_DEBUG"

--- a/asterius/src/Asterius/FrontendPlugin.hs
+++ b/asterius/src/Asterius/FrontendPlugin.hs
@@ -65,12 +65,8 @@ frontendPlugin = makeFrontendPlugin $ do
                   writeFile (p "dump-wasm-ast") $ show m
                   writeFile (p "dump-cmm-raw-ast") $ show cmmRaw
                   asmPrint dflags (p "dump-cmm-raw") cmmRaw
-                  writeFile (p "dump-cmm-ast") $ show cmm
-                  asmPrint dflags (p "dump-cmm") cmm
                   writeFile (p "dump-stg-ast") $ show stg
-                  asmPrint dflags (p "dump-stg") stg
-                  writeFile (p "dump-core-ast") $ show core
-                  asmPrint dflags (p "dump-core") $ GHC.cg_binds core,
+                  asmPrint dflags (p "dump-stg") stg,
         withCmmIR = \ir@CmmIR {..} obj_path -> do
           dflags <- GHC.getDynFlags
           setDynFlagsRef dflags
@@ -85,6 +81,4 @@ frontendPlugin = makeFrontendPlugin $ do
                 writeFile (p "dump-wasm-ast") $ show m
                 writeFile (p "dump-cmm-raw-ast") $ show cmmRaw
                 asmPrint dflags (p "dump-cmm-raw") cmmRaw
-                writeFile (p "dump-cmm-ast") $ show cmm
-                asmPrint dflags (p "dump-cmm") cmm
         }


### PR DESCRIPTION
This PR cleans up some unused code:

* In `Asterius.Foreign`, we now rely on exported functions of `DsForeign`/`TcForeign` as long as they're not modified.
* In `ghc-toolkit`, we only preserve the logic about STG and raw Cmm; all else is not necessary.