### PR TITLE
Util scripts for cleaning & rebuilding

### DIFF
--- a/utils/clean.sh
+++ b/utils/clean.sh
@@ -2,7 +2,9 @@
 
 export ROOT=$(stack path --local-install-root)
 
-stack clean asterius ghc-toolkit
+stack clean \
+  asterius \
+  ghc-toolkit
 rm -rf \
   $ROOT/share/*/asterius* \
   $ROOT/share/*/ghc-toolkit* \

--- a/utils/coffee-break.sh
+++ b/utils/coffee-break.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+
+export CPUS=$(getconf _NPROCESSORS_ONLN 2>/dev/null)
+export ASTERIUS_BUILD_OPTIONS=-j$CPUS
+export MAKEFLAGS=-j$CPUS
+
+. utils/clean.sh
+stack build -j$CPUS --test --no-run-tests asterius
+stack exec ahc-boot

--- a/utils/noon-break.sh
+++ b/utils/noon-break.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+
+export CPUS=$(getconf _NPROCESSORS_ONLN 2>/dev/null)
+export ASTERIUS_BUILD_OPTIONS=-j1
+export ASTERIUS_DEBUG=1
+export MAKEFLAGS=-j$CPUS
+
+. utils/clean.sh
+stack build -j$CPUS --test --no-run-tests asterius
+stack exec ahc-boot

--- a/utils/readme.md
+++ b/utils/readme.md
@@ -1,0 +1,34 @@
+# Util scripts
+
+This directory contains util scripts for hacking on asterius.
+
+## Cleaning & rebuilding
+
+These scripts must be called at the project root directory.
+
+* `utils/clean.sh`: Clean up the `ghc-toolkit` and `asterius` packages, removing
+  the source & compiled objects of the boot libs.
+* `utils/coffee-break.sh`: Do the cleanup, rebuild and reboot, using all CPU
+  cores.
+* `utils/noon-break.sh`: Similar to coffee break, but disables parallelism when
+  booting for deterministic ABI, and enables `ASTERIUS_DEBUG` for IR dumps and
+  Core/STG/Cmm linting. Natually, this one takes a lot of more time.
+
+In general, when the boot libs source or the wasm codegen logic is changed, the
+existing boot cache becomes out of date and thus must be rebuilt. Pick
+`coffee-break.sh` or `noon-break.sh` and get some rest then :)
+
+## Fetching V8 team's Node.js integration build
+
+`utils/v8-node.py` fetches the V8 team's Node.js integration build described
+[here](https://v8.dev/docs/node-integration). The script extracts to
+`$(pwd)/bin/node`, which is a Node.js v13 pre-release build with the latest V8
+revision. This is useful for testing bleeding edge V8 wasm features.
+
+Note that the V8 team's build doesn't bundle `npm`.
+
+## Formatting IR dumps with `pretty-show`
+
+`utils/format.hs` is a script to format IR dumps with `pretty-show`. It's used
+in very early days of this project and most likely bit rotten; open an issue to
+fix this script when the IR dumps need to be eyeballed again.


### PR DESCRIPTION
This PR adds two util scripts for convenient cleaning and rebuilding:

* `utils/coffee-break.sh` cleans up `ghc-toolkit`/`asterius`, rebuilds them, and executes `ahc-boot` with all CPU cores.
* `utils/noon-break.sh` does something similar, but disables parallelism for `ahc-boot` for deterministic ABI of boot cache, and flips on `ASTERIUS_DEBUG` so that IR dumps of boot libs are enabled, and Core/STG/Cmm linting is done. Takes longer time.

When rebooting is required, execute one of these scripts from the project root directory for proper cleaning and rebooting. Rebooting should be done when:

* The toolchain (underlying `ghc`) is updated
* Boot libs in `ghc-toolkit` is modified
* Wasm codegen logic in `asterius` which affects Cmm2Wasm is modified