### PR TITLE
Various changes in the js codegen

### DIFF
--- a/asterius/rts/rts.exception.mjs
+++ b/asterius/rts/rts.exception.mjs
@@ -50,9 +50,9 @@ export class ExceptionHelper {
         raw_layout = this.memory.i64Load(
           info + rtsConstants.offset_StgInfoTable_layout
         );
-      if (!this.infoTables.has(info))
+      if (this.infoTables && !this.infoTables.has(info))
         throw new WebAssembly.RuntimeError(
-          "raiseExceptionHelper: invalid info pointer"
+          `Invalid info table 0x${info.toString(16)}`
         );
       switch (type) {
         case ClosureTypes.UPDATE_FRAME: {

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -48,7 +48,7 @@ export async function newAsteriusInstance(req) {
     __asterius_fs = new MemoryFileSystem(),
     __asterius_bytestring_cbits = new ByteStringCBits(null),
     __asterius_text_cbits = new TextCBits(__asterius_memory),
-    __asterius_gc = new GC(__asterius_memory, __asterius_mblockalloc, __asterius_heapalloc, __asterius_stableptr_manager, __asterius_stablename_manager, __asterius_scheduler, req.infoTables, req.pinnedStaticClosures, req.symbolTable, __asterius_reentrancy_guard, req.yolo),
+    __asterius_gc = new GC(__asterius_memory, __asterius_mblockalloc, __asterius_heapalloc, __asterius_stableptr_manager, __asterius_stablename_manager, __asterius_scheduler, req.infoTables, req.exportStablePtrs, req.symbolTable, __asterius_reentrancy_guard, req.yolo),
     __asterius_exception_helper = new ExceptionHelper(__asterius_memory, __asterius_heapalloc, req.infoTables, req.symbolTable),
     __asterius_threadpaused = new ThreadPaused(__asterius_memory, req.infoTables, req.symbolTable),
     __asterius_float_cbits = new FloatCBits(__asterius_memory),

--- a/asterius/rts/rts.threadpaused.mjs
+++ b/asterius/rts/rts.threadpaused.mjs
@@ -24,9 +24,9 @@ export class ThreadPaused {
         raw_layout = this.memory.i64Load(
           info + rtsConstants.offset_StgInfoTable_layout
         );
-      if (!this.infoTables.has(info))
+      if (this.infoTables && !this.infoTables.has(info))
         throw new WebAssembly.RuntimeError(
-          "threadPaused: invalid info pointer"
+          `Invalid info table 0x${info.toString(16)}`
         );
       switch (type) {
         case ClosureTypes.UPDATE_FRAME: {

--- a/asterius/src/Asterius/Internals/ByteString.hs
+++ b/asterius/src/Asterius/Internals/ByteString.hs
@@ -1,11 +1,14 @@
 module Asterius.Internals.ByteString
-  ( intHex
-  ) where
+  ( intHex,
+  )
+where
 
 import Data.ByteString.Builder
 
-intHex :: Int -> Builder
+{-# INLINE intHex #-}
+intHex :: (Integral i, Show i) => i -> Builder
 intHex x
-  | x >= 0 = string7 "0x" <> wordHex (fromIntegral x)
+  | x >= 0 =
+    string7 "0x" <> wordHex (fromIntegral x)
   | otherwise =
     error $ "Asterius.Internals.ByteString.intHex: called with " <> show x

--- a/asterius/src/Asterius/JSGen/Constants.hs
+++ b/asterius/src/Asterius/JSGen/Constants.hs
@@ -13,9 +13,9 @@ rtsConstants :: Builder
 rtsConstants =
   mconcat $
   [ "export const dataTag = "
-  , intHex (fromIntegral dataTag)
+  , intHex dataTag
   , ";\nexport const functionTag = "
-  , intHex (fromIntegral functionTag)
+  , intHex functionTag
   , ";\nexport const mblock_size = "
   , intHex mblock_size
   , ";\nexport const block_size = "

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -174,27 +174,31 @@ genSymbolDict sym_map =
     (intersperse
        ","
        [ "\"" <> shortByteString (entityName sym) <> "\":" <>
-       intHex (fromIntegral sym_idx)
+       intHex sym_idx
        | (sym, sym_idx) <- M.toList sym_map
        ]) <>
   "})"
 
 genInfoTables :: [Int64] -> Builder
 genInfoTables sym_set =
-  "new Set([" <> mconcat (intersperse "," (map (intHex . fromIntegral) sym_set)) <>
+  "new Set([" <> mconcat (intersperse "," (map intHex sym_set)) <>
   "])"
 
-genPinnedStaticClosures ::
-     M.Map AsteriusEntitySymbol Int64
+genExportStablePtrs
+  :: M.Map AsteriusEntitySymbol Int64
   -> [AsteriusEntitySymbol]
   -> FFIMarshalState
   -> Builder
-genPinnedStaticClosures sym_map export_funcs FFIMarshalState {..} =
-  "new Set(" <>
-  string7
-    (show
-       (map ((sym_map !) . ffiExportClosure . (ffiExportDecls !)) export_funcs)) <>
-  ")"
+genExportStablePtrs sym_map export_funcs FFIMarshalState {..} =
+  "["
+    <> mconcat
+         ( intersperse
+             ","
+             ( map (intHex . (sym_map !) . ffiExportClosure . (ffiExportDecls !))
+                 export_funcs
+             )
+         )
+    <> "]"
 
 genLib :: Task -> LinkReport -> Builder
 genLib Task {..} LinkReport {..} =
@@ -207,10 +211,15 @@ genLib Task {..} LinkReport {..} =
     , generateFFIExportObject bundledFFIMarshalState
     , ", symbolTable: "
     , genSymbolDict symbol_table
-    , ", infoTables: "
-    , genInfoTables infoTableSet
-    , ", pinnedStaticClosures: "
-    , genPinnedStaticClosures
+    , if debug
+        then
+          mconcat
+            [ ", infoTables: ",
+              genInfoTables infoTableSet
+            ]
+        else mempty
+    , ", exportStablePtrs: "
+    , genExportStablePtrs
         staticsSymbolMap
         exportFunctions
         bundledFFIMarshalState
@@ -257,9 +266,6 @@ genDefEntry Task {..} =
         [ "module.then(m => "
         , out_base
         , "(m)).then(async i => {\n"
-        , if debug
-            then "i.logger.onEvent = ev => console.log(`[${ev.level}] ${ev.event}`);\n"
-            else mempty
         , "try {\n"
         , "i.exports.hs_init();\n"
         , "await i.exports.main();\n"


### PR DESCRIPTION
This PR changes rts js code and the js codegen in the following ways:

* We used to have an "info table check" in rts js code; it requires the set of all info pointer addresses to be emitted into the `.lib.mjs` script which bloats the script size. Now it's only enabled in the debug mode. (#299)
* We used to have a set of "pinned static closures" which are also gc roots, and they require special handling in gc. Now they're renamed to "export stable pointers" and are handled as vanilla stable pointers. (#301)
* The event logger no longer defaults to emitting every single event via `console.log`. Until we figure out a proper event log story, it's fine the way it is.