### PR TITLE
Remove CircleCI rate limit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -483,19 +483,19 @@ workflows:
             - asterius-boot
       - asterius-test-ghc-testsuite:
           requires:
-            - asterius-test
+            - asterius-boot
       - asterius-test-ghc-testsuite-yolo:
           requires:
-            - asterius-test
+            - asterius-boot
       - asterius-test-ghc-testsuite-debug:
           requires:
-            - asterius-test-ghc-testsuite
+            - asterius-boot
       - asterius-test-ghc-testsuite-debug-yolo:
           requires:
-            - asterius-test-ghc-testsuite-yolo
+            - asterius-boot
       - asterius-build-docker:
           requires:
-            - asterius-test
+            - asterius-boot
           filters:
             branches:
               only: master


### PR DESCRIPTION
This PR is a series of PRs to split up #321 

Previously, we did #244 to throttle our CircleCI jobs by rearranging them, so that the more time-consuming `asterius-ghc-testsuite` jobs are run only after `asterius-test` passes, and more expensive flavours of `asterius-ghc-testsuite` are run after cheaper flavours. Now this becomes troublesome since when working on major changes, we may break regular tests, but we'd still like `asterius-ghc-testsuite` to run early so we get some intuition on how bad the breakage is.