### PR TITLE
Display stack trace on error

### DIFF
--- a/asterius/rts/rts.scheduler.mjs
+++ b/asterius/rts/rts.scheduler.mjs
@@ -261,7 +261,7 @@ export class Scheduler {
             }
           }
           exports.context.reentrancyGuard.exit(0);
-          throw new WebAssembly.RuntimeError(e);
+          throw new WebAssembly.RuntimeError(e.stack);
       }
       );
   }


### PR DESCRIPTION
Display the stack trace on error. Compare:

Before:
```
RuntimeError: TypeError: Cannot mix BigInt and other types, use explicit conversions
    at file:///home/hsyl20/repo/asterius/diagrams/asterius/test/diagrams/rts.scheduler.mjs:264:17
ahc-link: callProcess: node "--experimental-modules" "SquareLimit.mjs" (exit 1): failed
diagrams: callProcess: ahc-link "--input-hs" "test/diagrams/SquareLimit.hs" "--run" "--verbose-err" "--binaryen" (exit 1): failed
```

After:
```
RuntimeError: TypeError: Cannot mix BigInt and other types, use explicit conversions
    at IntegerManager.timesInteger (file:///home/hsyl20/repo/asterius/diagrams/asterius/test/diagrams/rts.integer.mjs:83:40)
    at __asterius_jsffi_integerzmwiredzminzuGHCziIntegerziType_a1Ev (file:///home/hsyl20/repo/asterius/diagrams/asterius/test/diagrams/SquareLimit.lib.mjs:3:3317)
    at __asterius_jsffi_integerzmwiredzminzuGHCziIntegerziType_a1Ev_wrapper (wasm-function[7982]:0x2e703e)
    at textzm1zi2zi3zi1zmLZZOn9keu2Vl3XvFWCbVXmI_DataziTextziLazzyziBuilderziRealFloat_.LcaleV (wasm-function[14768]:0x55653f)
    at scheduleTSO (wasm-function[13925]:0x503d2a)
    at scheduleTSO_wrapper (wasm-function[13926]:0x503d7a)
    at Scheduler.scheduler_loop (file:///home/hsyl20/repo/asterius/diagrams/asterius/test/diagrams/rts.scheduler.mjs:379:15)
    at file:///home/hsyl20/repo/asterius/diagrams/asterius/test/diagrams/rts.scheduler.mjs:264:17
ahc-link: callProcess: node "--experimental-modules" "SquareLimit.mjs" (exit 1): failed
diagrams: callProcess: ahc-link "--input-hs" "test/diagrams/SquareLimit.hs" "--run" "--verbose-err" "--binaryen" (exit 1): failed
```