### PR TITLE
Misc fixes & improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,8 +141,8 @@ jobs:
             stack --no-terminal test asterius:fib --test-arguments="--tail-calls"
             stack --no-terminal test asterius:fib --test-arguments="--tail-calls --no-gc-sections"
 
-            # stack --no-terminal test asterius:nomain
-            # stack --no-terminal test asterius:nomain --test-arguments="--tail-calls"
+            stack --no-terminal test asterius:nomain
+            stack --no-terminal test asterius:nomain --test-arguments="--tail-calls"
 
   asterius-test-ghc-testsuite:
     docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV \
   DEBIAN_FRONTEND=noninteractive \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \
+  LC_CTYPE=C.UTF-8 \
   PATH=/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 WORKDIR /root/asterius
 
@@ -50,10 +51,10 @@ RUN \
     g++ \
     gnupg \
     make \
-    python-minimal \
     python3-minimal \
     xz-utils && \
   apt autoremove --purge -y && \
+  apt clean && \
   rm -rf \
     /root/.stack/programs/x86_64-linux/*.tar.xz \
     /var/lib/apt/lists/* \
@@ -61,4 +62,5 @@ RUN \
   mv /root/.stack/programs /tmp/ && \
   rm -rf /root/.stack && \
   mkdir /root/.stack && \
-  mv /tmp/programs /root/.stack/
+  mv /tmp/programs /root/.stack/ && \
+  node --version

--- a/asterius/app/ahc-ld.hs
+++ b/asterius/app/ahc-ld.hs
@@ -18,6 +18,7 @@ parseLinkTask args = do
       , linkOutput = link_output
       , linkObjs = link_objs
       , linkLibs = link_libs
+      , linkModule = mempty
       , debug = "--debug" `elem` args
       , gcSections = "--no-gc-sections" `notElem` args
       , binaryen = "--binaryen" `elem` args

--- a/asterius/src/Asterius/JSRun/NonMain.hs
+++ b/asterius/src/Asterius/JSRun/NonMain.hs
@@ -22,6 +22,7 @@ linkNonMain store_m extra_syms = (m, link_report)
           , linkOutput = ""
           , linkObjs = []
           , linkLibs = []
+          , linkModule = mempty
           , Asterius.Ld.debug = False
           , Asterius.Ld.gcSections = True
           , Asterius.Ld.binaryen = False

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -249,12 +250,12 @@ linkStart debug gc_sections binaryen verbose_err store root_syms export_funcs =
         }
     )
   where
-    (merged_m0, report) =
+    (merged_m0, !report) =
       mergeSymbols debug gc_sections verbose_err store root_syms export_funcs
     merged_m1
       | debug = addMemoryTrap merged_m0
       | otherwise = merged_m0
-    merged_m
+    !merged_m
       | verbose_err = merged_m1
       | otherwise =
         merged_m1
@@ -267,7 +268,7 @@ linkStart debug gc_sections binaryen verbose_err store root_syms export_funcs =
                              )
               $ staticsMap merged_m1
             }
-    (result_m, ss_sym_map, func_sym_map, tbl_slots, static_mbs) =
+    (!result_m, !ss_sym_map, !func_sym_map, !tbl_slots, !static_mbs) =
       resolveAsteriusModule debug
         binaryen
         (bundledFFIMarshalState report)

--- a/asterius/test/nomain.hs
+++ b/asterius/test/nomain.hs
@@ -18,6 +18,7 @@ main = do
     , "--full-sym-table"
     , "--ghc-option=-no-hs-main"
     , "--extra-root-symbol=NoMain_x_closure"
+    , "--no-gc-sections"
     ] <>
     args
   m <- decodeFile "test/nomain/NoMain.unlinked.bin"

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,10 +7,9 @@ packages:
   - npm-utils
   - wabt
   - wasm-toolkit
-ghc-build: standard
 setup-info:
   ghc:
-    linux64:
+    linux64-tinfo6:
       8.6.5:
         url: https://6507-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.6.5-x86_64-unknown-linux.tar.xz
         sha256: 3243867786e5920ceb9f42f12a8e7270293097018ed5d32b7c8559551146e442

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.0
+resolver: lts-14.3
 packages:
   - asterius
   - binaryen
@@ -12,9 +12,9 @@ setup-info:
   ghc:
     linux64:
       8.6.5:
-        url: https://6218-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.6.5-x86_64-unknown-linux.tar.xz
-        sha256: 3fb0667f5412b660b62a828d171dcab2f8c225f83376b2147532297cb10c07f1
+        url: https://6507-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.6.5-x86_64-unknown-linux.tar.xz
+        sha256: 3243867786e5920ceb9f42f12a8e7270293097018ed5d32b7c8559551146e442
     macosx:
       8.6.5:
-        url: https://6220-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.6.5-x86_64-apple-darwin.tar.xz
-        sha256: 2d694689b5cd099ec4729672cfec07ff09a037d38b913b49a5d016f81c7affb9
+        url: https://6508-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.6.5-x86_64-apple-darwin.tar.xz
+        sha256: c1615bcc78443f1fe466fb44b685850341e25a7aad405b31f930014cbf981870


### PR DESCRIPTION
* Fix broken `--bundle` flag in the Docker image
* From ongoing TH work: add `linkModule` for supplying in-memory `AsteriusModule`, which come from compiled splices
* Bump deps again, update ghc bindists which contain more...hooks. Sigh.
* Mark linux64 ghc bindists as `tinfo6` properly to avoid duplication with vanilla `tinfo6` bindists.

It's a pity that the attempt to fix `JSRun` using the new hooks turned out to be another rabbit hole. As demonstrated in https://gist.github.com/TerrorJack/fe89fb497f215aa433783adbf8d79357, we can intercept the iserv commands related to linking now, so given a Haskell module, we can trace the linking commands to find its deps and properly assemble the in-memory linker input, instead of having to do a regular `ahc-link` run and deserialize the linker state. However, making the `JSRun` to use this mechanism turns out to be harder. Will do a more detailed writeup after I sort out the TH mess.