### PR TITLE
Apply ormolu on the last master commit

### DIFF
--- a/asterius/Setup.hs
+++ b/asterius/Setup.hs
@@ -6,6 +6,6 @@ import Language.Haskell.GHC.Toolkit.GenPaths
 main :: IO ()
 main =
   defaultMainWithHooks $
-  genPaths
-    GenPathsOptions {targetModuleName = "BuildInfo_asterius"}
-    simpleUserHooks
+    genPaths
+      GenPathsOptions {targetModuleName = "BuildInfo_asterius"}
+      simpleUserHooks

--- a/asterius/app/ahc-boot.hs
+++ b/asterius/app/ahc-boot.hs
@@ -8,7 +8,7 @@ main = do
   install_opts <- getEnvDefault "ASTERIUS_INSTALL_OPTIONS" ""
   boot
     defaultBootArgs
-      { configureOptions = configureOptions defaultBootArgs <> " " <> conf_opts
-      , buildOptions = buildOptions defaultBootArgs <> " " <> build_opts
-      , installOptions = installOptions defaultBootArgs <> " " <> install_opts
+      { configureOptions = configureOptions defaultBootArgs <> " " <> conf_opts,
+        buildOptions = buildOptions defaultBootArgs <> " " <> build_opts,
+        installOptions = installOptions defaultBootArgs <> " " <> install_opts
       }

--- a/asterius/app/ahc-cabal.hs
+++ b/asterius/app/ahc-cabal.hs
@@ -7,57 +7,59 @@ main :: IO ()
 main = do
   args <- getArgs
   let extra_prog_args =
-        [ "--with-ghc=" <> ahc
-        , "--with-ghc-pkg=" <> ahcPkg
-        , "--ghc-option=-fexternal-interpreter"
-        , "--ghc-option=-pgml" <> ahcLd
+        [ "--with-ghc=" <> ahc,
+          "--with-ghc-pkg=" <> ahcPkg,
+          "--ghc-option=-fexternal-interpreter",
+          "--ghc-option=-pgml" <> ahcLd
         ]
       extra_args =
-        [ "--disable-shared"
-        , "--disable-executable-dynamic"
-        , "--disable-profiling"
-        , "--disable-debug-info"
-        , "--disable-library-for-ghci"
-        , "--disable-split-sections"
-        , "--disable-split-objs"
-        , "--disable-executable-stripping"
-        , "--disable-library-stripping"
-        , "--disable-tests"
-        , "--disable-coverage"
-        , "--disable-benchmarks"
-        , "--disable-relocatable"
-        ] <>
-        extra_prog_args
+        [ "--disable-shared",
+          "--disable-executable-dynamic",
+          "--disable-profiling",
+          "--disable-debug-info",
+          "--disable-library-for-ghci",
+          "--disable-split-sections",
+          "--disable-split-objs",
+          "--disable-executable-stripping",
+          "--disable-library-stripping",
+          "--disable-tests",
+          "--disable-coverage",
+          "--disable-benchmarks",
+          "--disable-relocatable"
+        ]
+          <> extra_prog_args
       (global_flags, command_flags) = span ("-" `isPrefixOf`) args
-      new_command_flags =
-        case command_flags of
-          command:flags
-            | command `elem`
-                [ "new-build"
-                , "new-configure"
-                , "v2-build"
-                , "v2-configure"
-                , "v1-configure"
-                , "v1-reconfigure"
-                , "v1-install"
-                ] -> command : (extra_args <> flags)
-            | command `elem` ["v1-build"] ->
-              command : (extra_prog_args <> flags)
-            | command `elem`
-                [ "update"
-                , "help"
-                , "info"
-                , "list"
-                , "fetch"
-                , "user-config"
-                , "get"
-                , "init"
-                , "sandbox"
-                , "new-update"
-                , "v2-update"
-                , "v1-sandbox"
-                ] -> command_flags
-            | otherwise -> error $ "ahc-cabal: Unsupported command " <> command
-          _ -> command_flags
+      new_command_flags = case command_flags of
+        command : flags
+          | command
+              `elem` [ "new-build",
+                       "new-configure",
+                       "v2-build",
+                       "v2-configure",
+                       "v1-configure",
+                       "v1-reconfigure",
+                       "v1-install"
+                     ] ->
+            command : (extra_args <> flags)
+          | command `elem` ["v1-build"] ->
+            command : (extra_prog_args <> flags)
+          | command
+              `elem` [ "update",
+                       "help",
+                       "info",
+                       "list",
+                       "fetch",
+                       "user-config",
+                       "get",
+                       "init",
+                       "sandbox",
+                       "new-update",
+                       "v2-update",
+                       "v1-sandbox"
+                     ] ->
+            command_flags
+          | otherwise ->
+            error $ "ahc-cabal: Unsupported command " <> command
+        _ -> command_flags
       new_args = global_flags <> new_command_flags
   callProcess "cabal" new_args

--- a/asterius/app/ahc-ld.hs
+++ b/asterius/app/ahc-ld.hs
@@ -12,26 +12,26 @@ import System.Environment.Blank
 parseLinkTask :: [String] -> IO LinkTask
 parseLinkTask args = do
   link_libs <- fmap catMaybes $ for link_libnames $ findFile link_libdirs
-  pure
-    LinkTask
-      { progName = prog_name
-      , linkOutput = link_output
-      , linkObjs = link_objs
-      , linkLibs = link_libs
-      , linkModule = mempty
-      , debug = "--debug" `elem` args
-      , gcSections = "--no-gc-sections" `notElem` args
-      , binaryen = "--binaryen" `elem` args
-      , verboseErr = "--verbose-err" `elem` args
-      , outputIR =
-          find ("--output-ir=" `isPrefixOf`) args >>= stripPrefix "--output-ir="
-      , rootSymbols =
-          map (AsteriusEntitySymbol . fromString) $
-          str_args "--extra-root-symbol="
-      , exportFunctions =
-          map (AsteriusEntitySymbol . fromString) $
+  pure LinkTask
+    { progName = prog_name,
+      linkOutput = link_output,
+      linkObjs = link_objs,
+      linkLibs = link_libs,
+      linkModule = mempty,
+      debug = "--debug" `elem` args,
+      gcSections = "--no-gc-sections" `notElem` args,
+      binaryen = "--binaryen" `elem` args,
+      verboseErr = "--verbose-err" `elem` args,
+      outputIR =
+        find ("--output-ir=" `isPrefixOf`) args
+          >>= stripPrefix "--output-ir=",
+      rootSymbols =
+        map (AsteriusEntitySymbol . fromString) $
+          str_args "--extra-root-symbol=",
+      exportFunctions =
+        map (AsteriusEntitySymbol . fromString) $
           str_args "--export-function="
-      }
+    }
   where
     Just (stripPrefix "--prog-name=" -> Just prog_name) =
       find ("--prog-name=" `isPrefixOf`) args
@@ -47,9 +47,9 @@ main :: IO ()
 main = do
   args <- getArgs
   case args of
-    "-Wl,--version":_ -> putStr "LLD"
+    "-Wl,--version" : _ -> putStr "LLD"
     _ -> do
-      let Just ('@':rsp_path) = find ((== '@') . head) args
+      let Just ('@' : rsp_path) = find ((== '@') . head) args
       rsp <- readFile rsp_path
       let rsp_args = map read $ lines rsp
       task <- parseLinkTask rsp_args

--- a/asterius/app/ahc-pkg.hs
+++ b/asterius/app/ahc-pkg.hs
@@ -9,8 +9,9 @@ main = do
   callProcess A.ghcPkg $ do
     arg <- args
     if arg == "--global"
-      then [ "--global"
-           , "--global-package-db=" <>
-             (A.dataDir </> ".boot" </> "asterius_lib" </> "package.conf.d")
-           ]
+      then
+        [ "--global",
+          "--global-package-db="
+            <> (A.dataDir </> ".boot" </> "asterius_lib" </> "package.conf.d")
+        ]
       else pure arg

--- a/asterius/app/ahc.hs
+++ b/asterius/app/ahc.hs
@@ -6,7 +6,7 @@ import System.FilePath
 main :: IO ()
 main =
   fakeGHCMain $
-  FakeGHCOptions
-    A.ghc
-    (A.dataDir </> ".boot" </> "asterius_lib")
-    A.frontendPlugin
+    FakeGHCOptions
+      A.ghc
+      (A.dataDir </> ".boot" </> "asterius_lib")
+      A.frontendPlugin

--- a/asterius/rts/genunicode.hs
+++ b/asterius/rts/genunicode.hs
@@ -1,40 +1,42 @@
 #! stack runghc
-import Data.List
 import Data.Char
+import Data.List
 
 -- | Generate ASCII implementations of u_iswcntrl, u_iswprint by checking
 -- | against GHC behaviour.
-
-
 bool2int :: Bool -> Int
 bool2int False = 0
 bool2int True = 1
 
 gencatArr :: [Int]
-gencatArr = map (fromEnum . generalCategory . toEnum) [0..255]
+gencatArr = map (fromEnum . generalCategory . toEnum) [0 .. 255]
 
 iswcntrlArr :: [Int]
-iswcntrlArr = map (bool2int . isControl . chr) [0..255]
-
+iswcntrlArr = map (bool2int . isControl . chr) [0 .. 255]
 
 iswprintArr :: [Int]
-iswprintArr = map (bool2int . isControl . chr) [0..255]
-
+iswprintArr = map (bool2int . isControl . chr) [0 .. 255]
 
 intarrS :: [Int] -> String
 intarrS as = "[" <> intercalate "," (map show as) <> "]"
 
-lookupS :: String -- ^ Function name
-  -> [Int] -- ^ Array to lookup
-  -> String
+lookupS ::
+  -- | Function name
+  String ->
+  -- | Array to lookup
+  [Int] ->
+  String
 lookupS fnname arr =
-  fnname <> "(i) {" <>
-  "\n\tvar lookup = " <> intarrS arr <> ";" <>
-  "\n\treturn lookup[i];" <>
-  "\n}"
+  fnname
+    <> "(i) {"
+    <> "\n\tvar lookup = "
+    <> intarrS arr
+    <> ";"
+    <> "\n\treturn lookup[i];"
+    <> "\n}"
 
 main :: IO ()
 main = do
-   putStrLn $ lookupS "u_gencat" gencatArr
-   putStrLn $ lookupS "u_iswcntrl" iswcntrlArr
-   putStrLn $ lookupS "u_iswprint" iswprintArr
+  putStrLn $ lookupS "u_gencat" gencatArr
+  putStrLn $ lookupS "u_iswcntrl" iswcntrlArr
+  putStrLn $ lookupS "u_iswprint" iswprintArr

--- a/asterius/src/Asterius/Ar.hs
+++ b/asterius/src/Asterius/Ar.hs
@@ -3,8 +3,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Asterius.Ar
-  ( loadAr
-  ) where
+  ( loadAr,
+  )
+where
 
 import qualified Ar as GHC
 import Asterius.Internals
@@ -19,9 +20,9 @@ loadAr p = do
   GHC.Archive entries <- GHC.loadAr p
   evaluate $
     foldl'
-      (\acc GHC.ArchiveEntry {..} ->
-         case decodeMaybe filedata of
-           Just m -> m <> acc
-           _ -> acc)
+      ( \acc GHC.ArchiveEntry {..} -> case decodeMaybe filedata of
+          Just m -> m <> acc
+          _ -> acc
+      )
       mempty
       entries

--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -24,13 +24,9 @@ import Asterius.Internals.MagicNumber
 import Asterius.Internals.Marshal
 import Asterius.Types
 import Asterius.TypesConv
-
 #if defined(BINARYEN)
-
 import Bindings.Binaryen.Raw
-
 #endif
-
 import Control.Exception
 import Control.Monad
 import Control.Monad.Cont
@@ -52,9 +48,7 @@ newtype MarshalError =
   deriving (Show)
 
 instance Exception MarshalError
-
 #if defined(BINARYEN)
-
 marshalBool :: Bool -> Int8
 marshalBool flag =
   if flag
@@ -594,17 +588,14 @@ serializeModule m =
 
 serializeModuleSExpr :: BinaryenModuleRef -> IO BS.ByteString
 serializeModuleSExpr m =
-
   c_BinaryenModuleAllocateAndWriteText m >>= BS.unsafePackCString
 
 setColorsEnabled :: Bool -> IO ()
 setColorsEnabled b = c_BinaryenSetColorsEnabled . toEnum . fromEnum $ b
 
 isColorsEnabled :: IO Bool
-
 isColorsEnabled = toEnum . fromEnum <$> c_BinaryenAreColorsEnabled
 #else
-
 err =
   error
     "The `asterius` package was configured without the `binaryen` Cabal flag."
@@ -620,5 +611,4 @@ c_BinaryenSetOptimizeLevel = err
 c_BinaryenSetShrinkLevel = err
 
 c_BinaryenModuleValidate = err
-
 #endif

--- a/asterius/src/Asterius/Backends/WasmToolkit.hs
+++ b/asterius/src/Asterius/Backends/WasmToolkit.hs
@@ -5,9 +5,10 @@
 {-# LANGUAGE StrictData #-}
 
 module Asterius.Backends.WasmToolkit
-  ( MarshalError(..)
-  , makeModule
-  ) where
+  ( MarshalError (..),
+    makeModule,
+  )
+where
 
 import Asterius.Internals
 import Asterius.Internals.Barf
@@ -41,13 +42,14 @@ data MarshalError
 
 instance Exception MarshalError
 
-data ModuleSymbolTable = ModuleSymbolTable
-  { functionTypeSymbols :: Map.Map FunctionType Wasm.FunctionTypeIndex
-  , functionSymbols :: Map.Map SBS.ShortByteString Wasm.FunctionIndex
-  }
+data ModuleSymbolTable
+  = ModuleSymbolTable
+      { functionTypeSymbols :: Map.Map FunctionType Wasm.FunctionTypeIndex,
+        functionSymbols :: Map.Map SBS.ShortByteString Wasm.FunctionIndex
+      }
 
 makeModuleSymbolTable ::
-     MonadError MarshalError m => Module -> m ModuleSymbolTable
+  MonadError MarshalError m => Module -> m ModuleSymbolTable
 makeModuleSymbolTable m@Module {..} = do
   let _has_dup l = length l /= length (nub l)
       _func_import_syms =
@@ -57,240 +59,237 @@ makeModuleSymbolTable m@Module {..} = do
       _func_types = generateWasmFunctionTypeSet m
   if _has_dup _func_import_syms
     then throwError DuplicateFunctionImport
-    else pure
-           ModuleSymbolTable
-             { functionTypeSymbols =
-                 Map.fromDistinctAscList $
-                 zip (Set.toList _func_types) (coerce [0 :: Word32 ..])
-             , functionSymbols =
-                 Map.fromList $
-                 zip (_func_import_syms <> _func_syms) (coerce [0 :: Word32 ..])
-             }
+    else pure ModuleSymbolTable
+      { functionTypeSymbols =
+          Map.fromDistinctAscList $
+            zip
+              (Set.toList _func_types)
+              (coerce [0 :: Word32 ..]),
+        functionSymbols =
+          Map.fromList $
+            zip
+              (_func_import_syms <> _func_syms)
+              (coerce [0 :: Word32 ..])
+      }
 
 makeValueType :: ValueType -> Wasm.ValueType
-makeValueType vt =
-  case vt of
-    I32 -> Wasm.I32
-    I64 -> Wasm.I64
-    F32 -> Wasm.F32
-    F64 -> Wasm.F64
+makeValueType vt = case vt of
+  I32 -> Wasm.I32
+  I64 -> Wasm.I64
+  F32 -> Wasm.F32
+  F64 -> Wasm.F64
 
 makeTypeSection ::
-     MonadError MarshalError m => Module -> ModuleSymbolTable -> m Wasm.Section
+  MonadError MarshalError m => Module -> ModuleSymbolTable -> m Wasm.Section
 makeTypeSection Module {} ModuleSymbolTable {..} = do
-  _func_types <-
-    for (Map.keys functionTypeSymbols) $ \FunctionType {..} -> do
-      let _param_types = map makeValueType paramTypes
-          _result_type = map makeValueType returnTypes
-      pure
-        Wasm.FunctionType
-          {parameterTypes = _param_types, resultTypes = _result_type}
+  _func_types <- for (Map.keys functionTypeSymbols) $ \FunctionType {..} -> do
+    let _param_types = map makeValueType paramTypes
+        _result_type = map makeValueType returnTypes
+    pure Wasm.FunctionType
+      { parameterTypes = _param_types,
+        resultTypes = _result_type
+      }
   pure Wasm.TypeSection {types = _func_types}
 
 makeImportSection ::
-     MonadError MarshalError m => Module -> ModuleSymbolTable -> m Wasm.Section
-makeImportSection Module {..} ModuleSymbolTable {..} =
-  pure
-    Wasm.ImportSection
-      { imports =
-          (case memoryImport of
-             MemoryImport {..} ->
-               Wasm.Import
-                 { moduleName = coerce externalModuleName
-                 , importName = coerce externalBaseName
-                 , importDescription =
-                     Wasm.ImportMemory $
-                     Wasm.MemoryType $
-                     Wasm.Limits
-                       { minLimit =
-                           fromIntegral $
-                           memoryMBlocks * (mblock_size `quot` 65536)
-                       , maxLimit = Nothing
-                       }
-                 }) :
-          (case tableImport of
-             TableImport {..} ->
-               Wasm.Import
-                 { moduleName = coerce externalModuleName
-                 , importName = coerce externalBaseName
-                 , importDescription =
-                     Wasm.ImportTable $
-                     Wasm.TableType Wasm.AnyFunc $
-                     Wasm.Limits
-                       {minLimit = fromIntegral tableSlots, maxLimit = Nothing}
-                 }) :
-          [ Wasm.Import
-            { moduleName = coerce externalModuleName
-            , importName = coerce externalBaseName
-            , importDescription =
-                Wasm.ImportFunction $ functionTypeSymbols ! functionType
+  MonadError MarshalError m => Module -> ModuleSymbolTable -> m Wasm.Section
+makeImportSection Module {..} ModuleSymbolTable {..} = pure Wasm.ImportSection
+  { imports =
+      ( case memoryImport of
+          MemoryImport {..} -> Wasm.Import
+            { moduleName = coerce externalModuleName,
+              importName = coerce externalBaseName,
+              importDescription = Wasm.ImportMemory $ Wasm.MemoryType $ Wasm.Limits
+                { minLimit =
+                    fromIntegral $
+                      memoryMBlocks
+                        * (mblock_size `quot` 65536),
+                  maxLimit = Nothing
+                }
             }
-          | FunctionImport {..} <- functionImports
+      )
+        : ( case tableImport of
+              TableImport {..} -> Wasm.Import
+                { moduleName = coerce externalModuleName,
+                  importName = coerce externalBaseName,
+                  importDescription = Wasm.ImportTable $ Wasm.TableType Wasm.AnyFunc $ Wasm.Limits
+                    { minLimit = fromIntegral tableSlots,
+                      maxLimit = Nothing
+                    }
+                }
+          )
+        : [ Wasm.Import
+              { moduleName = coerce externalModuleName,
+                importName = coerce externalBaseName,
+                importDescription =
+                  Wasm.ImportFunction $
+                    functionTypeSymbols
+                      ! functionType
+              }
+            | FunctionImport {..} <- functionImports
           ]
-      }
+  }
 
 makeFunctionSection ::
-     MonadError MarshalError m => Module -> ModuleSymbolTable -> m Wasm.Section
-makeFunctionSection Module {..} ModuleSymbolTable {..} =
-  pure
-    Wasm.FunctionSection
-      { functionTypeIndices =
-          [ functionTypeSymbols ! functionType
-          | Function {..} <- Map.elems functionMap'
-          ]
-      }
+  MonadError MarshalError m => Module -> ModuleSymbolTable -> m Wasm.Section
+makeFunctionSection Module {..} ModuleSymbolTable {..} = pure Wasm.FunctionSection
+  { functionTypeIndices =
+      [ functionTypeSymbols ! functionType
+        | Function {..} <- Map.elems functionMap'
+      ]
+  }
 
 makeExportSection ::
-     MonadError MarshalError m => Module -> ModuleSymbolTable -> m Wasm.Section
-makeExportSection Module {..} ModuleSymbolTable {..} =
-  pure
-    Wasm.ExportSection
-      { exports =
-          [ Wasm.Export
-            { exportName = coerce externalName
-            , exportDescription =
-                Wasm.ExportFunction $ functionSymbols ! internalName
-            }
-          | FunctionExport {..} <- functionExports
-          ] <>
-          (case memoryExport of
-             MemoryExport {..} ->
-               [ Wasm.Export
-                   { exportName = coerce externalName
-                   , exportDescription = Wasm.ExportMemory $ Wasm.MemoryIndex 0
-                   }
-               ]) <>
-          (case tableExport of
-             TableExport {..} ->
-               [ Wasm.Export
-                   { exportName = coerce externalName
-                   , exportDescription = Wasm.ExportTable $ Wasm.TableIndex 0
-                   }
-               ])
-      }
+  MonadError MarshalError m => Module -> ModuleSymbolTable -> m Wasm.Section
+makeExportSection Module {..} ModuleSymbolTable {..} = pure Wasm.ExportSection
+  { exports =
+      [ Wasm.Export
+          { exportName = coerce externalName,
+            exportDescription =
+              Wasm.ExportFunction $
+                functionSymbols
+                  ! internalName
+          }
+        | FunctionExport {..} <- functionExports
+      ]
+        <> ( case memoryExport of
+               MemoryExport {..} ->
+                 [ Wasm.Export
+                     { exportName = coerce externalName,
+                       exportDescription =
+                         Wasm.ExportMemory $
+                           Wasm.MemoryIndex 0
+                     }
+                 ]
+           )
+        <> ( case tableExport of
+               TableExport {..} ->
+                 [ Wasm.Export
+                     { exportName = coerce externalName,
+                       exportDescription =
+                         Wasm.ExportTable $
+                           Wasm.TableIndex 0
+                     }
+                 ]
+           )
+  }
 
 makeElementSection ::
-     MonadError MarshalError m => Module -> ModuleSymbolTable -> m Wasm.Section
-makeElementSection Module {..} ModuleSymbolTable {..} =
-  pure
-    Wasm.ElementSection
-      { elements =
-          case functionTable of
-            FunctionTable {..} ->
-              [ Wasm.Element
-                  { tableIndex = Wasm.TableIndex 0
-                  , tableOffset =
-                      Wasm.Expression
-                        { instructions =
-                            [ Wasm.I32Const
-                                {i32ConstValue = fromIntegral tableOffset}
-                            ]
-                        }
-                  , tableInitialValues =
-                      [ functionSymbols ! _func_sym
-                      | _func_sym <- tableFunctionNames
-                      ]
-                  }
-              ]
-      }
-
-data DeBruijnContext = DeBruijnContext
-  { currentLevel :: Word32
-  , capturedLevels :: Map.Map SBS.ShortByteString Word32
+  MonadError MarshalError m => Module -> ModuleSymbolTable -> m Wasm.Section
+makeElementSection Module {..} ModuleSymbolTable {..} = pure Wasm.ElementSection
+  { elements = case functionTable of
+      FunctionTable {..} ->
+        [ Wasm.Element
+            { tableIndex = Wasm.TableIndex 0,
+              tableOffset = Wasm.Expression
+                { instructions =
+                    [Wasm.I32Const {i32ConstValue = fromIntegral tableOffset}]
+                },
+              tableInitialValues =
+                [ functionSymbols ! _func_sym
+                  | _func_sym <- tableFunctionNames
+                ]
+            }
+        ]
   }
+
+data DeBruijnContext
+  = DeBruijnContext
+      { currentLevel :: Word32,
+        capturedLevels :: Map.Map SBS.ShortByteString Word32
+      }
 
 emptyDeBruijnContext :: DeBruijnContext
 emptyDeBruijnContext =
   DeBruijnContext {currentLevel = 0, capturedLevels = mempty}
 
 bindLabel :: SBS.ShortByteString -> DeBruijnContext -> DeBruijnContext
-bindLabel k DeBruijnContext {..} =
-  DeBruijnContext
-    { currentLevel = succ currentLevel
-    , capturedLevels =
-        if SBS.null k
-          then capturedLevels
-          else Map.insert k currentLevel capturedLevels
-    }
+bindLabel k DeBruijnContext {..} = DeBruijnContext
+  { currentLevel = succ currentLevel,
+    capturedLevels =
+      if SBS.null k
+        then capturedLevels
+        else Map.insert k currentLevel capturedLevels
+  }
 
 extractLabel :: DeBruijnContext -> SBS.ShortByteString -> Wasm.LabelIndex
 extractLabel DeBruijnContext {..} k =
   coerce $ currentLevel - capturedLevels ! k - 1
 
-data LocalContext = LocalContext
-  { localCount :: Map.Map ValueType Word32
-  , localMap :: Map.Map BinaryenIndex Word32
-  }
+data LocalContext
+  = LocalContext
+      { localCount :: Map.Map ValueType Word32,
+        localMap :: Map.Map BinaryenIndex Word32
+      }
 
 emptyLocalContext :: LocalContext
 emptyLocalContext = LocalContext {localCount = mempty, localMap = mempty}
 
 makeLocalContext :: Module -> Function -> LocalContext
 makeLocalContext Module {} Function {..} =
-  snd $
-  foldl'
-    (\(i, LocalContext {..}) (orig_vt, orig_i) ->
-       ( succ i
-       , LocalContext
-           { localCount =
-               Map.alter
-                 (Just . \case
-                    Just c -> succ c
-                    _ -> 1)
-                 orig_vt
-                 localCount
-           , localMap = Map.insert orig_i i localMap
-           }))
-    (arity, emptyLocalContext) $
-  sort $ zip varTypes [arity ..]
+  snd
+    $ foldl'
+      ( \(i, LocalContext {..}) (orig_vt, orig_i) ->
+          ( succ i,
+            LocalContext
+              { localCount =
+                  Map.alter
+                    ( Just . \case
+                        Just c -> succ c
+                        _ -> 1
+                    )
+                    orig_vt
+                    localCount,
+                localMap = Map.insert orig_i i localMap
+              }
+          )
+      )
+      (arity, emptyLocalContext)
+    $ sort
+    $ zip varTypes [arity ..]
   where
     arity = fromIntegral $ length $ paramTypes functionType
 
 lookupLocalContext :: LocalContext -> BinaryenIndex -> Wasm.LocalIndex
-lookupLocalContext LocalContext {..} i =
-  coerce $
-  case Map.lookup i localMap of
-    Just j -> j
-    _ -> i
+lookupLocalContext LocalContext {..} i = coerce $ case Map.lookup i localMap of
+  Just j -> j
+  _ -> i
 
 -- TODO: reduce infer usage
 makeInstructions ::
-     MonadError MarshalError m
-  => Bool
-  -> Map.Map AsteriusEntitySymbol Int64
-  -> ModuleSymbolTable
-  -> DeBruijnContext
-  -> LocalContext
-  -> Expression
-  -> m (DList.DList Wasm.Instruction)
+  MonadError MarshalError m =>
+  Bool ->
+  Map.Map AsteriusEntitySymbol Int64 ->
+  ModuleSymbolTable ->
+  DeBruijnContext ->
+  LocalContext ->
+  Expression ->
+  m (DList.DList Wasm.Instruction)
 makeInstructions tail_calls sym_map _module_symtable@ModuleSymbolTable {..} _de_bruijn_ctx _local_ctx expr =
   case expr of
     Block {..}
       | SBS.null name ->
-        fmap mconcat $
-        for bodys $
-        makeInstructions
-          tail_calls
-          sym_map
-          _module_symtable
-          _de_bruijn_ctx
-          _local_ctx
-      | otherwise -> do
-        let _new_de_bruijn_ctx = bindLabel name _de_bruijn_ctx
-        bs <-
-          for bodys $
+        fmap mconcat $ for bodys $
           makeInstructions
             tail_calls
             sym_map
             _module_symtable
-            _new_de_bruijn_ctx
+            _de_bruijn_ctx
             _local_ctx
-        pure $
-          DList.singleton
-            Wasm.Block
-              { blockResultType = map makeValueType blockReturnTypes
-              , blockInstructions = DList.toList $ mconcat bs
-              }
+      | otherwise -> do
+        let _new_de_bruijn_ctx = bindLabel name _de_bruijn_ctx
+        bs <-
+          for bodys $
+            makeInstructions
+              tail_calls
+              sym_map
+              _module_symtable
+              _new_de_bruijn_ctx
+              _local_ctx
+        pure $ DList.singleton Wasm.Block
+          { blockResultType = map makeValueType blockReturnTypes,
+            blockInstructions = DList.toList $ mconcat bs
+          }
     If {..} -> do
       let _new_de_bruijn_ctx = bindLabel mempty _de_bruijn_ctx
       c <-
@@ -302,34 +301,31 @@ makeInstructions tail_calls sym_map _module_symtable@ModuleSymbolTable {..} _de_
           _local_ctx
           condition
       t <-
-        DList.toList <$>
-        makeInstructions
-          tail_calls
-          sym_map
-          _module_symtable
-          _new_de_bruijn_ctx
-          _local_ctx
-          ifTrue
+        DList.toList
+          <$> makeInstructions
+            tail_calls
+            sym_map
+            _module_symtable
+            _new_de_bruijn_ctx
+            _local_ctx
+            ifTrue
       f <-
-        DList.toList <$>
-        makeInstructionsMaybe
-          tail_calls
-          sym_map
-          _module_symtable
-          _new_de_bruijn_ctx
-          _local_ctx
-          ifFalse
+        DList.toList
+          <$> makeInstructionsMaybe
+            tail_calls
+            sym_map
+            _module_symtable
+            _new_de_bruijn_ctx
+            _local_ctx
+            ifFalse
       pure $
-        c <>
-        DList.singleton
-          Wasm.If
-            { ifResultType = map makeValueType $ infer ifTrue
-            , thenInstructions = t
-            , elseInstructions =
-                case f of
-                  [] -> Nothing
-                  _ -> Just f
-            }
+        c <> DList.singleton Wasm.If
+          { ifResultType = map makeValueType $ infer ifTrue,
+            thenInstructions = t,
+            elseInstructions = case f of
+              [] -> Nothing
+              _ -> Just f
+          }
     Loop {..} -> do
       let _new_de_bruijn_ctx = bindLabel name _de_bruijn_ctx
       b <-
@@ -340,9 +336,10 @@ makeInstructions tail_calls sym_map _module_symtable@ModuleSymbolTable {..} _de_
           _new_de_bruijn_ctx
           _local_ctx
           body
-      pure $
-        DList.singleton
-          Wasm.Loop {loopResultType = [], loopInstructions = DList.toList b}
+      pure $ DList.singleton Wasm.Loop
+        { loopResultType = [],
+          loopInstructions = DList.toList b
+        }
     Break {..} -> do
       let _lbl = extractLabel _de_bruijn_ctx name
       case breakCondition of
@@ -367,53 +364,53 @@ makeInstructions tail_calls sym_map _module_symtable@ModuleSymbolTable {..} _de_
           _local_ctx
           condition
       pure $
-        c <>
-        DList.singleton
-          Wasm.BranchTable
-            { branchTableLabels = map (extractLabel _de_bruijn_ctx) names
-            , branchTableFallbackLabel = extractLabel _de_bruijn_ctx defaultName
-            }
-    Call {..} ->
-      case Map.lookup (coerce target) functionSymbols of
-        Just i -> do
-          xs <-
-            for
-              (if target == "barf"
-                 then [ case operands of
-                          [] -> ConstI64 0
-                          x:_ -> x
-                      ]
-                 else operands) $
-            makeInstructions
+        c <> DList.singleton Wasm.BranchTable
+          { branchTableLabels = map (extractLabel _de_bruijn_ctx) names,
+            branchTableFallbackLabel = extractLabel _de_bruijn_ctx defaultName
+          }
+    Call {..} -> case Map.lookup (coerce target) functionSymbols of
+      Just i -> do
+        xs <-
+          for
+            ( if target == "barf"
+                then
+                  [ case operands of
+                      [] -> ConstI64 0
+                      x : _ -> x
+                  ]
+                else operands
+            )
+            $ makeInstructions
               tail_calls
               sym_map
               _module_symtable
               _de_bruijn_ctx
               _local_ctx
-          pure $ mconcat xs <> DList.singleton Wasm.Call {callFunctionIndex = i}
-        _
-          | Map.member ("__asterius_barf_" <> target) sym_map ->
-            makeInstructions
-              tail_calls
-              sym_map
-              _module_symtable
-              _de_bruijn_ctx
-              _local_ctx $
-            barf target callReturnTypes
-          | otherwise -> pure $ DList.singleton Wasm.Unreachable
+        pure $ mconcat xs <> DList.singleton Wasm.Call {callFunctionIndex = i}
+      _
+        | Map.member ("__asterius_barf_" <> target) sym_map ->
+          makeInstructions
+            tail_calls
+            sym_map
+            _module_symtable
+            _de_bruijn_ctx
+            _local_ctx
+            $ barf target callReturnTypes
+        | otherwise ->
+          pure $ DList.singleton Wasm.Unreachable
     CallImport {..} -> do
       xs <-
         for operands $
-        makeInstructions
-          tail_calls
-          sym_map
-          _module_symtable
-          _de_bruijn_ctx
-          _local_ctx
+          makeInstructions
+            tail_calls
+            sym_map
+            _module_symtable
+            _de_bruijn_ctx
+            _local_ctx
       pure $
-        mconcat xs <>
-        DList.singleton
-          Wasm.Call {callFunctionIndex = functionSymbols ! target'}
+        mconcat xs <> DList.singleton Wasm.Call
+          { callFunctionIndex = functionSymbols ! target'
+          }
     CallIndirect {..} -> do
       f <-
         makeInstructions
@@ -425,21 +422,19 @@ makeInstructions tail_calls sym_map _module_symtable@ModuleSymbolTable {..} _de_
           indirectTarget
       xs <-
         for operands $
-        makeInstructions
-          tail_calls
-          sym_map
-          _module_symtable
-          _de_bruijn_ctx
-          _local_ctx
+          makeInstructions
+            tail_calls
+            sym_map
+            _module_symtable
+            _de_bruijn_ctx
+            _local_ctx
       pure $
-        mconcat xs <> f <>
-        DList.singleton
-          Wasm.CallIndirect
-            {callIndirectFuctionTypeIndex = functionTypeSymbols ! functionType}
-    GetLocal {..} ->
-      pure $
-      DList.singleton
-        Wasm.GetLocal {getLocalIndex = lookupLocalContext _local_ctx index}
+        mconcat xs <> f <> DList.singleton Wasm.CallIndirect
+          { callIndirectFuctionTypeIndex = functionTypeSymbols ! functionType
+          }
+    GetLocal {..} -> pure $ DList.singleton Wasm.GetLocal
+      { getLocalIndex = lookupLocalContext _local_ctx index
+      }
     SetLocal {..} -> do
       v <-
         makeInstructions
@@ -450,31 +445,30 @@ makeInstructions tail_calls sym_map _module_symtable@ModuleSymbolTable {..} _de_
           _local_ctx
           value
       pure $
-        v <>
-        DList.singleton
-          Wasm.SetLocal {setLocalIndex = lookupLocalContext _local_ctx index}
+        v <> DList.singleton Wasm.SetLocal
+          { setLocalIndex = lookupLocalContext _local_ctx index
+          }
     Load {..} -> do
-      let _mem_arg =
-            Wasm.MemoryArgument
-              {memoryArgumentAlignment = 0, memoryArgumentOffset = offset}
-      op <-
-        DList.singleton <$>
-        case (signed, bytes, valueType) of
-          (_, 4, I32) -> pure $ Wasm.I32Load _mem_arg
-          (_, 8, I64) -> pure $ Wasm.I64Load _mem_arg
-          (_, 4, F32) -> pure $ Wasm.F32Load _mem_arg
-          (_, 8, F64) -> pure $ Wasm.F64Load _mem_arg
-          (True, 1, I32) -> pure $ Wasm.I32Load8Signed _mem_arg
-          (False, 1, I32) -> pure $ Wasm.I32Load8Unsigned _mem_arg
-          (True, 2, I32) -> pure $ Wasm.I32Load16Signed _mem_arg
-          (False, 2, I32) -> pure $ Wasm.I32Load16Unsigned _mem_arg
-          (True, 1, I64) -> pure $ Wasm.I64Load8Signed _mem_arg
-          (False, 1, I64) -> pure $ Wasm.I64Load8Unsigned _mem_arg
-          (True, 2, I64) -> pure $ Wasm.I64Load16Signed _mem_arg
-          (False, 2, I64) -> pure $ Wasm.I64Load16Unsigned _mem_arg
-          (True, 4, I64) -> pure $ Wasm.I64Load32Signed _mem_arg
-          (False, 4, I64) -> pure $ Wasm.I64Load32Unsigned _mem_arg
-          _ -> throwError $ UnsupportedExpression expr
+      let _mem_arg = Wasm.MemoryArgument
+            { memoryArgumentAlignment = 0,
+              memoryArgumentOffset = offset
+            }
+      op <- DList.singleton <$> case (signed, bytes, valueType) of
+        (_, 4, I32) -> pure $ Wasm.I32Load _mem_arg
+        (_, 8, I64) -> pure $ Wasm.I64Load _mem_arg
+        (_, 4, F32) -> pure $ Wasm.F32Load _mem_arg
+        (_, 8, F64) -> pure $ Wasm.F64Load _mem_arg
+        (True, 1, I32) -> pure $ Wasm.I32Load8Signed _mem_arg
+        (False, 1, I32) -> pure $ Wasm.I32Load8Unsigned _mem_arg
+        (True, 2, I32) -> pure $ Wasm.I32Load16Signed _mem_arg
+        (False, 2, I32) -> pure $ Wasm.I32Load16Unsigned _mem_arg
+        (True, 1, I64) -> pure $ Wasm.I64Load8Signed _mem_arg
+        (False, 1, I64) -> pure $ Wasm.I64Load8Unsigned _mem_arg
+        (True, 2, I64) -> pure $ Wasm.I64Load16Signed _mem_arg
+        (False, 2, I64) -> pure $ Wasm.I64Load16Unsigned _mem_arg
+        (True, 4, I64) -> pure $ Wasm.I64Load32Signed _mem_arg
+        (False, 4, I64) -> pure $ Wasm.I64Load32Unsigned _mem_arg
+        _ -> throwError $ UnsupportedExpression expr
       p <-
         makeInstructions
           tail_calls
@@ -485,22 +479,21 @@ makeInstructions tail_calls sym_map _module_symtable@ModuleSymbolTable {..} _de_
           ptr
       pure $ p <> op
     Store {..} -> do
-      let _mem_arg =
-            Wasm.MemoryArgument
-              {memoryArgumentAlignment = 0, memoryArgumentOffset = offset}
-      op <-
-        DList.singleton <$>
-        case (bytes, valueType) of
-          (4, I32) -> pure $ Wasm.I32Store _mem_arg
-          (8, I64) -> pure $ Wasm.I64Store _mem_arg
-          (4, F32) -> pure $ Wasm.F32Store _mem_arg
-          (8, F64) -> pure $ Wasm.F64Store _mem_arg
-          (1, I32) -> pure $ Wasm.I32Store8 _mem_arg
-          (2, I32) -> pure $ Wasm.I32Store16 _mem_arg
-          (1, I64) -> pure $ Wasm.I64Store8 _mem_arg
-          (2, I64) -> pure $ Wasm.I64Store16 _mem_arg
-          (4, I64) -> pure $ Wasm.I64Store32 _mem_arg
-          _ -> throwError $ UnsupportedExpression expr
+      let _mem_arg = Wasm.MemoryArgument
+            { memoryArgumentAlignment = 0,
+              memoryArgumentOffset = offset
+            }
+      op <- DList.singleton <$> case (bytes, valueType) of
+        (4, I32) -> pure $ Wasm.I32Store _mem_arg
+        (8, I64) -> pure $ Wasm.I64Store _mem_arg
+        (4, F32) -> pure $ Wasm.F32Store _mem_arg
+        (8, F64) -> pure $ Wasm.F64Store _mem_arg
+        (1, I32) -> pure $ Wasm.I32Store8 _mem_arg
+        (2, I32) -> pure $ Wasm.I32Store16 _mem_arg
+        (1, I64) -> pure $ Wasm.I64Store8 _mem_arg
+        (2, I64) -> pure $ Wasm.I64Store16 _mem_arg
+        (4, I64) -> pure $ Wasm.I64Store32 _mem_arg
+        _ -> throwError $ UnsupportedExpression expr
       p <-
         makeInstructions
           tail_calls
@@ -531,56 +524,54 @@ makeInstructions tail_calls sym_map _module_symtable@ModuleSymbolTable {..} _de_
           _de_bruijn_ctx
           _local_ctx
           operand0
-      op <-
-        DList.singleton <$>
-        case unaryOp of
-          ClzInt32 -> pure Wasm.I32Clz
-          CtzInt32 -> pure Wasm.I32Ctz
-          PopcntInt32 -> pure Wasm.I32Popcnt
-          NegFloat32 -> pure Wasm.F32Neg
-          AbsFloat32 -> pure Wasm.F32Abs
-          CeilFloat32 -> pure Wasm.F32Ceil
-          FloorFloat32 -> pure Wasm.F32Floor
-          TruncFloat32 -> pure Wasm.F32Trunc
-          NearestFloat32 -> pure Wasm.F32Nearest
-          SqrtFloat32 -> pure Wasm.F32Sqrt
-          EqZInt32 -> pure Wasm.I32Eqz
-          ClzInt64 -> pure Wasm.I64Clz
-          CtzInt64 -> pure Wasm.I64Ctz
-          PopcntInt64 -> pure Wasm.I64Popcnt
-          NegFloat64 -> pure Wasm.F64Neg
-          AbsFloat64 -> pure Wasm.F64Abs
-          CeilFloat64 -> pure Wasm.F64Ceil
-          FloorFloat64 -> pure Wasm.F64Floor
-          TruncFloat64 -> pure Wasm.F64Trunc
-          NearestFloat64 -> pure Wasm.F64Nearest
-          SqrtFloat64 -> pure Wasm.F64Sqrt
-          EqZInt64 -> pure Wasm.I64Eqz
-          ExtendSInt32 -> pure Wasm.I64ExtendSFromI32
-          ExtendUInt32 -> pure Wasm.I64ExtendUFromI32
-          WrapInt64 -> pure Wasm.I32WrapFromI64
-          TruncSFloat32ToInt32 -> pure Wasm.I32TruncSFromF32
-          TruncSFloat32ToInt64 -> pure Wasm.I64TruncSFromF32
-          TruncUFloat32ToInt32 -> pure Wasm.I32TruncUFromF32
-          TruncUFloat32ToInt64 -> pure Wasm.I64TruncUFromF32
-          TruncSFloat64ToInt32 -> pure Wasm.I32TruncSFromF64
-          TruncSFloat64ToInt64 -> pure Wasm.I64TruncSFromF64
-          TruncUFloat64ToInt32 -> pure Wasm.I32TruncUFromF64
-          TruncUFloat64ToInt64 -> pure Wasm.I64TruncUFromF64
-          ReinterpretFloat32 -> pure Wasm.I32ReinterpretFromF32
-          ReinterpretFloat64 -> pure Wasm.I64ReinterpretFromF64
-          ConvertSInt32ToFloat32 -> pure Wasm.F32ConvertSFromI32
-          ConvertSInt32ToFloat64 -> pure Wasm.F64ConvertSFromI32
-          ConvertUInt32ToFloat32 -> pure Wasm.F32ConvertUFromI32
-          ConvertUInt32ToFloat64 -> pure Wasm.F64ConvertUFromI32
-          ConvertSInt64ToFloat32 -> pure Wasm.F32ConvertSFromI64
-          ConvertSInt64ToFloat64 -> pure Wasm.F64ConvertSFromI64
-          ConvertUInt64ToFloat32 -> pure Wasm.F32ConvertUFromI64
-          ConvertUInt64ToFloat64 -> pure Wasm.F64ConvertUFromI64
-          PromoteFloat32 -> pure Wasm.F64PromoteFromF32
-          DemoteFloat64 -> pure Wasm.F32DemoteFromF64
-          ReinterpretInt32 -> pure Wasm.F32ReinterpretFromI32
-          ReinterpretInt64 -> pure Wasm.F64ReinterpretFromI64
+      op <- DList.singleton <$> case unaryOp of
+        ClzInt32 -> pure Wasm.I32Clz
+        CtzInt32 -> pure Wasm.I32Ctz
+        PopcntInt32 -> pure Wasm.I32Popcnt
+        NegFloat32 -> pure Wasm.F32Neg
+        AbsFloat32 -> pure Wasm.F32Abs
+        CeilFloat32 -> pure Wasm.F32Ceil
+        FloorFloat32 -> pure Wasm.F32Floor
+        TruncFloat32 -> pure Wasm.F32Trunc
+        NearestFloat32 -> pure Wasm.F32Nearest
+        SqrtFloat32 -> pure Wasm.F32Sqrt
+        EqZInt32 -> pure Wasm.I32Eqz
+        ClzInt64 -> pure Wasm.I64Clz
+        CtzInt64 -> pure Wasm.I64Ctz
+        PopcntInt64 -> pure Wasm.I64Popcnt
+        NegFloat64 -> pure Wasm.F64Neg
+        AbsFloat64 -> pure Wasm.F64Abs
+        CeilFloat64 -> pure Wasm.F64Ceil
+        FloorFloat64 -> pure Wasm.F64Floor
+        TruncFloat64 -> pure Wasm.F64Trunc
+        NearestFloat64 -> pure Wasm.F64Nearest
+        SqrtFloat64 -> pure Wasm.F64Sqrt
+        EqZInt64 -> pure Wasm.I64Eqz
+        ExtendSInt32 -> pure Wasm.I64ExtendSFromI32
+        ExtendUInt32 -> pure Wasm.I64ExtendUFromI32
+        WrapInt64 -> pure Wasm.I32WrapFromI64
+        TruncSFloat32ToInt32 -> pure Wasm.I32TruncSFromF32
+        TruncSFloat32ToInt64 -> pure Wasm.I64TruncSFromF32
+        TruncUFloat32ToInt32 -> pure Wasm.I32TruncUFromF32
+        TruncUFloat32ToInt64 -> pure Wasm.I64TruncUFromF32
+        TruncSFloat64ToInt32 -> pure Wasm.I32TruncSFromF64
+        TruncSFloat64ToInt64 -> pure Wasm.I64TruncSFromF64
+        TruncUFloat64ToInt32 -> pure Wasm.I32TruncUFromF64
+        TruncUFloat64ToInt64 -> pure Wasm.I64TruncUFromF64
+        ReinterpretFloat32 -> pure Wasm.I32ReinterpretFromF32
+        ReinterpretFloat64 -> pure Wasm.I64ReinterpretFromF64
+        ConvertSInt32ToFloat32 -> pure Wasm.F32ConvertSFromI32
+        ConvertSInt32ToFloat64 -> pure Wasm.F64ConvertSFromI32
+        ConvertUInt32ToFloat32 -> pure Wasm.F32ConvertUFromI32
+        ConvertUInt32ToFloat64 -> pure Wasm.F64ConvertUFromI32
+        ConvertSInt64ToFloat32 -> pure Wasm.F32ConvertSFromI64
+        ConvertSInt64ToFloat64 -> pure Wasm.F64ConvertSFromI64
+        ConvertUInt64ToFloat32 -> pure Wasm.F32ConvertUFromI64
+        ConvertUInt64ToFloat64 -> pure Wasm.F64ConvertUFromI64
+        PromoteFloat32 -> pure Wasm.F64PromoteFromF32
+        DemoteFloat64 -> pure Wasm.F32DemoteFromF64
+        ReinterpretInt32 -> pure Wasm.F32ReinterpretFromI32
+        ReinterpretInt64 -> pure Wasm.F64ReinterpretFromI64
       pure $ x <> op
     Binary {..} -> do
       x <-
@@ -599,129 +590,128 @@ makeInstructions tail_calls sym_map _module_symtable@ModuleSymbolTable {..} _de_
           _de_bruijn_ctx
           _local_ctx
           operand1
-      op <-
-        DList.singleton <$>
-        case binaryOp of
-          AddInt32 -> pure Wasm.I32Add
-          SubInt32 -> pure Wasm.I32Sub
-          MulInt32 -> pure Wasm.I32Mul
-          DivSInt32 -> pure Wasm.I32DivS
-          DivUInt32 -> pure Wasm.I32DivU
-          RemSInt32 -> pure Wasm.I32RemS
-          RemUInt32 -> pure Wasm.I32RemU
-          AndInt32 -> pure Wasm.I32And
-          OrInt32 -> pure Wasm.I32Or
-          XorInt32 -> pure Wasm.I32Xor
-          ShlInt32 -> pure Wasm.I32Shl
-          ShrUInt32 -> pure Wasm.I32ShrU
-          ShrSInt32 -> pure Wasm.I32ShrS
-          RotLInt32 -> pure Wasm.I32RotL
-          RotRInt32 -> pure Wasm.I32RotR
-          EqInt32 -> pure Wasm.I32Eq
-          NeInt32 -> pure Wasm.I32Ne
-          LtSInt32 -> pure Wasm.I32LtS
-          LtUInt32 -> pure Wasm.I32LtU
-          LeSInt32 -> pure Wasm.I32LeS
-          LeUInt32 -> pure Wasm.I32LeU
-          GtSInt32 -> pure Wasm.I32GtS
-          GtUInt32 -> pure Wasm.I32GtU
-          GeSInt32 -> pure Wasm.I32GeS
-          GeUInt32 -> pure Wasm.I32GeU
-          AddInt64 -> pure Wasm.I64Add
-          SubInt64 -> pure Wasm.I64Sub
-          MulInt64 -> pure Wasm.I64Mul
-          DivSInt64 -> pure Wasm.I64DivS
-          DivUInt64 -> pure Wasm.I64DivU
-          RemSInt64 -> pure Wasm.I64RemS
-          RemUInt64 -> pure Wasm.I64RemU
-          AndInt64 -> pure Wasm.I64And
-          OrInt64 -> pure Wasm.I64Or
-          XorInt64 -> pure Wasm.I64Xor
-          ShlInt64 -> pure Wasm.I64Shl
-          ShrUInt64 -> pure Wasm.I64ShrU
-          ShrSInt64 -> pure Wasm.I64ShrS
-          RotLInt64 -> pure Wasm.I64RotL
-          RotRInt64 -> pure Wasm.I64RotR
-          EqInt64 -> pure Wasm.I64Eq
-          NeInt64 -> pure Wasm.I64Ne
-          LtSInt64 -> pure Wasm.I64LtS
-          LtUInt64 -> pure Wasm.I64LtU
-          LeSInt64 -> pure Wasm.I64LeS
-          LeUInt64 -> pure Wasm.I64LeU
-          GtSInt64 -> pure Wasm.I64GtS
-          GtUInt64 -> pure Wasm.I64GtU
-          GeSInt64 -> pure Wasm.I64GeS
-          GeUInt64 -> pure Wasm.I64GeU
-          AddFloat32 -> pure Wasm.F32Add
-          SubFloat32 -> pure Wasm.F32Sub
-          MulFloat32 -> pure Wasm.F32Mul
-          DivFloat32 -> pure Wasm.F32Div
-          CopySignFloat32 -> pure Wasm.F32Copysign
-          MinFloat32 -> pure Wasm.F32Min
-          MaxFloat32 -> pure Wasm.F32Max
-          EqFloat32 -> pure Wasm.F32Eq
-          NeFloat32 -> pure Wasm.F32Ne
-          LtFloat32 -> pure Wasm.F32Lt
-          LeFloat32 -> pure Wasm.F32Le
-          GtFloat32 -> pure Wasm.F32Gt
-          GeFloat32 -> pure Wasm.F32Ge
-          AddFloat64 -> pure Wasm.F64Add
-          SubFloat64 -> pure Wasm.F64Sub
-          MulFloat64 -> pure Wasm.F64Mul
-          DivFloat64 -> pure Wasm.F64Div
-          CopySignFloat64 -> pure Wasm.F64Copysign
-          MinFloat64 -> pure Wasm.F64Min
-          MaxFloat64 -> pure Wasm.F64Max
-          EqFloat64 -> pure Wasm.F64Eq
-          NeFloat64 -> pure Wasm.F64Ne
-          LtFloat64 -> pure Wasm.F64Lt
-          LeFloat64 -> pure Wasm.F64Le
-          GtFloat64 -> pure Wasm.F64Gt
-          GeFloat64 -> pure Wasm.F64Ge
+      op <- DList.singleton <$> case binaryOp of
+        AddInt32 -> pure Wasm.I32Add
+        SubInt32 -> pure Wasm.I32Sub
+        MulInt32 -> pure Wasm.I32Mul
+        DivSInt32 -> pure Wasm.I32DivS
+        DivUInt32 -> pure Wasm.I32DivU
+        RemSInt32 -> pure Wasm.I32RemS
+        RemUInt32 -> pure Wasm.I32RemU
+        AndInt32 -> pure Wasm.I32And
+        OrInt32 -> pure Wasm.I32Or
+        XorInt32 -> pure Wasm.I32Xor
+        ShlInt32 -> pure Wasm.I32Shl
+        ShrUInt32 -> pure Wasm.I32ShrU
+        ShrSInt32 -> pure Wasm.I32ShrS
+        RotLInt32 -> pure Wasm.I32RotL
+        RotRInt32 -> pure Wasm.I32RotR
+        EqInt32 -> pure Wasm.I32Eq
+        NeInt32 -> pure Wasm.I32Ne
+        LtSInt32 -> pure Wasm.I32LtS
+        LtUInt32 -> pure Wasm.I32LtU
+        LeSInt32 -> pure Wasm.I32LeS
+        LeUInt32 -> pure Wasm.I32LeU
+        GtSInt32 -> pure Wasm.I32GtS
+        GtUInt32 -> pure Wasm.I32GtU
+        GeSInt32 -> pure Wasm.I32GeS
+        GeUInt32 -> pure Wasm.I32GeU
+        AddInt64 -> pure Wasm.I64Add
+        SubInt64 -> pure Wasm.I64Sub
+        MulInt64 -> pure Wasm.I64Mul
+        DivSInt64 -> pure Wasm.I64DivS
+        DivUInt64 -> pure Wasm.I64DivU
+        RemSInt64 -> pure Wasm.I64RemS
+        RemUInt64 -> pure Wasm.I64RemU
+        AndInt64 -> pure Wasm.I64And
+        OrInt64 -> pure Wasm.I64Or
+        XorInt64 -> pure Wasm.I64Xor
+        ShlInt64 -> pure Wasm.I64Shl
+        ShrUInt64 -> pure Wasm.I64ShrU
+        ShrSInt64 -> pure Wasm.I64ShrS
+        RotLInt64 -> pure Wasm.I64RotL
+        RotRInt64 -> pure Wasm.I64RotR
+        EqInt64 -> pure Wasm.I64Eq
+        NeInt64 -> pure Wasm.I64Ne
+        LtSInt64 -> pure Wasm.I64LtS
+        LtUInt64 -> pure Wasm.I64LtU
+        LeSInt64 -> pure Wasm.I64LeS
+        LeUInt64 -> pure Wasm.I64LeU
+        GtSInt64 -> pure Wasm.I64GtS
+        GtUInt64 -> pure Wasm.I64GtU
+        GeSInt64 -> pure Wasm.I64GeS
+        GeUInt64 -> pure Wasm.I64GeU
+        AddFloat32 -> pure Wasm.F32Add
+        SubFloat32 -> pure Wasm.F32Sub
+        MulFloat32 -> pure Wasm.F32Mul
+        DivFloat32 -> pure Wasm.F32Div
+        CopySignFloat32 -> pure Wasm.F32Copysign
+        MinFloat32 -> pure Wasm.F32Min
+        MaxFloat32 -> pure Wasm.F32Max
+        EqFloat32 -> pure Wasm.F32Eq
+        NeFloat32 -> pure Wasm.F32Ne
+        LtFloat32 -> pure Wasm.F32Lt
+        LeFloat32 -> pure Wasm.F32Le
+        GtFloat32 -> pure Wasm.F32Gt
+        GeFloat32 -> pure Wasm.F32Ge
+        AddFloat64 -> pure Wasm.F64Add
+        SubFloat64 -> pure Wasm.F64Sub
+        MulFloat64 -> pure Wasm.F64Mul
+        DivFloat64 -> pure Wasm.F64Div
+        CopySignFloat64 -> pure Wasm.F64Copysign
+        MinFloat64 -> pure Wasm.F64Min
+        MaxFloat64 -> pure Wasm.F64Max
+        EqFloat64 -> pure Wasm.F64Eq
+        NeFloat64 -> pure Wasm.F64Ne
+        LtFloat64 -> pure Wasm.F64Lt
+        LeFloat64 -> pure Wasm.F64Le
+        GtFloat64 -> pure Wasm.F64Gt
+        GeFloat64 -> pure Wasm.F64Ge
       pure $ x <> y <> op
     ReturnCall {..}
-      | tail_calls ->
-        case Map.lookup (coerce returnCallTarget64) functionSymbols of
-          Just i ->
-            pure $ DList.singleton Wasm.ReturnCall {returnCallFunctionIndex = i}
-          _
-            | Map.member ("__asterius_barf_" <> returnCallTarget64) sym_map ->
-              makeInstructions
-                tail_calls
-                sym_map
-                _module_symtable
-                _de_bruijn_ctx
-                _local_ctx $
-              barf returnCallTarget64 []
-            | otherwise -> pure $ DList.singleton Wasm.Unreachable
-      | otherwise ->
-        case Map.lookup returnCallTarget64 sym_map of
-          Just t ->
+      | tail_calls -> case Map.lookup (coerce returnCallTarget64) functionSymbols of
+        Just i -> pure $
+          DList.singleton Wasm.ReturnCall {returnCallFunctionIndex = i}
+        _
+          | Map.member ("__asterius_barf_" <> returnCallTarget64) sym_map ->
             makeInstructions
               tail_calls
               sym_map
               _module_symtable
               _de_bruijn_ctx
               _local_ctx
-              Store
-                { bytes = 8
-                , offset = 0
-                , ptr =
-                    ConstI32 $
-                    fromIntegral $ (sym_map ! "__asterius_pc") .&. 0xFFFFFFFF
-                , value = ConstI64 t
-                , valueType = I64
-                }
-          _
-            | Map.member ("__asterius_barf_" <> returnCallTarget64) sym_map ->
-              makeInstructions
-                tail_calls
-                sym_map
-                _module_symtable
-                _de_bruijn_ctx
-                _local_ctx $
-              barf returnCallTarget64 []
-            | otherwise -> pure $ DList.singleton Wasm.Unreachable
+              $ barf returnCallTarget64 []
+          | otherwise ->
+            pure $ DList.singleton Wasm.Unreachable
+      | otherwise -> case Map.lookup returnCallTarget64 sym_map of
+        Just t -> makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
+          Store
+            { bytes = 8,
+              offset = 0,
+              ptr =
+                ConstI32
+                  $ fromIntegral
+                  $ (sym_map ! "__asterius_pc")
+                    .&. 0xFFFFFFFF,
+              value = ConstI64 t,
+              valueType = I64
+            }
+        _
+          | Map.member ("__asterius_barf_" <> returnCallTarget64) sym_map ->
+            makeInstructions
+              tail_calls
+              sym_map
+              _module_symtable
+              _de_bruijn_ctx
+              _local_ctx
+              $ barf returnCallTarget64 []
+          | otherwise ->
+            pure $ DList.singleton Wasm.Unreachable
     ReturnCallIndirect {..}
       | tail_calls -> do
         x <-
@@ -730,46 +720,45 @@ makeInstructions tail_calls sym_map _module_symtable@ModuleSymbolTable {..} _de_
             sym_map
             _module_symtable
             _de_bruijn_ctx
-            _local_ctx $
-          Unary {unaryOp = WrapInt64, operand0 = returnCallIndirectTarget64}
-        pure $
-          x <>
-          DList.singleton
-            Wasm.ReturnCallIndirect
-              { returnCallIndirectFunctionTypeIndex =
-                  functionTypeSymbols !
-                  FunctionType {paramTypes = [], returnTypes = []}
+            _local_ctx
+            $ Unary
+              { unaryOp = WrapInt64,
+                operand0 = returnCallIndirectTarget64
               }
-      | otherwise ->
-        makeInstructions
-          tail_calls
-          sym_map
-          _module_symtable
-          _de_bruijn_ctx
-          _local_ctx
-          Store
-            { bytes = 8
-            , offset = 0
-            , ptr =
-                ConstI32 $
-                fromIntegral $ (sym_map ! "__asterius_pc") .&. 0xFFFFFFFF
-            , value = returnCallIndirectTarget64
-            , valueType = I64
+        pure $
+          x <> DList.singleton Wasm.ReturnCallIndirect
+            { returnCallIndirectFunctionTypeIndex = functionTypeSymbols
+                ! FunctionType {paramTypes = [], returnTypes = []}
             }
+      | otherwise -> makeInstructions
+        tail_calls
+        sym_map
+        _module_symtable
+        _de_bruijn_ctx
+        _local_ctx
+        Store
+          { bytes = 8,
+            offset = 0,
+            ptr =
+              ConstI32
+                $ fromIntegral
+                $ (sym_map ! "__asterius_pc")
+                  .&. 0xFFFFFFFF,
+            value = returnCallIndirectTarget64,
+            valueType = I64
+          }
     Host {..} -> do
-      let op =
-            DList.singleton $
-            case hostOp of
-              CurrentMemory -> Wasm.MemorySize
-              GrowMemory -> Wasm.MemoryGrow
+      let op = DList.singleton $ case hostOp of
+            CurrentMemory -> Wasm.MemorySize
+            GrowMemory -> Wasm.MemoryGrow
       xs <-
         for operands $
-        makeInstructions
-          tail_calls
-          sym_map
-          _module_symtable
-          _de_bruijn_ctx
-          _local_ctx
+          makeInstructions
+            tail_calls
+            sym_map
+            _module_symtable
+            _de_bruijn_ctx
+            _local_ctx
       pure $ mconcat xs <> op
     Nop -> pure $ DList.singleton Wasm.Nop
     Unreachable -> pure $ DList.singleton Wasm.Unreachable
@@ -779,37 +768,35 @@ makeInstructions tail_calls sym_map _module_symtable@ModuleSymbolTable {..} _de_
         sym_map
         _module_symtable
         _de_bruijn_ctx
-        _local_ctx $
-      relooper graph
-    Symbol {..} ->
-      case Map.lookup unresolvedSymbol sym_map of
-        Just x ->
+        _local_ctx
+        $ relooper graph
+    Symbol {..} -> case Map.lookup unresolvedSymbol sym_map of
+      Just x -> pure $ DList.singleton Wasm.I64Const
+        { i64ConstValue = x + fromIntegral symbolOffset
+        }
+      _
+        | Map.member ("__asterius_barf_" <> unresolvedSymbol) sym_map ->
+          makeInstructions
+            tail_calls
+            sym_map
+            _module_symtable
+            _de_bruijn_ctx
+            _local_ctx
+            $ barf unresolvedSymbol [I64]
+        | otherwise ->
           pure $
-          DList.singleton
-            Wasm.I64Const {i64ConstValue = x + fromIntegral symbolOffset}
-        _
-          | Map.member ("__asterius_barf_" <> unresolvedSymbol) sym_map ->
-            makeInstructions
-              tail_calls
-              sym_map
-              _module_symtable
-              _de_bruijn_ctx
-              _local_ctx $
-            barf unresolvedSymbol [I64]
-          | otherwise ->
-            pure $
             DList.singleton Wasm.I64Const {i64ConstValue = invalidAddress}
     _ -> throwError $ UnsupportedExpression expr
 
 makeInstructionsMaybe ::
-     MonadError MarshalError m
-  => Bool
-  -> Map.Map AsteriusEntitySymbol Int64
-  -> ModuleSymbolTable
-  -> DeBruijnContext
-  -> LocalContext
-  -> Maybe Expression
-  -> m (DList.DList Wasm.Instruction)
+  MonadError MarshalError m =>
+  Bool ->
+  Map.Map AsteriusEntitySymbol Int64 ->
+  ModuleSymbolTable ->
+  DeBruijnContext ->
+  LocalContext ->
+  Maybe Expression ->
+  m (DList.DList Wasm.Instruction)
 makeInstructionsMaybe tail_calls sym_map _module_symtable _de_bruijn_ctx _local_ctx m_expr =
   case m_expr of
     Just expr ->
@@ -823,59 +810,54 @@ makeInstructionsMaybe tail_calls sym_map _module_symtable _de_bruijn_ctx _local_
     _ -> pure mempty
 
 makeCodeSection ::
-     MonadError MarshalError m
-  => Bool
-  -> Map.Map AsteriusEntitySymbol Int64
-  -> Module
-  -> ModuleSymbolTable
-  -> m Wasm.Section
+  MonadError MarshalError m =>
+  Bool ->
+  Map.Map AsteriusEntitySymbol Int64 ->
+  Module ->
+  ModuleSymbolTable ->
+  m Wasm.Section
 makeCodeSection tail_calls sym_map _mod@Module {..} _module_symtable =
-  fmap Wasm.CodeSection $
-  for (Map.elems functionMap') $ \_func@Function {..} -> do
-    let _local_ctx@LocalContext {..} = makeLocalContext _mod _func
-        _locals =
-          flip map (Map.toList localCount) $ \case
+  fmap Wasm.CodeSection
+    $ for (Map.elems functionMap')
+    $ \_func@Function {..} -> do
+      let _local_ctx@LocalContext {..} = makeLocalContext _mod _func
+          _locals = flip map (Map.toList localCount) $ \case
             (I32, c) -> (Wasm.I32, c)
             (I64, c) -> (Wasm.I64, c)
             (F32, c) -> (Wasm.F32, c)
             (F64, c) -> (Wasm.F64, c)
-    _body <-
-      makeInstructions
-        tail_calls
-        sym_map
-        _module_symtable
-        emptyDeBruijnContext
-        _local_ctx
-        body
-    pure
-      Wasm.Function
+      _body <-
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          emptyDeBruijnContext
+          _local_ctx
+          body
+      pure Wasm.Function
         { functionLocals =
             [ Wasm.Locals {localsCount = c, localsType = vt}
-            | (vt, c) <- _locals
-            ]
-        , functionBody = coerce $ DList.toList _body
+              | (vt, c) <- _locals
+            ],
+          functionBody = coerce $ DList.toList _body
         }
 
 makeDataSection ::
-     MonadError MarshalError m => Module -> ModuleSymbolTable -> m Wasm.Section
+  MonadError MarshalError m => Module -> ModuleSymbolTable -> m Wasm.Section
 makeDataSection Module {..} _module_symtable = do
-  segs <-
-    for memorySegments $ \DataSegment {..} ->
-      pure
-        Wasm.DataSegment
-          { memoryIndex = Wasm.MemoryIndex 0
-          , memoryOffset =
-              Wasm.Expression {instructions = [Wasm.I32Const offset]}
-          , memoryInitialBytes = content
-          }
+  segs <- for memorySegments $ \DataSegment {..} -> pure Wasm.DataSegment
+    { memoryIndex = Wasm.MemoryIndex 0,
+      memoryOffset = Wasm.Expression {instructions = [Wasm.I32Const offset]},
+      memoryInitialBytes = content
+    }
   pure Wasm.DataSection {dataSegments = segs}
 
 makeModule ::
-     MonadError MarshalError m
-  => Bool
-  -> Map.Map AsteriusEntitySymbol Int64
-  -> Module
-  -> m Wasm.Module
+  MonadError MarshalError m =>
+  Bool ->
+  Map.Map AsteriusEntitySymbol Int64 ->
+  Module ->
+  m Wasm.Module
 makeModule tail_calls sym_map m = do
   _module_symtable <- makeModuleSymbolTable m
   _type_sec <- makeTypeSection m _module_symtable
@@ -887,11 +869,11 @@ makeModule tail_calls sym_map m = do
   _data_sec <- makeDataSection m _module_symtable
   pure $
     Wasm.Module
-      [ _type_sec
-      , _import_sec
-      , _func_sec
-      , _export_sec
-      , _elem_sec
-      , _code_sec
-      , _data_sec
+      [ _type_sec,
+        _import_sec,
+        _func_sec,
+        _export_sec,
+        _elem_sec,
+        _code_sec,
+        _data_sec
       ]

--- a/asterius/src/Asterius/BuildInfo.hs
+++ b/asterius/src/Asterius/BuildInfo.hs
@@ -1,13 +1,14 @@
 module Asterius.BuildInfo
-  ( ghc
-  , ghcPkg
-  , ghcLibDir
-  , ahc
-  , ahcPkg
-  , ahcLd
-  , ahcDist
-  , dataDir
-  ) where
+  ( ghc,
+    ghcPkg,
+    ghcLibDir,
+    ahc,
+    ahcPkg,
+    ahcLd,
+    ahcDist,
+    dataDir,
+  )
+where
 
 import BuildInfo_asterius
 import System.Directory
@@ -15,9 +16,6 @@ import System.FilePath
 
 ahc, ahcPkg, ahcLd, ahcDist :: FilePath
 ahc = binDir </> "ahc" <.> exeExtension
-
 ahcPkg = binDir </> "ahc-pkg" <.> exeExtension
-
 ahcLd = binDir </> "ahc-ld" <.> exeExtension
-
 ahcDist = binDir </> "ahc-dist" <.> exeExtension

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -3,19 +3,20 @@
 {-# OPTIONS_GHC -Wno-overflowed-literals #-}
 
 module Asterius.Builtins
-  ( BuiltinsOptions(..)
-  , defaultBuiltinsOptions
-  , rtsAsteriusModuleSymbol
-  , rtsAsteriusModule
-  , rtsFunctionImports
-  , rtsFunctionExports
-  , emitErrorMessage
-  , wasmPageSize
-  , generateWrapperFunction
-  , ShouldSext(..)
-  , genWrap
-  , genExtend
-  ) where
+  ( BuiltinsOptions (..),
+    defaultBuiltinsOptions,
+    rtsAsteriusModuleSymbol,
+    rtsAsteriusModule,
+    rtsFunctionImports,
+    rtsFunctionExports,
+    emitErrorMessage,
+    wasmPageSize,
+    generateWrapperFunction,
+    ShouldSext (..),
+    genWrap,
+    genExtend,
+  )
+where
 
 import Asterius.EDSL
 import Asterius.Internals
@@ -36,574 +37,683 @@ import Prelude hiding (IO)
 wasmPageSize :: Int
 wasmPageSize = 65536
 
-data BuiltinsOptions = BuiltinsOptions
-  { progName :: String
-  , threadStateSize :: Int
-  , debug, hasMain :: Bool
-  }
+data BuiltinsOptions
+  = BuiltinsOptions
+      { progName :: String,
+        threadStateSize :: Int,
+        debug, hasMain :: Bool
+      }
 
 defaultBuiltinsOptions :: BuiltinsOptions
-defaultBuiltinsOptions =
-  BuiltinsOptions
-    { progName =
-        error "Asterius.Builtins.defaultBuiltinsOptions: unknown progName"
-    , threadStateSize = 65536
-    , debug = False
-    , hasMain = True
-    }
+defaultBuiltinsOptions = BuiltinsOptions
+  { progName =
+      error
+        "Asterius.Builtins.defaultBuiltinsOptions: unknown progName",
+    threadStateSize = 65536,
+    debug = False,
+    hasMain = True
+  }
 
 rtsAsteriusModuleSymbol :: AsteriusModuleSymbol
-rtsAsteriusModuleSymbol =
-  AsteriusModuleSymbol
-    { unitId = SBS.toShort $ GHC.fs_bs $ GHC.unitIdFS GHC.rtsUnitId
-    , moduleName = ["Asterius"]
-    }
+rtsAsteriusModuleSymbol = AsteriusModuleSymbol
+  { unitId = SBS.toShort $ GHC.fs_bs $ GHC.unitIdFS GHC.rtsUnitId,
+    moduleName = ["Asterius"]
+  }
 
 rtsAsteriusModule :: BuiltinsOptions -> AsteriusModule
 rtsAsteriusModule opts =
   mempty
     { staticsMap =
         Map.fromList
-          [ ( "MainCapability"
-            , AsteriusStatics
-                { staticsType = Bytes
-                , asteriusStatics =
-                    [ Serialized $
-                      SBS.pack $
-                      replicate (8 * roundup_bytes_to_words sizeof_Capability) 0
+          [ ( "MainCapability",
+              AsteriusStatics
+                { staticsType = Bytes,
+                  asteriusStatics =
+                    [ Serialized $ SBS.pack $
+                        replicate
+                          (8 * roundup_bytes_to_words sizeof_Capability)
+                          0
                     ]
-                })
-          , ( "rts_stop_on_exception"
-            , AsteriusStatics
-                { staticsType = Bytes
-                , asteriusStatics = [Serialized $ encodeStorable (0 :: Word64)]
-                })
-          , ( "n_capabilities"
-            , AsteriusStatics
-                { staticsType = ConstBytes
-                , asteriusStatics = [Serialized $ encodeStorable (1 :: Word32)]
-                })
-          , ( "enabled_capabilities"
-            , AsteriusStatics
-                { staticsType = ConstBytes
-                , asteriusStatics = [Serialized $ encodeStorable (1 :: Word32)]
-                })
-          , ( "prog_name"
-            , AsteriusStatics
-                { staticsType = ConstBytes
-                , asteriusStatics =
-                    [Serialized $ fromString (progName opts <> "\0")]
-                })
-          , ( "prog_argv"
-            , AsteriusStatics
-                { staticsType = ConstBytes
-                , asteriusStatics = [SymbolStatic "prog_name" 0]
-                })
-          , ( "__asterius_localeEncoding"
-            , AsteriusStatics
-                { staticsType = ConstBytes
-                , asteriusStatics = [Serialized "UTF-8\0"]
-                })
-          , ( "__asterius_pc"
-            , AsteriusStatics
-                { staticsType = Bytes
-                , asteriusStatics = [Serialized $ encodeStorable invalidAddress]
-                })
-          , ( "__asterius_i64_slot"
-            , AsteriusStatics
-                { staticsType = Bytes
-                , asteriusStatics = [Serialized $ SBS.pack $ replicate 8 0]
-                })
-          ]
-    , functionMap =
+                }
+            ),
+            ( "rts_stop_on_exception",
+              AsteriusStatics
+                { staticsType = Bytes,
+                  asteriusStatics = [Serialized $ encodeStorable (0 :: Word64)]
+                }
+            ),
+            ( "n_capabilities",
+              AsteriusStatics
+                { staticsType = ConstBytes,
+                  asteriusStatics = [Serialized $ encodeStorable (1 :: Word32)]
+                }
+            ),
+            ( "enabled_capabilities",
+              AsteriusStatics
+                { staticsType = ConstBytes,
+                  asteriusStatics = [Serialized $ encodeStorable (1 :: Word32)]
+                }
+            ),
+            ( "prog_name",
+              AsteriusStatics
+                { staticsType = ConstBytes,
+                  asteriusStatics =
+                    [ Serialized $
+                        fromString (progName opts <> "\0")
+                    ]
+                }
+            ),
+            ( "prog_argv",
+              AsteriusStatics
+                { staticsType = ConstBytes,
+                  asteriusStatics = [SymbolStatic "prog_name" 0]
+                }
+            ),
+            ( "__asterius_localeEncoding",
+              AsteriusStatics
+                { staticsType = ConstBytes,
+                  asteriusStatics = [Serialized "UTF-8\0"]
+                }
+            ),
+            ( "__asterius_pc",
+              AsteriusStatics
+                { staticsType = Bytes,
+                  asteriusStatics = [Serialized $ encodeStorable invalidAddress]
+                }
+            ),
+            ( "__asterius_i64_slot",
+              AsteriusStatics
+                { staticsType = Bytes,
+                  asteriusStatics = [Serialized $ SBS.pack $ replicate 8 0]
+                }
+            )
+          ],
+      functionMap =
         Map.fromList $
-        map (\(func_sym, (_, func)) -> (func_sym, func))
-            (byteStringCBits <> floatCBits  <> unicodeCBits <> md5CBits <> textCBits)
-    }  <> hsInitFunction opts
-       <> createThreadFunction opts
-       <> getThreadIdFunction opts
-       <> genAllocateFunction opts "allocate"
-       <> genAllocateFunction opts "allocateMightFail"
-       <> allocatePinnedFunction opts
-       <> newCAFFunction opts
-       <> stgReturnFunction opts
-       <> printI64Function opts
-       <> printF32Function opts
-       <> printF64Function opts
-       <> assertEqI64Function opts
-       <> strlenFunction opts
-       <> debugBelch2Function opts
-       <> memchrFunction opts
-       <> memcpyFunction opts
-       <> memsetFunction opts
-       <> memcmpFunction opts
-       <> fromJSArrayBufferFunction opts
-       <> toJSArrayBufferFunction opts
-       <> fromJSStringFunction opts
-       <> fromJSArrayFunction opts
-       <> threadPausedFunction opts
-       <> dirtyMutVarFunction opts
-       <> dirtyMVarFunction opts
-       <> dirtyStackFunction opts
-       <> recordClosureMutatedFunction opts
-       <> tryWakeupThreadFunction opts
-       <> raiseExceptionHelperFunction opts
-       <> barfFunction opts
-       <> getProgArgvFunction opts
-       <> suspendThreadFunction opts
-       <> scheduleThreadFunction opts
-       <> scheduleThreadOnFunction opts
-       <> resumeThreadFunction opts
-       <> performMajorGCFunction opts
-       <> performGCFunction opts
-       <> localeEncodingFunction opts
-       <> isattyFunction opts
-       <> fdReadyFunction opts
-       <> rtsSupportsBoundThreadsFunction opts
-       <> readFunction opts
-       <> writeFunction opts
-       <> (if debug opts then generateRtsAsteriusDebugModule opts else mempty)
-       -- | Add in the module that contain functions which need to be
-       -- | exposed to the outside world. So add in the module, and
-       -- | the module wrapped by using `generateWrapperModule`.
-       <> generateRtsExternalInterfaceModule opts
-       <> generateWrapperModule (generateRtsExternalInterfaceModule opts)
+          map
+            (\(func_sym, (_, func)) -> (func_sym, func))
+            ( byteStringCBits
+                <> floatCBits
+                <> unicodeCBits
+                <> md5CBits
+                <> textCBits
+            )
+    }
+    <> hsInitFunction opts
+    <> createThreadFunction opts
+    <> getThreadIdFunction opts
+    <> genAllocateFunction opts "allocate"
+    <> genAllocateFunction opts "allocateMightFail"
+    <> allocatePinnedFunction opts
+    <> newCAFFunction opts
+    <> stgReturnFunction opts
+    <> printI64Function opts
+    <> printF32Function opts
+    <> printF64Function opts
+    <> assertEqI64Function opts
+    <> strlenFunction opts
+    <> debugBelch2Function opts
+    <> memchrFunction opts
+    <> memcpyFunction opts
+    <> memsetFunction opts
+    <> memcmpFunction opts
+    <> fromJSArrayBufferFunction opts
+    <> toJSArrayBufferFunction opts
+    <> fromJSStringFunction opts
+    <> fromJSArrayFunction opts
+    <> threadPausedFunction opts
+    <> dirtyMutVarFunction opts
+    <> dirtyMVarFunction opts
+    <> dirtyStackFunction opts
+    <> recordClosureMutatedFunction opts
+    <> tryWakeupThreadFunction opts
+    <> raiseExceptionHelperFunction opts
+    <> barfFunction opts
+    <> getProgArgvFunction opts
+    <> suspendThreadFunction opts
+    <> scheduleThreadFunction opts
+    <> scheduleThreadOnFunction opts
+    <> resumeThreadFunction opts
+    <> performMajorGCFunction opts
+    <> performGCFunction opts
+    <> localeEncodingFunction opts
+    <> isattyFunction opts
+    <> fdReadyFunction opts
+    <> rtsSupportsBoundThreadsFunction opts
+    <> readFunction opts
+    <> writeFunction opts
+    <> (if debug opts then generateRtsAsteriusDebugModule opts else mempty)
+    -- Add in the module that contain functions which need to be
+    -- exposed to the outside world. So add in the module, and
+    -- the module wrapped by using `generateWrapperModule`.
+    <> generateRtsExternalInterfaceModule opts
+    <> generateWrapperModule (generateRtsExternalInterfaceModule opts)
 
-
--- | Generate the module consisting of functions which need to be wrapped
--- | for communication with the external runtime.
+-- Generate the module consisting of functions which need to be wrapped
+-- for communication with the external runtime.
 generateRtsExternalInterfaceModule :: BuiltinsOptions -> AsteriusModule
-generateRtsExternalInterfaceModule opts = mempty
-  <> rtsApplyFunction opts
-  <> createGenThreadFunction opts
-  <> createIOThreadFunction opts
-  <> createStrictIOThreadFunction opts
-  <> scheduleTSOFunction opts
-  <> rtsGetSchedStatusFunction opts
-  <> rtsCheckSchedStatusFunction opts
-  <> getStablePtrWrapperFunction opts
-  <> deRefStablePtrWrapperFunction opts
-  <> freeStablePtrWrapperFunction opts
-  <> makeStableNameWrapperFunction opts
-  <> rtsMkBoolFunction opts
-  <> rtsMkDoubleFunction opts
-  <> rtsMkCharFunction opts
-  <> rtsMkIntFunction opts
-  <> rtsMkWordFunction opts
-  <> rtsMkPtrFunction opts
-  <> rtsMkStablePtrFunction opts
-  <> rtsGetBoolFunction opts
-  <> rtsGetDoubleFunction opts
-  <> generateRtsGetIntFunction opts "rts_getChar"
-  <> generateRtsGetIntFunction opts "rts_getInt"
-  <> generateRtsGetIntFunction opts "rts_getWord"
-  <> generateRtsGetIntFunction opts "rts_getPtr"
-  <> generateRtsGetIntFunction opts "rts_getStablePtr"
-  <> loadI64Function opts
+generateRtsExternalInterfaceModule opts =
+  mempty
+    <> rtsApplyFunction opts
+    <> createGenThreadFunction opts
+    <> createIOThreadFunction opts
+    <> createStrictIOThreadFunction opts
+    <> scheduleTSOFunction opts
+    <> rtsGetSchedStatusFunction opts
+    <> rtsCheckSchedStatusFunction opts
+    <> getStablePtrWrapperFunction opts
+    <> deRefStablePtrWrapperFunction opts
+    <> freeStablePtrWrapperFunction opts
+    <> makeStableNameWrapperFunction opts
+    <> rtsMkBoolFunction opts
+    <> rtsMkDoubleFunction opts
+    <> rtsMkCharFunction opts
+    <> rtsMkIntFunction opts
+    <> rtsMkWordFunction opts
+    <> rtsMkPtrFunction opts
+    <> rtsMkStablePtrFunction opts
+    <> rtsGetBoolFunction opts
+    <> rtsGetDoubleFunction opts
+    <> generateRtsGetIntFunction opts "rts_getChar"
+    <> generateRtsGetIntFunction opts "rts_getInt"
+    <> generateRtsGetIntFunction opts "rts_getWord"
+    <> generateRtsGetIntFunction opts "rts_getPtr"
+    <> generateRtsGetIntFunction opts "rts_getStablePtr"
+    <> loadI64Function opts
 
--- | Generate the module consisting of debug functions
+-- Generate the module consisting of debug functions
 generateRtsAsteriusDebugModule :: BuiltinsOptions -> AsteriusModule
-generateRtsAsteriusDebugModule opts = mempty
-  <> getF64GlobalRegFunction opts  "__asterius_Load_Sp" Sp
-  <> getF64GlobalRegFunction opts  "__asterius_Load_SpLim" SpLim
-  <> getF64GlobalRegFunction opts  "__asterius_Load_Hp" Hp
-  <> getF64GlobalRegFunction opts  "__asterius_Load_HpLim" SpLim
+generateRtsAsteriusDebugModule opts =
+  mempty
+    <> getF64GlobalRegFunction opts "__asterius_Load_Sp" Sp
+    <> getF64GlobalRegFunction opts "__asterius_Load_SpLim" SpLim
+    <> getF64GlobalRegFunction opts "__asterius_Load_Hp" Hp
+    <> getF64GlobalRegFunction opts "__asterius_Load_HpLim" SpLim
 
 rtsFunctionImports :: Bool -> [FunctionImport]
 rtsFunctionImports debug =
   [ FunctionImport
-    { internalName = "__asterius_" <> op <> "_" <> showSBS ft
-    , externalModuleName = "Math"
-    , externalBaseName = op
-    , functionType = FunctionType {paramTypes = [ft], returnTypes = [ft]}
-    }
-  | ft <- [F32, F64]
-  , op <-
-      [ "sin"
-      , "cos"
-      , "tan"
-      , "sinh"
-      , "cosh"
-      , "tanh"
-      , "asin"
-      , "acos"
-      , "atan"
-      , "log"
-      , "exp"
-      ]
-  ] <>
-  [ FunctionImport
-    { internalName = "__asterius_" <> op <> "_" <> showSBS ft
-    , externalModuleName = "Math"
-    , externalBaseName = op
-    , functionType = FunctionType {paramTypes = [ft, ft], returnTypes = [ft]}
-    }
-  | ft <- [F32, F64]
-  , op <- ["pow"]
-  ] <>
-  [ FunctionImport
-      { internalName = "__asterius_newStablePtr"
-      , externalModuleName = "StablePtr"
-      , externalBaseName = "newStablePtr"
-      , functionType = FunctionType {paramTypes = [F64], returnTypes = [F64]}
+      { internalName = "__asterius_" <> op <> "_" <> showSBS ft,
+        externalModuleName = "Math",
+        externalBaseName = op,
+        functionType = FunctionType {paramTypes = [ft], returnTypes = [ft]}
       }
-  , FunctionImport
-      { internalName = "__asterius_deRefStablePtr"
-      , externalModuleName = "StablePtr"
-      , externalBaseName = "deRefStablePtr"
-      , functionType = FunctionType {paramTypes = [F64], returnTypes = [F64]}
-      }
-  , FunctionImport
-      { internalName = "__asterius_freeStablePtr"
-      , externalModuleName = "StablePtr"
-      , externalBaseName = "freeStablePtr"
-      , functionType = FunctionType {paramTypes = [F64], returnTypes = []}
-      }
-  , FunctionImport
-      { internalName = "__asterius_makeStableName"
-      , externalModuleName = "StableName"
-      , externalBaseName = "makeStableName"
-      , functionType = FunctionType {paramTypes = [F64], returnTypes = [F64]}
-      }
-  , FunctionImport
-      { internalName = "printI64"
-      , externalModuleName = "rts"
-      , externalBaseName = "printI64"
-      , functionType = FunctionType {paramTypes = [F64], returnTypes = []}
-      }
-  , FunctionImport
-      { internalName = "assertEqI64"
-      , externalModuleName = "rts"
-      , externalBaseName = "assertEqI64"
-      , functionType = FunctionType {paramTypes = [F64, F64], returnTypes = []}
-      }
-  , FunctionImport
-      { internalName = "printF32"
-      , externalModuleName = "rts"
-      , externalBaseName = "print"
-      , functionType = FunctionType {paramTypes = [F32], returnTypes = []}
-      }
-  , FunctionImport
-      { internalName = "printF64"
-      , externalModuleName = "rts"
-      , externalBaseName = "print"
-      , functionType = FunctionType {paramTypes = [F64], returnTypes = []}
-      }
-  , FunctionImport
-      { internalName = "__asterius_newTSO"
-      , externalModuleName = "Scheduler"
-      , externalBaseName = "newTSO"
-      , functionType = FunctionType {paramTypes = [], returnTypes = [I32]}
-      }
-  , FunctionImport
-      { internalName = "__asterius_setTSOret"
-      , externalModuleName = "Scheduler"
-      , externalBaseName = "setTSOret"
-      , functionType = FunctionType {paramTypes = [I32, F64], returnTypes = []}
-      }
-  , FunctionImport
-      { internalName = "__asterius_setTSOrstat"
-      , externalModuleName = "Scheduler"
-      , externalBaseName = "setTSOrstat"
-      , functionType = FunctionType {paramTypes = [I32, I32], returnTypes = []}
-      }
-  , FunctionImport
-      { internalName = "__asterius_getTSOret"
-      , externalModuleName = "Scheduler"
-      , externalBaseName = "getTSOret"
-      , functionType = FunctionType {paramTypes = [I32], returnTypes = [F64]}
-      }
-  , FunctionImport
-      { internalName = "__asterius_getTSOrstat"
-      , externalModuleName = "Scheduler"
-      , externalBaseName = "getTSOrstat"
-      , functionType = FunctionType {paramTypes = [I32], returnTypes = [I32]}
-      }
-  , FunctionImport
-      { internalName = "__asterius_hpAlloc"
-      , externalModuleName = "HeapAlloc"
-      , externalBaseName = "hpAlloc"
-      , functionType = FunctionType {paramTypes = [F64], returnTypes = [F64]}
-      }
-  , FunctionImport
-      { internalName = "__asterius_allocate"
-      , externalModuleName = "HeapAlloc"
-      , externalBaseName = "allocate"
-      , functionType = FunctionType {paramTypes = [F64], returnTypes = [F64]}
-      }
-  , FunctionImport
-      { internalName = "__asterius_allocatePinned"
-      , externalModuleName = "HeapAlloc"
-      , externalBaseName = "allocatePinned"
-      , functionType = FunctionType {paramTypes = [F64], returnTypes = [F64]}
-      }
-  , FunctionImport
-      { internalName = "__asterius_strlen"
-      , externalModuleName = "Memory"
-      , externalBaseName = "strlen"
-      , functionType = FunctionType {paramTypes = [F64], returnTypes = [F64]}
-      }
-  , FunctionImport
-      { internalName = "__asterius_debugBelch2"
-      , externalModuleName = "Messages"
-      , externalBaseName = "debugBelch2"
-      , functionType = FunctionType {paramTypes = [F64, F64], returnTypes = []}
-      }
-  , FunctionImport
-      { internalName = "__asterius_memchr"
-      , externalModuleName = "Memory"
-      , externalBaseName = "memchr"
-      , functionType =
-          FunctionType {paramTypes = [F64, F64, F64], returnTypes = [F64]}
-      }
-  , FunctionImport
-      { internalName = "__asterius_memcpy"
-      , externalModuleName = "Memory"
-      , externalBaseName = "memcpy"
-      , functionType =
-          FunctionType {paramTypes = [F64, F64, F64], returnTypes = []}
-      }
-  , FunctionImport
-      { internalName = "__asterius_memmove"
-      , externalModuleName = "Memory"
-      , externalBaseName = "memmove"
-      , functionType =
-          FunctionType {paramTypes = [F64, F64, F64], returnTypes = []}
-      }
-  , FunctionImport
-      { internalName = "__asterius_memset"
-      , externalModuleName = "Memory"
-      , externalBaseName = "memset"
-      , functionType =
-          FunctionType {paramTypes = [F64, F64, F64], returnTypes = []}
-      }
-  , FunctionImport
-      { internalName = "__asterius_memcmp"
-      , externalModuleName = "Memory"
-      , externalBaseName = "memcmp"
-      , functionType =
-          FunctionType {paramTypes = [F64, F64, F64], returnTypes = [I32]}
-      }
-  , FunctionImport
-      { internalName = "__asterius_fromJSArrayBuffer_imp"
-      , externalModuleName = "HeapBuilder"
-      , externalBaseName = "fromJSArrayBuffer"
-      , functionType = FunctionType {paramTypes = [F64], returnTypes = [F64]}
-      }
-  , FunctionImport
-      { internalName = "__asterius_toJSArrayBuffer_imp"
-      , externalModuleName = "HeapBuilder"
-      , externalBaseName = "toJSArrayBuffer"
-      , functionType =
-          FunctionType {paramTypes = [F64, F64], returnTypes = [F64]}
-      }
-  , FunctionImport
-      { internalName = "__asterius_fromJSString_imp"
-      , externalModuleName = "HeapBuilder"
-      , externalBaseName = "fromJSString"
-      , functionType = FunctionType {paramTypes = [F64], returnTypes = [F64]}
-      }
-  , FunctionImport
-      { internalName = "__asterius_fromJSArray_imp"
-      , externalModuleName = "HeapBuilder"
-      , externalBaseName = "fromJSArray"
-      , functionType = FunctionType {paramTypes = [F64], returnTypes = [F64]}
-      }
-  , FunctionImport
-      { internalName = "__asterius_performGC"
-      , externalModuleName = "GC"
-      , externalBaseName = "performGC"
-      , functionType = FunctionType {paramTypes = [], returnTypes = []}
-      }
-  , FunctionImport
-      { internalName = "__asterius_raiseExceptionHelper"
-      , externalModuleName = "ExceptionHelper"
-      , externalBaseName = "raiseExceptionHelper"
-      , functionType =
-          FunctionType {paramTypes = [F64, F64, F64], returnTypes = [F64]}
-      }
-  , FunctionImport
-      { internalName = "__asterius_barf"
-      , externalModuleName = "ExceptionHelper"
-      , externalBaseName = "barf"
-      , functionType = FunctionType {paramTypes = [F64], returnTypes = []}
-      }
-  , FunctionImport
-      { internalName = "__asterius_threadPaused"
-      , externalModuleName = "ThreadPaused"
-      , externalBaseName = "threadPaused"
-      , functionType = FunctionType {paramTypes = [F64, F64], returnTypes = []}
-      }
-  , FunctionImport
-      { internalName = "__asterius_enqueueTSO"
-      , externalModuleName = "Scheduler"
-      , externalBaseName = "enqueueTSO"
-      , functionType = FunctionType {paramTypes = [F64], returnTypes = []}
-      }
-  , FunctionImport
-      { internalName = "__asterius_enter"
-      , externalModuleName = "ReentrancyGuard"
-      , externalBaseName = "enter"
-      , functionType = FunctionType {paramTypes = [I32], returnTypes = []}
-      }
-  , FunctionImport
-      { internalName = "__asterius_exit"
-      , externalModuleName = "ReentrancyGuard"
-      , externalBaseName = "exit"
-      , functionType = FunctionType {paramTypes = [I32], returnTypes = []}
-      }
-
-  , FunctionImport
-      { internalName = "__asterius_mul2"
-      , externalModuleName = "Integer"
-      , externalBaseName = "mul2"
-      , functionType = FunctionType {
-          paramTypes = [I32, I32, I32, I32, I32]
-          , returnTypes = [I32]
-          }
-      }
-  , FunctionImport
-      { internalName = "__asterius_quotrem2_quotient"
-      , externalModuleName = "Integer"
-      , externalBaseName = "quotrem2_quotient"
-      , functionType = FunctionType {
-          paramTypes = [I32, I32, I32, I32, I32, I32, I32]
-          , returnTypes = [I32]
-          }
-      }
-  , FunctionImport
-      { internalName = "__asterius_quotrem2_remainder"
-      , externalModuleName = "Integer"
-      , externalBaseName = "quotrem2_remainder"
-      , functionType = FunctionType {
-          paramTypes = [I32, I32, I32, I32, I32, I32, I32]
-          , returnTypes = [I32]
-          }
-      }
-  , FunctionImport
-      { internalName = "__asterius_read"
-      , externalModuleName = "fs"
-      , externalBaseName = "read"
-      , functionType =
-          FunctionType {paramTypes = [F64, F64, F64], returnTypes = [F64]}
-      }
-  , FunctionImport
-      { internalName = "__asterius_write"
-      , externalModuleName = "fs"
-      , externalBaseName = "write"
-      , functionType =
-          FunctionType {paramTypes = [F64, F64, F64], returnTypes = [F64]}
-      }
-  ] <>
-  (if debug
-     then [ FunctionImport
-              { internalName = "__asterius_traceCmm"
-              , externalModuleName = "Tracing"
-              , externalBaseName = "traceCmm"
-              , functionType =
-                  FunctionType {paramTypes = [F64], returnTypes = []}
-              }
-          , FunctionImport
-              { internalName = "__asterius_traceCmmBlock"
-              , externalModuleName = "Tracing"
-              , externalBaseName = "traceCmmBlock"
-              , functionType =
-                  FunctionType {paramTypes = [F64, I32], returnTypes = []}
-              }
-          , FunctionImport
-              { internalName = "__asterius_traceCmmSetLocal"
-              , externalModuleName = "Tracing"
-              , externalBaseName = "traceCmmSetLocal"
-              , functionType =
-                  FunctionType {paramTypes = [F64, I32, F64], returnTypes = []}
-              }
-          ] <>
-          concat
-            [ [ FunctionImport
-                  { internalName = "__asterius_load_" <> k
-                  , externalModuleName = "MemoryTrap"
-                  , externalBaseName = "load" <> k
-                  , functionType =
-                      FunctionType {paramTypes = [I64, I64, I32], returnTypes = [t]}
-                  }
-              , FunctionImport
-                  { internalName = "__asterius_store_" <> k
-                  , externalModuleName = "MemoryTrap"
-                  , externalBaseName = "store" <> k
-                  , functionType =
-                      FunctionType
-                        {paramTypes = [I64, I64, I32, t], returnTypes = []}
-                  }
-            ]
-            | (k, t) <-
-                [ ("I8", I32)
-                , ("I16", I32)
-                , ("I32", I32)
-                , ("I64", I64)
-                , ("F32", F32)
-                , ("F64", F64)
-                ]
-            ] <>
-          [ FunctionImport
-            { internalName = "__asterius_load_" <> k1 <> "_" <> s <> b
-            , externalModuleName = "MemoryTrap"
-            , externalBaseName = "load" <> k1 <> s <> b
-            , functionType =
-                FunctionType {paramTypes = [I64, I64, I32], returnTypes = [t1]}
-            }
-          | (k1, t1) <- [("I32", I32), ("I64", I64)]
-          , s <- ["S", "U"]
-          , b <- ["8", "16"]
-          ]
-     else []) <>
-  map (fst . snd) (byteStringCBits <> floatCBits <> unicodeCBits <> md5CBits <> textCBits)
+    | ft <- [F32, F64],
+      op <-
+        [ "sin",
+          "cos",
+          "tan",
+          "sinh",
+          "cosh",
+          "tanh",
+          "asin",
+          "acos",
+          "atan",
+          "log",
+          "exp"
+        ]
+  ]
+    <> [ FunctionImport
+           { internalName = "__asterius_" <> op <> "_" <> showSBS ft,
+             externalModuleName = "Math",
+             externalBaseName = op,
+             functionType = FunctionType
+               { paramTypes = [ft, ft],
+                 returnTypes = [ft]
+               }
+           }
+         | ft <- [F32, F64],
+           op <- ["pow"]
+       ]
+    <> [ FunctionImport
+           { internalName = "__asterius_newStablePtr",
+             externalModuleName = "StablePtr",
+             externalBaseName = "newStablePtr",
+             functionType = FunctionType
+               { paramTypes = [F64],
+                 returnTypes = [F64]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_deRefStablePtr",
+             externalModuleName = "StablePtr",
+             externalBaseName = "deRefStablePtr",
+             functionType = FunctionType
+               { paramTypes = [F64],
+                 returnTypes = [F64]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_freeStablePtr",
+             externalModuleName = "StablePtr",
+             externalBaseName = "freeStablePtr",
+             functionType = FunctionType {paramTypes = [F64], returnTypes = []}
+           },
+         FunctionImport
+           { internalName = "__asterius_makeStableName",
+             externalModuleName = "StableName",
+             externalBaseName = "makeStableName",
+             functionType = FunctionType
+               { paramTypes = [F64],
+                 returnTypes = [F64]
+               }
+           },
+         FunctionImport
+           { internalName = "printI64",
+             externalModuleName = "rts",
+             externalBaseName = "printI64",
+             functionType = FunctionType {paramTypes = [F64], returnTypes = []}
+           },
+         FunctionImport
+           { internalName = "assertEqI64",
+             externalModuleName = "rts",
+             externalBaseName = "assertEqI64",
+             functionType = FunctionType
+               { paramTypes = [F64, F64],
+                 returnTypes = []
+               }
+           },
+         FunctionImport
+           { internalName = "printF32",
+             externalModuleName = "rts",
+             externalBaseName = "print",
+             functionType = FunctionType {paramTypes = [F32], returnTypes = []}
+           },
+         FunctionImport
+           { internalName = "printF64",
+             externalModuleName = "rts",
+             externalBaseName = "print",
+             functionType = FunctionType {paramTypes = [F64], returnTypes = []}
+           },
+         FunctionImport
+           { internalName = "__asterius_newTSO",
+             externalModuleName = "Scheduler",
+             externalBaseName = "newTSO",
+             functionType = FunctionType {paramTypes = [], returnTypes = [I32]}
+           },
+         FunctionImport
+           { internalName = "__asterius_setTSOret",
+             externalModuleName = "Scheduler",
+             externalBaseName = "setTSOret",
+             functionType = FunctionType
+               { paramTypes = [I32, F64],
+                 returnTypes = []
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_setTSOrstat",
+             externalModuleName = "Scheduler",
+             externalBaseName = "setTSOrstat",
+             functionType = FunctionType
+               { paramTypes = [I32, I32],
+                 returnTypes = []
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_getTSOret",
+             externalModuleName = "Scheduler",
+             externalBaseName = "getTSOret",
+             functionType = FunctionType
+               { paramTypes = [I32],
+                 returnTypes = [F64]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_getTSOrstat",
+             externalModuleName = "Scheduler",
+             externalBaseName = "getTSOrstat",
+             functionType = FunctionType
+               { paramTypes = [I32],
+                 returnTypes = [I32]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_hpAlloc",
+             externalModuleName = "HeapAlloc",
+             externalBaseName = "hpAlloc",
+             functionType = FunctionType
+               { paramTypes = [F64],
+                 returnTypes = [F64]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_allocate",
+             externalModuleName = "HeapAlloc",
+             externalBaseName = "allocate",
+             functionType = FunctionType
+               { paramTypes = [F64],
+                 returnTypes = [F64]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_allocatePinned",
+             externalModuleName = "HeapAlloc",
+             externalBaseName = "allocatePinned",
+             functionType = FunctionType
+               { paramTypes = [F64],
+                 returnTypes = [F64]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_strlen",
+             externalModuleName = "Memory",
+             externalBaseName = "strlen",
+             functionType = FunctionType
+               { paramTypes = [F64],
+                 returnTypes = [F64]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_debugBelch2",
+             externalModuleName = "Messages",
+             externalBaseName = "debugBelch2",
+             functionType = FunctionType
+               { paramTypes = [F64, F64],
+                 returnTypes = []
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_memchr",
+             externalModuleName = "Memory",
+             externalBaseName = "memchr",
+             functionType = FunctionType
+               { paramTypes = [F64, F64, F64],
+                 returnTypes = [F64]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_memcpy",
+             externalModuleName = "Memory",
+             externalBaseName = "memcpy",
+             functionType = FunctionType
+               { paramTypes = [F64, F64, F64],
+                 returnTypes = []
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_memmove",
+             externalModuleName = "Memory",
+             externalBaseName = "memmove",
+             functionType = FunctionType
+               { paramTypes = [F64, F64, F64],
+                 returnTypes = []
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_memset",
+             externalModuleName = "Memory",
+             externalBaseName = "memset",
+             functionType = FunctionType
+               { paramTypes = [F64, F64, F64],
+                 returnTypes = []
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_memcmp",
+             externalModuleName = "Memory",
+             externalBaseName = "memcmp",
+             functionType = FunctionType
+               { paramTypes = [F64, F64, F64],
+                 returnTypes = [I32]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_fromJSArrayBuffer_imp",
+             externalModuleName = "HeapBuilder",
+             externalBaseName = "fromJSArrayBuffer",
+             functionType = FunctionType
+               { paramTypes = [F64],
+                 returnTypes = [F64]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_toJSArrayBuffer_imp",
+             externalModuleName = "HeapBuilder",
+             externalBaseName = "toJSArrayBuffer",
+             functionType = FunctionType
+               { paramTypes = [F64, F64],
+                 returnTypes = [F64]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_fromJSString_imp",
+             externalModuleName = "HeapBuilder",
+             externalBaseName = "fromJSString",
+             functionType = FunctionType
+               { paramTypes = [F64],
+                 returnTypes = [F64]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_fromJSArray_imp",
+             externalModuleName = "HeapBuilder",
+             externalBaseName = "fromJSArray",
+             functionType = FunctionType
+               { paramTypes = [F64],
+                 returnTypes = [F64]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_performGC",
+             externalModuleName = "GC",
+             externalBaseName = "performGC",
+             functionType = FunctionType {paramTypes = [], returnTypes = []}
+           },
+         FunctionImport
+           { internalName = "__asterius_raiseExceptionHelper",
+             externalModuleName = "ExceptionHelper",
+             externalBaseName = "raiseExceptionHelper",
+             functionType = FunctionType
+               { paramTypes = [F64, F64, F64],
+                 returnTypes = [F64]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_barf",
+             externalModuleName = "ExceptionHelper",
+             externalBaseName = "barf",
+             functionType = FunctionType {paramTypes = [F64], returnTypes = []}
+           },
+         FunctionImport
+           { internalName = "__asterius_threadPaused",
+             externalModuleName = "ThreadPaused",
+             externalBaseName = "threadPaused",
+             functionType = FunctionType
+               { paramTypes = [F64, F64],
+                 returnTypes = []
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_enqueueTSO",
+             externalModuleName = "Scheduler",
+             externalBaseName = "enqueueTSO",
+             functionType = FunctionType {paramTypes = [F64], returnTypes = []}
+           },
+         FunctionImport
+           { internalName = "__asterius_enter",
+             externalModuleName = "ReentrancyGuard",
+             externalBaseName = "enter",
+             functionType = FunctionType {paramTypes = [I32], returnTypes = []}
+           },
+         FunctionImport
+           { internalName = "__asterius_exit",
+             externalModuleName = "ReentrancyGuard",
+             externalBaseName = "exit",
+             functionType = FunctionType {paramTypes = [I32], returnTypes = []}
+           },
+         FunctionImport
+           { internalName = "__asterius_mul2",
+             externalModuleName = "Integer",
+             externalBaseName = "mul2",
+             functionType = FunctionType
+               { paramTypes = [I32, I32, I32, I32, I32],
+                 returnTypes = [I32]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_quotrem2_quotient",
+             externalModuleName = "Integer",
+             externalBaseName = "quotrem2_quotient",
+             functionType = FunctionType
+               { paramTypes = [I32, I32, I32, I32, I32, I32, I32],
+                 returnTypes = [I32]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_quotrem2_remainder",
+             externalModuleName = "Integer",
+             externalBaseName = "quotrem2_remainder",
+             functionType = FunctionType
+               { paramTypes = [I32, I32, I32, I32, I32, I32, I32],
+                 returnTypes = [I32]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_read",
+             externalModuleName = "fs",
+             externalBaseName = "read",
+             functionType = FunctionType
+               { paramTypes = [F64, F64, F64],
+                 returnTypes = [F64]
+               }
+           },
+         FunctionImport
+           { internalName = "__asterius_write",
+             externalModuleName = "fs",
+             externalBaseName = "write",
+             functionType = FunctionType
+               { paramTypes = [F64, F64, F64],
+                 returnTypes = [F64]
+               }
+           }
+       ]
+    <> ( if debug
+           then
+             [ FunctionImport
+                 { internalName = "__asterius_traceCmm",
+                   externalModuleName = "Tracing",
+                   externalBaseName = "traceCmm",
+                   functionType = FunctionType
+                     { paramTypes = [F64],
+                       returnTypes = []
+                     }
+                 },
+               FunctionImport
+                 { internalName = "__asterius_traceCmmBlock",
+                   externalModuleName = "Tracing",
+                   externalBaseName = "traceCmmBlock",
+                   functionType = FunctionType
+                     { paramTypes = [F64, I32],
+                       returnTypes = []
+                     }
+                 },
+               FunctionImport
+                 { internalName = "__asterius_traceCmmSetLocal",
+                   externalModuleName = "Tracing",
+                   externalBaseName = "traceCmmSetLocal",
+                   functionType = FunctionType
+                     { paramTypes = [F64, I32, F64],
+                       returnTypes = []
+                     }
+                 }
+             ]
+               <> concat
+                 [ [ FunctionImport
+                       { internalName = "__asterius_load_" <> k,
+                         externalModuleName = "MemoryTrap",
+                         externalBaseName = "load" <> k,
+                         functionType = FunctionType
+                           { paramTypes = [I64, I64, I32],
+                             returnTypes = [t]
+                           }
+                       },
+                     FunctionImport
+                       { internalName = "__asterius_store_" <> k,
+                         externalModuleName = "MemoryTrap",
+                         externalBaseName = "store" <> k,
+                         functionType = FunctionType
+                           { paramTypes = [I64, I64, I32, t],
+                             returnTypes = []
+                           }
+                       }
+                   ]
+                   | (k, t) <-
+                       [ ("I8", I32),
+                         ("I16", I32),
+                         ("I32", I32),
+                         ("I64", I64),
+                         ("F32", F32),
+                         ("F64", F64)
+                       ]
+                 ]
+               <> [ FunctionImport
+                      { internalName = "__asterius_load_" <> k1 <> "_" <> s <> b,
+                        externalModuleName = "MemoryTrap",
+                        externalBaseName = "load" <> k1 <> s <> b,
+                        functionType = FunctionType
+                          { paramTypes = [I64, I64, I32],
+                            returnTypes = [t1]
+                          }
+                      }
+                    | (k1, t1) <- [("I32", I32), ("I64", I64)],
+                      s <- ["S", "U"],
+                      b <- ["8", "16"]
+                  ]
+           else []
+       )
+    <> map
+      (fst . snd)
+      ( byteStringCBits <> floatCBits <> unicodeCBits <> md5CBits <> textCBits
+      )
 
 rtsFunctionExports :: Bool -> [FunctionExport]
 rtsFunctionExports debug =
   [ FunctionExport {internalName = f <> "_wrapper", externalName = f}
-  | f <-
-      [ "loadI64"
-      , "rts_mkBool"
-      , "rts_mkDouble"
-      , "rts_mkChar"
-      , "rts_mkInt"
-      , "rts_mkWord"
-      , "rts_mkPtr"
-      , "rts_mkStablePtr"
-      , "rts_getBool"
-      , "rts_getDouble"
-      , "rts_getChar"
-      , "rts_getInt"
-      , "rts_getWord"
-      , "rts_getPtr"
-      , "rts_getStablePtr"
-      , "rts_apply"
-      , "createGenThread"
-      , "createStrictIOThread"
-      , "createIOThread"
-      , "scheduleTSO"
-      , "rts_getSchedStatus"
-      , "rts_checkSchedStatus"
-      , "getStablePtr"
-      , "deRefStablePtr"
-      , "hs_free_stable_ptr"
-      ,  "makeStableName"
-      ]
-  ] <>
-  [ FunctionExport {internalName = "__asterius_" <> f, externalName = f}
-  | f <- ["getTSOret", "getTSOrstat"]
-  ] <>
-  [ FunctionExport {internalName = f, externalName = f}
-  | f <-
-      (if debug
-         then [ "__asterius_Load_Sp"
-              , "__asterius_Load_SpLim"
-              , "__asterius_Load_Hp"
-              , "__asterius_Load_HpLim"
-              ]
-         else []) <>
-      ["hs_init"]
+    | f <-
+        [ "loadI64",
+          "rts_mkBool",
+          "rts_mkDouble",
+          "rts_mkChar",
+          "rts_mkInt",
+          "rts_mkWord",
+          "rts_mkPtr",
+          "rts_mkStablePtr",
+          "rts_getBool",
+          "rts_getDouble",
+          "rts_getChar",
+          "rts_getInt",
+          "rts_getWord",
+          "rts_getPtr",
+          "rts_getStablePtr",
+          "rts_apply",
+          "createGenThread",
+          "createStrictIOThread",
+          "createIOThread",
+          "scheduleTSO",
+          "rts_getSchedStatus",
+          "rts_checkSchedStatus",
+          "getStablePtr",
+          "deRefStablePtr",
+          "hs_free_stable_ptr",
+          "makeStableName"
+        ]
   ]
+    <> [ FunctionExport {internalName = "__asterius_" <> f, externalName = f}
+         | f <- ["getTSOret", "getTSOrstat"]
+       ]
+    <> [ FunctionExport {internalName = f, externalName = f}
+         | f <-
+             ( if debug
+                 then
+                   [ "__asterius_Load_Sp",
+                     "__asterius_Load_SpLim",
+                     "__asterius_Load_Hp",
+                     "__asterius_Load_HpLim"
+                   ]
+                 else []
+             )
+               <> ["hs_init"]
+       ]
 
 emitErrorMessage :: [ValueType] -> SBS.ShortByteString -> Expression
 emitErrorMessage vts ev = Barf {barfMessage = ev, barfReturnTypes = vts}
@@ -611,160 +721,227 @@ emitErrorMessage vts ev = Barf {barfMessage = ev, barfReturnTypes = vts}
 byteStringCBits :: [(AsteriusEntitySymbol, (FunctionImport, Function))]
 byteStringCBits =
   map
-    (\(func_sym, param_vts, ret_vts) ->
-       ( AsteriusEntitySymbol func_sym
-       , generateRTSWrapper "bytestring" func_sym param_vts ret_vts))
-    [ ("fps_reverse", [I64, I64, I64], [])
-    , ("fps_intersperse", [I64, I64, I64, I64], [])
-    , ("fps_maximum", [I64, I64], [I64])
-    , ("fps_minimum", [I64, I64], [I64])
-    , ("fps_count", [I64, I64, I64], [I64])
-    , ("fps_memcpy_offsets", [I64, I64, I64, I64, I64], [I64])
-    , ("_hs_bytestring_int_dec", [I64, I64], [I64])
-    , ("_hs_bytestring_long_long_int_dec", [I64, I64], [I64])
-    , ("_hs_bytestring_uint_dec", [I64, I64], [I64])
-    , ("_hs_bytestring_long_long_uint_dec", [I64, I64], [I64])
-    , ("_hs_bytestring_int_dec_padded9", [I64, I64], [])
-    , ("_hs_bytestring_long_long_int_dec_padded18", [I64, I64], [])
-    , ("_hs_bytestring_uint_hex", [I64, I64], [I64])
-    , ("_hs_bytestring_long_long_uint_hex", [I64, I64], [I64])
+    ( \(func_sym, param_vts, ret_vts) ->
+        ( AsteriusEntitySymbol func_sym,
+          generateRTSWrapper "bytestring" func_sym param_vts ret_vts
+        )
+    )
+    [ ("fps_reverse", [I64, I64, I64], []),
+      ("fps_intersperse", [I64, I64, I64, I64], []),
+      ("fps_maximum", [I64, I64], [I64]),
+      ("fps_minimum", [I64, I64], [I64]),
+      ("fps_count", [I64, I64, I64], [I64]),
+      ("fps_memcpy_offsets", [I64, I64, I64, I64, I64], [I64]),
+      ("_hs_bytestring_int_dec", [I64, I64], [I64]),
+      ("_hs_bytestring_long_long_int_dec", [I64, I64], [I64]),
+      ("_hs_bytestring_uint_dec", [I64, I64], [I64]),
+      ("_hs_bytestring_long_long_uint_dec", [I64, I64], [I64]),
+      ("_hs_bytestring_int_dec_padded9", [I64, I64], []),
+      ("_hs_bytestring_long_long_int_dec_padded18", [I64, I64], []),
+      ("_hs_bytestring_uint_hex", [I64, I64], [I64]),
+      ("_hs_bytestring_long_long_uint_hex", [I64, I64], [I64])
     ]
 
 textCBits :: [(AsteriusEntitySymbol, (FunctionImport, Function))]
 textCBits =
   map
-    (\(func_sym, param_vts, ret_vts) ->
-       ( AsteriusEntitySymbol func_sym
-       , generateRTSWrapper "text" func_sym param_vts ret_vts))
-    [ ("_hs_text_memcpy", [I64, I64, I64, I64, I64], [])
-    , ("_hs_text_memcmp", [I64, I64, I64, I64, I64], [I64])
+    ( \(func_sym, param_vts, ret_vts) ->
+        ( AsteriusEntitySymbol func_sym,
+          generateRTSWrapper "text" func_sym param_vts ret_vts
+        )
+    )
+    [ ("_hs_text_memcpy", [I64, I64, I64, I64, I64], []),
+      ("_hs_text_memcmp", [I64, I64, I64, I64, I64], [I64])
     ]
 
 floatCBits :: [(AsteriusEntitySymbol, (FunctionImport, Function))]
 floatCBits =
-    map (\(func_sym, param_vts, ret_vts) ->
-       ( AsteriusEntitySymbol func_sym
-       , generateRTSWrapper "floatCBits" func_sym param_vts ret_vts))
-    [ ("isFloatNegativeZero", [F32], [I64])
-    , ("isDoubleNegativeZero", [F64], [I64])
-    , ("isFloatNaN", [F32], [I64])
-    , ("isDoubleNaN", [F64], [I64])
-    , ("isFloatFinite", [F32], [I64])
-    , ("isDoubleFinite", [F64], [I64])
-    , ("isFloatDenormalized", [F32], [I64])
-    , ("isDoubleDenormalized", [F64], [I64])
-    , ("isFloatInfinite", [F32], [I64])
-    , ("isDoubleInfinite", [F64], [I64])
-    , ("__decodeFloat_Int", [I64, I64, F32], [])
-    , ("rintDouble", [F64], [F64])
-    , ("rintFloat", [F32], [F32])
+  map
+    ( \(func_sym, param_vts, ret_vts) ->
+        ( AsteriusEntitySymbol func_sym,
+          generateRTSWrapper "floatCBits" func_sym param_vts ret_vts
+        )
+    )
+    [ ("isFloatNegativeZero", [F32], [I64]),
+      ("isDoubleNegativeZero", [F64], [I64]),
+      ("isFloatNaN", [F32], [I64]),
+      ("isDoubleNaN", [F64], [I64]),
+      ("isFloatFinite", [F32], [I64]),
+      ("isDoubleFinite", [F64], [I64]),
+      ("isFloatDenormalized", [F32], [I64]),
+      ("isDoubleDenormalized", [F64], [I64]),
+      ("isFloatInfinite", [F32], [I64]),
+      ("isDoubleInfinite", [F64], [I64]),
+      ("__decodeFloat_Int", [I64, I64, F32], []),
+      ("rintDouble", [F64], [F64]),
+      ("rintFloat", [F32], [F32])
     ]
 
 md5CBits :: [(AsteriusEntitySymbol, (FunctionImport, Function))]
 md5CBits =
-    map (\(func_sym, param_vts, ret_vts) ->
-       ( AsteriusEntitySymbol func_sym
-       , generateRTSWrapper "MD5" func_sym param_vts ret_vts))
-    [ ("__hsbase_MD5Init", [I64], [])
-    , ("__hsbase_MD5Update", [I64, I64, I64], [])
-    , ("__hsbase_MD5Final", [I64, I64], [])
+  map
+    ( \(func_sym, param_vts, ret_vts) ->
+        ( AsteriusEntitySymbol func_sym,
+          generateRTSWrapper "MD5" func_sym param_vts ret_vts
+        )
+    )
+    [ ("__hsbase_MD5Init", [I64], []),
+      ("__hsbase_MD5Update", [I64, I64, I64], []),
+      ("__hsbase_MD5Final", [I64, I64], [])
     ]
 
 generateRTSWrapper ::
-     SBS.ShortByteString
-  -> SBS.ShortByteString
-  -> [ValueType]
-  -> [ValueType]
-  -> (FunctionImport, Function)
+  SBS.ShortByteString ->
+  SBS.ShortByteString ->
+  [ValueType] ->
+  [ValueType] ->
+  (FunctionImport, Function)
 generateRTSWrapper mod_sym func_sym param_vts ret_vts =
   ( FunctionImport
-      { internalName = "__asterius_" <> func_sym
-      , externalModuleName = mod_sym
-      , externalBaseName = func_sym
-      , functionType =
-          FunctionType {paramTypes = map fst xs, returnTypes = fst ret}
+      { internalName = "__asterius_" <> func_sym,
+        externalModuleName = mod_sym,
+        externalBaseName = func_sym,
+        functionType = FunctionType
+          { paramTypes = map fst xs,
+            returnTypes = fst ret
+          }
+      },
+    Function
+      { functionType = FunctionType
+          { paramTypes = param_vts,
+            returnTypes = ret_vts
+          },
+        varTypes = [],
+        body = snd
+          ret
+          CallImport
+            { target' = "__asterius_" <> func_sym,
+              operands = map snd xs,
+              callImportReturnTypes = fst ret
+            }
       }
-  , Function
-      { functionType =
-          FunctionType {paramTypes = param_vts, returnTypes = ret_vts}
-      , varTypes = []
-      , body =
-          snd
-            ret
-            CallImport
-              { target' = "__asterius_" <> func_sym
-              , operands = map snd xs
-              , callImportReturnTypes = fst ret
-              }
-      })
+  )
   where
     xs =
       zipWith
-        (\i vt ->
-           case vt of
-             I64 ->
-               ( F64
-               , convertSInt64ToFloat64 GetLocal {index = i, valueType = I64})
-             _ -> (vt, GetLocal {index = i, valueType = vt}))
+        ( \i vt -> case vt of
+            I64 ->
+              (F64, convertSInt64ToFloat64 GetLocal {index = i, valueType = I64})
+            _ -> (vt, GetLocal {index = i, valueType = vt})
+        )
         [0 ..]
         param_vts
-    ret =
-      case ret_vts of
-        [I64] -> ([F64], truncUFloat64ToInt64)
-        _ -> (ret_vts, id)
+    ret = case ret_vts of
+      [I64] -> ([F64], truncUFloat64ToInt64)
+      _ -> (ret_vts, id)
 
 generateWrapperFunction :: AsteriusEntitySymbol -> Function -> Function
 generateWrapperFunction func_sym Function {functionType = FunctionType {..}} =
   Function
-    { functionType =
-        FunctionType
-          { paramTypes =
-              [ wrapper_param_type
-              | (_, wrapper_param_type, _) <- wrapper_param_types
-              ]
-          , returnTypes = wrapper_return_types
-          }
-    , varTypes = []
-    , body =
-        to_wrapper_return_types $
-        Call
-          { target = func_sym
-          , operands =
-              [ from_wrapper_param_type
-                GetLocal {index = i, valueType = wrapper_param_type}
+    { functionType = FunctionType
+        { paramTypes =
+            [ wrapper_param_type
+              | (_, wrapper_param_type, _) <-
+                  wrapper_param_types
+            ],
+          returnTypes = wrapper_return_types
+        },
+      varTypes = [],
+      body = to_wrapper_return_types $ Call
+        { target = func_sym,
+          operands =
+            [ from_wrapper_param_type GetLocal
+                { index = i,
+                  valueType = wrapper_param_type
+                }
               | (i, wrapper_param_type, from_wrapper_param_type) <-
                   wrapper_param_types
-              ]
-          , callReturnTypes = returnTypes
-          }
+            ],
+          callReturnTypes = returnTypes
+        }
     }
   where
     wrapper_param_types =
       [ case param_type of
-        I64 -> (i, F64, truncSFloat64ToInt64)
-        _ -> (i, param_type, id)
-      | (i, param_type) <- zip [0 ..] paramTypes
+          I64 -> (i, F64, truncSFloat64ToInt64)
+          _ -> (i, param_type, id)
+        | (i, param_type) <- zip [0 ..] paramTypes
       ]
-    (wrapper_return_types, to_wrapper_return_types) =
-      case returnTypes of
-        [I64] -> ([F64], convertSInt64ToFloat64)
-        _ -> (returnTypes, id)
+    (wrapper_return_types, to_wrapper_return_types) = case returnTypes of
+      [I64] -> ([F64], convertSInt64ToFloat64)
+      _ -> (returnTypes, id)
 
-
--- | Renames each function in the module to <name>_wrapper, and
--- | edits their implementation using 'generateWrapperFunction'
+-- Renames each function in the module to <name>_wrapper, and
+-- edits their implementation using 'generateWrapperFunction'
 generateWrapperModule :: AsteriusModule -> AsteriusModule
-generateWrapperModule m = m
-   { functionMap = Map.fromList $ map wrap $ Map.toList $ functionMap m
-   }
-   where
-      wrap (n,f) = (n <> "_wrapper", generateWrapperFunction n f)
+generateWrapperModule m =
+  m
+    { functionMap = Map.fromList $ map wrap $ Map.toList $ functionMap m
+    }
+  where
+    wrap (n, f) = (n <> "_wrapper", generateWrapperFunction n f)
 
-
-
-
-hsInitFunction, rtsApplyFunction, rtsGetSchedStatusFunction, rtsCheckSchedStatusFunction, scheduleTSOFunction, createThreadFunction, createGenThreadFunction, createIOThreadFunction, createStrictIOThreadFunction, getThreadIdFunction, allocatePinnedFunction, newCAFFunction, stgReturnFunction, getStablePtrWrapperFunction, deRefStablePtrWrapperFunction, freeStablePtrWrapperFunction, rtsMkBoolFunction, rtsMkDoubleFunction, rtsMkCharFunction, rtsMkIntFunction, rtsMkWordFunction, rtsMkPtrFunction, rtsMkStablePtrFunction, rtsGetBoolFunction, rtsGetDoubleFunction, loadI64Function, printI64Function, assertEqI64Function, printF32Function, printF64Function, strlenFunction, memchrFunction, memcpyFunction, memsetFunction, memcmpFunction, fromJSArrayBufferFunction, toJSArrayBufferFunction, fromJSStringFunction, fromJSArrayFunction, threadPausedFunction, dirtyMutVarFunction, dirtyMVarFunction, dirtyStackFunction, recordClosureMutatedFunction, raiseExceptionHelperFunction, barfFunction, getProgArgvFunction, suspendThreadFunction, scheduleThreadFunction, scheduleThreadOnFunction, resumeThreadFunction, performMajorGCFunction, performGCFunction, localeEncodingFunction, isattyFunction, fdReadyFunction, rtsSupportsBoundThreadsFunction, readFunction, writeFunction, tryWakeupThreadFunction ::
-     BuiltinsOptions -> AsteriusModule
+hsInitFunction,
+  rtsApplyFunction,
+  rtsGetSchedStatusFunction,
+  rtsCheckSchedStatusFunction,
+  scheduleTSOFunction,
+  createThreadFunction,
+  createGenThreadFunction,
+  createIOThreadFunction,
+  createStrictIOThreadFunction,
+  getThreadIdFunction,
+  allocatePinnedFunction,
+  newCAFFunction,
+  stgReturnFunction,
+  getStablePtrWrapperFunction,
+  deRefStablePtrWrapperFunction,
+  freeStablePtrWrapperFunction,
+  rtsMkBoolFunction,
+  rtsMkDoubleFunction,
+  rtsMkCharFunction,
+  rtsMkIntFunction,
+  rtsMkWordFunction,
+  rtsMkPtrFunction,
+  rtsMkStablePtrFunction,
+  rtsGetBoolFunction,
+  rtsGetDoubleFunction,
+  loadI64Function,
+  printI64Function,
+  assertEqI64Function,
+  printF32Function,
+  printF64Function,
+  strlenFunction,
+  memchrFunction,
+  memcpyFunction,
+  memsetFunction,
+  memcmpFunction,
+  fromJSArrayBufferFunction,
+  toJSArrayBufferFunction,
+  fromJSStringFunction,
+  fromJSArrayFunction,
+  threadPausedFunction,
+  dirtyMutVarFunction,
+  dirtyMVarFunction,
+  dirtyStackFunction,
+  recordClosureMutatedFunction,
+  raiseExceptionHelperFunction,
+  barfFunction,
+  getProgArgvFunction,
+  suspendThreadFunction,
+  scheduleThreadFunction,
+  scheduleThreadOnFunction,
+  resumeThreadFunction,
+  performMajorGCFunction,
+  performGCFunction,
+  localeEncodingFunction,
+  isattyFunction,
+  fdReadyFunction,
+  rtsSupportsBoundThreadsFunction,
+  readFunction,
+  writeFunction,
+  tryWakeupThreadFunction ::
+    BuiltinsOptions -> AsteriusModule
 
 initCapability :: EDSL ()
 initCapability = do
@@ -775,8 +952,8 @@ initCapability = do
   storeI64 mainCapability offset_Capability_total_allocated $ constI64 0
   storeI64
     mainCapability
-    (offset_Capability_f + offset_StgFunTable_stgEagerBlackholeInfo) $
-    symbol "__stg_EAGER_BLACKHOLE_info"
+    (offset_Capability_f + offset_StgFunTable_stgEagerBlackholeInfo)
+    $ symbol "__stg_EAGER_BLACKHOLE_info"
   storeI64 mainCapability (offset_Capability_f + offset_StgFunTable_stgGCEnter1) $
     symbol "__stg_gc_enter_1"
   storeI64 mainCapability (offset_Capability_f + offset_StgFunTable_stgGCFun) $
@@ -789,44 +966,40 @@ initCapability = do
   storeI64 mainCapability (offset_Capability_r + offset_StgRegTable_rCurrentTSO) $
     constI64 0
 
-hsInitFunction _ =
-  runEDSL "hs_init" $ do
-    initCapability
-    bd_nursery <-
-      truncUFloat64ToInt64 <$> callImport' "__asterius_hpAlloc" [constF64 8] F64
-    putLVal currentNursery bd_nursery
+hsInitFunction _ = runEDSL "hs_init" $ do
+  initCapability
+  bd_nursery <-
+    truncUFloat64ToInt64 <$> callImport' "__asterius_hpAlloc" [constF64 8] F64
+  putLVal currentNursery bd_nursery
 
 enter, exit :: Int -> EDSL ()
 enter i = callImport "__asterius_enter" [constI32 i]
-
 exit i = callImport "__asterius_exit" [constI32 i]
 
-rtsApplyFunction _ =
-  runEDSL "rts_apply" $ do
-    setReturnTypes [I64]
-    [f, arg] <- params [I64, I64]
-    ap <-
-      call'
-        "allocate"
-        [mainCapability, constI64 $ roundup_bytes_to_words sizeof_StgThunk + 2]
-        I64
-    storeI64 ap 0 $ symbol "stg_ap_2_upd_info"
-    storeI64 ap offset_StgThunk_payload f
-    storeI64 ap (offset_StgThunk_payload + 8) arg
-    emit ap
+rtsApplyFunction _ = runEDSL "rts_apply" $ do
+  setReturnTypes [I64]
+  [f, arg] <- params [I64, I64]
+  ap <-
+    call'
+      "allocate"
+      [mainCapability, constI64 $ roundup_bytes_to_words sizeof_StgThunk + 2]
+      I64
+  storeI64 ap 0 $ symbol "stg_ap_2_upd_info"
+  storeI64 ap offset_StgThunk_payload f
+  storeI64 ap (offset_StgThunk_payload + 8) arg
+  emit ap
 
-rtsGetSchedStatusFunction _ =
-  runEDSL "rts_getSchedStatus" $ do
-    setReturnTypes [I32]
-    tid <- param I32
-    callImport' "__asterius_getTSOrstat" [tid] I32 >>= emit
+rtsGetSchedStatusFunction _ = runEDSL "rts_getSchedStatus" $ do
+  setReturnTypes [I32]
+  tid <- param I32
+  callImport' "__asterius_getTSOrstat" [tid] I32 >>= emit
 
-rtsCheckSchedStatusFunction _ =
-  runEDSL"rts_checkSchedStatus" $ do
-    tid <- param I32
-    stat <- call' "rts_getSchedStatus" [tid] I32
-    if' [] (stat `eqInt32` constI32 scheduler_Success) mempty $
-      emit $ emitErrorMessage [] "IllegalSchedulerStatusCode"
+rtsCheckSchedStatusFunction _ = runEDSL "rts_checkSchedStatus" $ do
+  tid <- param I32
+  stat <- call' "rts_getSchedStatus" [tid] I32
+  if' [] (stat `eqInt32` constI32 scheduler_Success) mempty
+    $ emit
+    $ emitErrorMessage [] "IllegalSchedulerStatusCode"
 
 dirtyTSO :: Expression -> Expression -> EDSL ()
 dirtyTSO _ tso =
@@ -844,83 +1017,82 @@ dirtySTACK _ stack =
     (storeI32 stack offset_StgStack_dirty $ constI32 1)
     mempty
 
--- | `_scheduleTSO(tso,func)` executes the given tso starting at the given
+-- `_scheduleTSO(tso,func)` executes the given tso starting at the given
 -- function
-scheduleTSOFunction BuiltinsOptions {} =
-  runEDSL "scheduleTSO" $ do
-    [tso,func] <- params [I64,I64]
-    -- store the current TSO
-    putLVal currentTSO tso
-    -- indicate in the Capability that we are running the TSO
-    -- TODO: remove all the useless Capability related stuff
-    storeI64
-      mainCapability
-      (offset_Capability_r + offset_StgRegTable_rCurrentTSO)
-      tso
-    storeI32 mainCapability offset_Capability_interrupt $ constI32 0
-    storeI32 mainCapability offset_Capability_idle $ constI32 0
-    dirtyTSO mainCapability tso
-    dirtySTACK mainCapability (loadI64 tso offset_StgTSO_stackobj)
-    -- execute the TSO (using stgRun trampolining machinery)
-    stgRun func
-    -- indicate in the Capability that we are not running anything
-    storeI64
-      mainCapability
-      (offset_Capability_r + offset_StgRegTable_rCurrentTSO)
-      (constI64 0)
-    storeI32 mainCapability offset_Capability_interrupt $ constI32 1
-    storeI32 mainCapability offset_Capability_idle $ constI32 1
-    -- unset the current TSO
-    putLVal currentTSO (constI64 0)
+scheduleTSOFunction BuiltinsOptions {} = runEDSL "scheduleTSO" $ do
+  [tso, func] <- params [I64, I64]
+  -- store the current TSO
+  putLVal currentTSO tso
+  -- indicate in the Capability that we are running the TSO
+  -- TODO: remove all the useless Capability related stuff
+  storeI64
+    mainCapability
+    (offset_Capability_r + offset_StgRegTable_rCurrentTSO)
+    tso
+  storeI32 mainCapability offset_Capability_interrupt $ constI32 0
+  storeI32 mainCapability offset_Capability_idle $ constI32 0
+  dirtyTSO mainCapability tso
+  dirtySTACK mainCapability (loadI64 tso offset_StgTSO_stackobj)
+  -- execute the TSO (using stgRun trampolining machinery)
+  stgRun func
+  -- indicate in the Capability that we are not running anything
+  storeI64
+    mainCapability
+    (offset_Capability_r + offset_StgRegTable_rCurrentTSO)
+    (constI64 0)
+  storeI32 mainCapability offset_Capability_interrupt $ constI32 1
+  storeI32 mainCapability offset_Capability_idle $ constI32 1
+  -- unset the current TSO
+  putLVal currentTSO (constI64 0)
 
--- | Return the thread ID of the given tso
-getThreadIdFunction BuiltinsOptions {} =
-  runEDSL "rts_getThreadId" $ do
-    setReturnTypes [I64]
-    tso <- param I64
-    emit (extendUInt32 (loadI32 tso offset_StgTSO_id))
+-- Return the thread ID of the given tso
+getThreadIdFunction BuiltinsOptions {} = runEDSL "rts_getThreadId" $ do
+  setReturnTypes [I64]
+  tso <- param I64
+  emit (extendUInt32 (loadI32 tso offset_StgTSO_id))
 
-createThreadFunction BuiltinsOptions {..} =
-  runEDSL "createThread" $ do
-    setReturnTypes [I64]
-    let alloc_words = constI64 $ roundup_bytes_to_words threadStateSize
-    tso_p <- call' "allocatePinned" [mainCapability, alloc_words] I64
-    stack_p <- i64Local $ tso_p `addInt64` constI64 offset_StgTSO_StgStack
-    storeI64 stack_p 0 $ symbol "stg_STACK_info"
-    stack_size_w <-
-      i64Local $
-      alloc_words `subInt64`
-      constI64 ((offset_StgTSO_StgStack + offset_StgStack_stack) `div` 8)
-    storeI32 stack_p offset_StgStack_stack_size $ wrapInt64 stack_size_w
-    storeI64 stack_p offset_StgStack_sp $
-      (stack_p `addInt64` constI64 offset_StgStack_stack) `addInt64`
-      (stack_size_w `mulInt64` constI64 8)
-    storeI32 stack_p offset_StgStack_dirty $ constI32 1
-    storeI64 tso_p 0 $ symbol "stg_TSO_info"
-    storeI16 tso_p offset_StgTSO_what_next $ constI32 next_ThreadRunGHC
-    storeI16 tso_p offset_StgTSO_why_blocked $ constI32 blocked_NotBlocked
-    storeI64 tso_p offset_StgTSO_blocked_exceptions $
-      symbol "stg_END_TSO_QUEUE_closure"
-    storeI32 tso_p offset_StgTSO_flags $ constI32 0
-    storeI32 tso_p offset_StgTSO_dirty $ constI32 1
-    storeI32 tso_p offset_StgTSO_saved_errno $ constI32 0
-    storeI64 tso_p offset_StgTSO_cap mainCapability
-    storeI64 tso_p offset_StgTSO_stackobj stack_p
-    storeI32 tso_p offset_StgTSO_tot_stack_size $ wrapInt64 stack_size_w
-    storeI64 tso_p offset_StgTSO_alloc_limit (constI64 0)
-    storeI64 stack_p offset_StgStack_sp $
-      loadI64 stack_p offset_StgStack_sp `subInt64`
-      constI64 (8 * roundup_bytes_to_words sizeof_StgStopFrame)
-    storeI64 (loadI64 stack_p offset_StgStack_sp) 0 $
-      symbol "stg_stop_thread_info"
-    callImport' "__asterius_newTSO" [] I32 >>= storeI32 tso_p offset_StgTSO_id
-    emit tso_p
+createThreadFunction BuiltinsOptions {..} = runEDSL "createThread" $ do
+  setReturnTypes [I64]
+  let alloc_words = constI64 $ roundup_bytes_to_words threadStateSize
+  tso_p <- call' "allocatePinned" [mainCapability, alloc_words] I64
+  stack_p <- i64Local $ tso_p `addInt64` constI64 offset_StgTSO_StgStack
+  storeI64 stack_p 0 $ symbol "stg_STACK_info"
+  stack_size_w <-
+    i64Local $
+      alloc_words
+        `subInt64` constI64
+          ((offset_StgTSO_StgStack + offset_StgStack_stack) `div` 8)
+  storeI32 stack_p offset_StgStack_stack_size $ wrapInt64 stack_size_w
+  storeI64 stack_p offset_StgStack_sp $
+    (stack_p `addInt64` constI64 offset_StgStack_stack)
+      `addInt64` (stack_size_w `mulInt64` constI64 8)
+  storeI32 stack_p offset_StgStack_dirty $ constI32 1
+  storeI64 tso_p 0 $ symbol "stg_TSO_info"
+  storeI16 tso_p offset_StgTSO_what_next $ constI32 next_ThreadRunGHC
+  storeI16 tso_p offset_StgTSO_why_blocked $ constI32 blocked_NotBlocked
+  storeI64 tso_p offset_StgTSO_blocked_exceptions $
+    symbol "stg_END_TSO_QUEUE_closure"
+  storeI32 tso_p offset_StgTSO_flags $ constI32 0
+  storeI32 tso_p offset_StgTSO_dirty $ constI32 1
+  storeI32 tso_p offset_StgTSO_saved_errno $ constI32 0
+  storeI64 tso_p offset_StgTSO_cap mainCapability
+  storeI64 tso_p offset_StgTSO_stackobj stack_p
+  storeI32 tso_p offset_StgTSO_tot_stack_size $ wrapInt64 stack_size_w
+  storeI64 tso_p offset_StgTSO_alloc_limit (constI64 0)
+  storeI64 stack_p offset_StgStack_sp $
+    loadI64 stack_p offset_StgStack_sp
+      `subInt64` constI64 (8 * roundup_bytes_to_words sizeof_StgStopFrame)
+  storeI64 (loadI64 stack_p offset_StgStack_sp) 0 $
+    symbol "stg_stop_thread_info"
+  callImport' "__asterius_newTSO" [] I32 >>= storeI32 tso_p offset_StgTSO_id
+  emit tso_p
 
 pushClosure :: Expression -> Expression -> EDSL ()
 pushClosure tso c = do
   stack_p <- i64Local $ loadI64 tso offset_StgTSO_stackobj
   storeI64 stack_p offset_StgStack_sp $
-    loadI64 stack_p offset_StgStack_sp `subInt64` constI64 8
+    loadI64 stack_p offset_StgStack_sp
+      `subInt64` constI64 8
   storeI64 (loadI64 stack_p offset_StgStack_sp) 0 c
 
 createThreadHelper :: (Expression -> [Expression]) -> EDSL ()
@@ -932,34 +1104,34 @@ createThreadHelper mk_closures = do
   emit t
 
 createGenThreadFunction _ =
-  runEDSL "createGenThread" $
-  createThreadHelper $ \closure -> [closure, symbol "stg_enter_info"]
+  runEDSL "createGenThread" $ createThreadHelper $ \closure ->
+    [closure, symbol "stg_enter_info"]
 
 createIOThreadFunction _ =
-  runEDSL "createIOThread" $
-  createThreadHelper $ \closure ->
+  runEDSL "createIOThread" $ createThreadHelper $ \closure ->
     [symbol "stg_ap_v_info", closure, symbol "stg_enter_info"]
 
 createStrictIOThreadFunction _ =
-  runEDSL "createStrictIOThread"  $
-  createThreadHelper $ \closure ->
-    [ symbol "stg_forceIO_info"
-    , symbol "stg_ap_v_info"
-    , closure
-    , symbol "stg_enter_info"
+  runEDSL "createStrictIOThread" $ createThreadHelper $ \closure ->
+    [ symbol "stg_forceIO_info",
+      symbol "stg_ap_v_info",
+      closure,
+      symbol "stg_enter_info"
     ]
 
-
-genAllocateFunction :: BuiltinsOptions
-    -> AsteriusEntitySymbol -- ^ Name of the allocation function
-    ->  AsteriusModule -- ^ Module representing the function
-genAllocateFunction (BuiltinsOptions {}) n =
-  runEDSL n $ do
-    setReturnTypes [I64]
-    [_, n] <- params [I64, I64]
-    (truncUFloat64ToInt64 <$>
-     callImport' "__asterius_allocate" [convertUInt64ToFloat64 n] F64) >>=
-      emit
+genAllocateFunction ::
+  BuiltinsOptions ->
+  -- Name of the allocation function
+  AsteriusEntitySymbol ->
+  -- Module representing the function
+  AsteriusModule
+genAllocateFunction (BuiltinsOptions {}) n = runEDSL n $ do
+  setReturnTypes [I64]
+  [_, n] <- params [I64, I64]
+  ( truncUFloat64ToInt64
+      <$> callImport' "__asterius_allocate" [convertUInt64ToFloat64 n] F64
+    )
+    >>= emit
 
 {-
 allocateFunction BuiltinsOptions {} =
@@ -970,34 +1142,32 @@ allocateFunction BuiltinsOptions {} =
      callImport' "__asterius_allocate" [convertUInt64ToFloat64 n] F64) >>=
       emit
   -}
+allocatePinnedFunction _ = runEDSL "allocatePinned" $ do
+  setReturnTypes [I64]
+  [_, n] <- params [I64, I64]
+  ( truncUFloat64ToInt64
+      <$> callImport' "__asterius_allocatePinned" [convertUInt64ToFloat64 n] F64
+    )
+    >>= emit
 
-allocatePinnedFunction _ =
-  runEDSL "allocatePinned" $ do
-    setReturnTypes [I64]
-    [_, n] <- params [I64, I64]
-    (truncUFloat64ToInt64 <$>
-     callImport' "__asterius_allocatePinned" [convertUInt64ToFloat64 n] F64) >>=
-      emit
+newCAFFunction _ = runEDSL "newCAF" $ do
+  setReturnTypes [I64]
+  [reg, caf] <- params [I64, I64]
+  orig_info <- i64Local $ loadI64 caf 0
+  storeI64 caf offset_StgIndStatic_saved_info orig_info
+  bh <-
+    call'
+      "allocate"
+      [mainCapability, constI64 $ roundup_bytes_to_words sizeof_StgInd]
+      I64
+  storeI64 bh 0 $ symbol "stg_CAF_BLACKHOLE_info"
+  storeI64 bh offset_StgInd_indirectee $
+    loadI64 reg offset_StgRegTable_rCurrentTSO
+  storeI64 caf offset_StgIndStatic_indirectee bh
+  storeI64 caf 0 $ symbol "stg_IND_STATIC_info"
+  emit bh
 
-newCAFFunction _ =
-  runEDSL "newCAF" $ do
-    setReturnTypes [I64]
-    [reg, caf] <- params [I64, I64]
-    orig_info <- i64Local $ loadI64 caf 0
-    storeI64 caf offset_StgIndStatic_saved_info orig_info
-    bh <-
-      call'
-        "allocate"
-        [mainCapability, constI64 $ roundup_bytes_to_words sizeof_StgInd]
-        I64
-    storeI64 bh 0 $ symbol "stg_CAF_BLACKHOLE_info"
-    storeI64 bh offset_StgInd_indirectee $
-      loadI64 reg offset_StgRegTable_rCurrentTSO
-    storeI64 caf offset_StgIndStatic_indirectee bh
-    storeI64 caf 0 $ symbol "stg_IND_STATIC_info"
-    emit bh
-
--- | Repeatedly calls the function pointed by ``__asterius_pc`` until this
+-- Repeatedly calls the function pointed by ``__asterius_pc`` until this
 -- pointer is NULL.
 --
 -- This trampolining code is required to implement indirect tail-calls: instead
@@ -1015,88 +1185,93 @@ stgRun init_f = do
       callIndirect (getLVal pc_reg)
       break' loop_lbl Nothing
 
--- | Return from a STG function
+-- Return from a STG function
 stgReturnFunction _ =
-  -- store NULL in the __asterius_pc register. This will break stgRun
-  -- trampolining loop.
-  runEDSL "StgReturn" $ storeI64 (symbol "__asterius_pc") 0 $ constI64 0
+  runEDSL "StgReturn" $ storeI64 (symbol "__asterius_pc") 0 $ constI64 0 -- store NULL in the __asterius_pc register. This will break stgRun
+      -- trampolining loop.
 
-getStablePtrWrapperFunction _ =
-  runEDSL "getStablePtr"  $ do
-    setReturnTypes [I64]
-    obj64 <- param I64
-    sp_f64 <-
-      callImport' "__asterius_newStablePtr" [convertUInt64ToFloat64 obj64] F64
-    emit $ truncUFloat64ToInt64 sp_f64
+getStablePtrWrapperFunction _ = runEDSL "getStablePtr" $ do
+  setReturnTypes [I64]
+  obj64 <- param I64
+  sp_f64 <-
+    callImport'
+      "__asterius_newStablePtr"
+      [convertUInt64ToFloat64 obj64]
+      F64
+  emit $ truncUFloat64ToInt64 sp_f64
 
-deRefStablePtrWrapperFunction _ =
-  runEDSL "deRefStablePtr" $ do
-    setReturnTypes [I64]
-    sp64 <- param I64
-    obj_f64 <-
-      callImport' "__asterius_deRefStablePtr" [convertUInt64ToFloat64 sp64] F64
-    emit $ truncUFloat64ToInt64 obj_f64
+deRefStablePtrWrapperFunction _ = runEDSL "deRefStablePtr" $ do
+  setReturnTypes [I64]
+  sp64 <- param I64
+  obj_f64 <-
+    callImport'
+      "__asterius_deRefStablePtr"
+      [convertUInt64ToFloat64 sp64]
+      F64
+  emit $ truncUFloat64ToInt64 obj_f64
 
-freeStablePtrWrapperFunction _ =
-  runEDSL"hs_free_stable_ptr"  $ do
-    sp64 <- param I64
-    callImport "__asterius_freeStablePtr" [convertUInt64ToFloat64 sp64]
+freeStablePtrWrapperFunction _ = runEDSL "hs_free_stable_ptr" $ do
+  sp64 <- param I64
+  callImport "__asterius_freeStablePtr" [convertUInt64ToFloat64 sp64]
 
-makeStableNameWrapperFunction _ =
-  runEDSL "makeStableName" $ do
-    setReturnTypes [I64]
-    sp64 <- param I64
-    obj_f64 <-
-      callImport' "__asterius_makeStableName" [convertUInt64ToFloat64 sp64] F64
-    emit $ truncUFloat64ToInt64 obj_f64
+makeStableNameWrapperFunction _ = runEDSL "makeStableName" $ do
+  setReturnTypes [I64]
+  sp64 <- param I64
+  obj_f64 <-
+    callImport'
+      "__asterius_makeStableName"
+      [convertUInt64ToFloat64 sp64]
+      F64
+  emit $ truncUFloat64ToInt64 obj_f64
 
 rtsMkHelper ::
-   BuiltinsOptions
-  -> AsteriusEntitySymbol -- ^ Name of the function to be built
-  -> AsteriusEntitySymbol -- ^ Mangled name of the primop constructor
-  -> AsteriusModule
-rtsMkHelper _ n con_sym =
-  runEDSL n  $ do
-    setReturnTypes [I64]
-    [i] <- params [I64]
-    p <- call' "allocate" [mainCapability, constI64 2] I64
-    storeI64 p 0 $ symbol con_sym
-    storeI64 p 8 i
-    emit p
+  BuiltinsOptions ->
+  -- Name of the function to be built
+  AsteriusEntitySymbol ->
+  -- Mangled name of the primop constructor
+  AsteriusEntitySymbol ->
+  AsteriusModule
+rtsMkHelper _ n con_sym = runEDSL n $ do
+  setReturnTypes [I64]
+  [i] <- params [I64]
+  p <- call' "allocate" [mainCapability, constI64 2] I64
+  storeI64 p 0 $ symbol con_sym
+  storeI64 p 8 i
+  emit p
 
-rtsMkBoolFunction _ =
-  runEDSL "rts_mkBool" $ do
-    setReturnTypes [I64]
-    [i] <- params [I64]
-    if'
-      [I64]
-      (eqZInt64 i)
-      (emit $ symbol' "ghczmprim_GHCziTypes_False_closure" 1)
-      (emit $ symbol' "ghczmprim_GHCziTypes_True_closure" 2)
+rtsMkBoolFunction _ = runEDSL "rts_mkBool" $ do
+  setReturnTypes [I64]
+  [i] <- params [I64]
+  if'
+    [I64]
+    (eqZInt64 i)
+    (emit $ symbol' "ghczmprim_GHCziTypes_False_closure" 1)
+    (emit $ symbol' "ghczmprim_GHCziTypes_True_closure" 2)
 
-rtsMkDoubleFunction _ =
-  runEDSL "rts_mkDouble" $ do
-    setReturnTypes [I64]
-    [i] <- params [F64]
-    p <- call' "allocate" [mainCapability, constI64 2] I64
-    storeI64 p 0 $ symbol "ghczmprim_GHCziTypes_Dzh_con_info"
-    storeF64 p 8 i
-    emit p
+rtsMkDoubleFunction _ = runEDSL "rts_mkDouble" $ do
+  setReturnTypes [I64]
+  [i] <- params [F64]
+  p <- call' "allocate" [mainCapability, constI64 2] I64
+  storeI64 p 0 $ symbol "ghczmprim_GHCziTypes_Dzh_con_info"
+  storeF64 p 8 i
+  emit p
 
-rtsMkCharFunction _ =
-  runEDSL "rts_mkChar" $ do
-    setReturnTypes [I64]
-    [i] <- params [I64]
-    p <- call' "allocate" [mainCapability, constI64 2] I64
-    storeI64 p 0 $ symbol "ghczmprim_GHCziTypes_Czh_con_info"
-    storeI64 p 8 i
-    emit p
+rtsMkCharFunction _ = runEDSL "rts_mkChar" $ do
+  setReturnTypes [I64]
+  [i] <- params [I64]
+  p <- call' "allocate" [mainCapability, constI64 2] I64
+  storeI64 p 0 $ symbol "ghczmprim_GHCziTypes_Czh_con_info"
+  storeI64 p 8 i
+  emit p
 
-rtsMkIntFunction opts = rtsMkHelper opts "rts_mkInt" "ghczmprim_GHCziTypes_Izh_con_info"
+rtsMkIntFunction opts =
+  rtsMkHelper opts "rts_mkInt" "ghczmprim_GHCziTypes_Izh_con_info"
 
-rtsMkWordFunction opts = rtsMkHelper opts "rts_mkWord" "ghczmprim_GHCziTypes_Wzh_con_info"
+rtsMkWordFunction opts =
+  rtsMkHelper opts "rts_mkWord" "ghczmprim_GHCziTypes_Wzh_con_info"
 
-rtsMkPtrFunction opts = rtsMkHelper opts "rts_mkPtr" "base_GHCziPtr_Ptr_con_info"
+rtsMkPtrFunction opts =
+  rtsMkHelper opts "rts_mkPtr" "base_GHCziPtr_Ptr_con_info"
 
 rtsMkStablePtrFunction opts =
   rtsMkHelper opts "rts_mkStablePtr" "base_GHCziStable_StablePtr_con_info"
@@ -1104,35 +1279,30 @@ rtsMkStablePtrFunction opts =
 unTagClosure :: Expression -> Expression
 unTagClosure p = p `andInt64` constI64 0xFFFFFFFFFFFFFFF8
 
-rtsGetBoolFunction _ =
-  runEDSL "rts_getBool" $ do
-    setReturnTypes [I64]
-    p <- param I64
-    emit $
-      extendUInt32 $
-      neInt32
-        (constI32 0)
-        (loadI32 (loadI64 (unTagClosure p) 0) offset_StgInfoTable_srt)
+rtsGetBoolFunction _ = runEDSL "rts_getBool" $ do
+  setReturnTypes [I64]
+  p <- param I64
+  emit $ extendUInt32 $
+    neInt32
+      (constI32 0)
+      (loadI32 (loadI64 (unTagClosure p) 0) offset_StgInfoTable_srt)
 
-rtsGetDoubleFunction _ =
-  runEDSL "rts_getDouble" $ do
-    setReturnTypes [F64]
-    p <- param I64
-    emit $ loadF64 (unTagClosure p) offset_StgClosure_payload
+rtsGetDoubleFunction _ = runEDSL "rts_getDouble" $ do
+  setReturnTypes [F64]
+  p <- param I64
+  emit $ loadF64 (unTagClosure p) offset_StgClosure_payload
 
 -- rtsGetCharFunction = rtsGetIntFunction
-
 -- generate a function which internally performs getInt, but is
 -- named differently
-generateRtsGetIntFunction :: BuiltinsOptions
-  -> AsteriusEntitySymbol -- Name of the function
-  -> AsteriusModule
-generateRtsGetIntFunction _ n =
-  runEDSL n $ do
-    setReturnTypes [I64]
-    p <- param I64
-    emit $ loadI64 (unTagClosure p) offset_StgClosure_payload
-
+generateRtsGetIntFunction ::
+  BuiltinsOptions ->
+  AsteriusEntitySymbol -> -- Name of the function
+  AsteriusModule
+generateRtsGetIntFunction _ n = runEDSL n $ do
+  setReturnTypes [I64]
+  p <- param I64
+  emit $ loadI64 (unTagClosure p) offset_StgClosure_payload
 
 {-
 rtsGetIntFunction _ =
@@ -1141,258 +1311,231 @@ rtsGetIntFunction _ =
     p <- param I64
     emit $ loadI64 (unTagClosure p) offset_StgClosure_payload
 -}
+loadI64Function _ = runEDSL "loadI64" $ do
+  setReturnTypes [I64]
+  p <- param I64
+  emit $ loadI64 p 0
 
-loadI64Function _ =
-  runEDSL "loadI64"  $ do
-    setReturnTypes [I64]
-    p <- param I64
-    emit $ loadI64 p 0
+printI64Function _ = runEDSL "print_i64" $ do
+  x <- param I64
+  callImport "printI64" [convertSInt64ToFloat64 x]
 
-printI64Function _ =
-  runEDSL "print_i64" $ do
-    x <- param I64
-    callImport "printI64" [convertSInt64ToFloat64 x]
+assertEqI64Function _ = runEDSL "assert_eq_i64" $ do
+  x <- param I64
+  y <- param I64
+  callImport "assertEqI64" [convertSInt64ToFloat64 x, convertSInt64ToFloat64 y]
 
-assertEqI64Function _ =
-  runEDSL "assert_eq_i64"  $ do
-    x <- param I64
-    y <- param I64
-    callImport
-      "assertEqI64"
-      [convertSInt64ToFloat64 x, convertSInt64ToFloat64 y]
+printF32Function _ = runEDSL "print_f32" $ do
+  x <- param F32
+  callImport "printF32" [x]
 
-printF32Function _ =
-  runEDSL "print_f32" $ do
-    x <- param F32
-    callImport "printF32" [x]
+printF64Function _ = runEDSL "print_f64" $ do
+  x <- param F64
+  callImport "printF64" [x]
 
-printF64Function _ =
-  runEDSL "print_f64" $ do
-    x <- param F64
-    callImport "printF64" [x]
+strlenFunction _ = runEDSL "strlen" $ do
+  setReturnTypes [I64]
+  [str] <- params [I64]
+  len <- callImport' "__asterius_strlen" [convertUInt64ToFloat64 str] F64
+  emit $ truncUFloat64ToInt64 len
 
-strlenFunction _ =
-  runEDSL "strlen"  $ do
-    setReturnTypes [I64]
-    [str] <- params [I64]
-    len <- callImport' "__asterius_strlen" [convertUInt64ToFloat64 str] F64
-    emit $ truncUFloat64ToInt64 len
+debugBelch2Function _ = runEDSL "debugBelch2" $ do
+  [fmt, str] <- params [I64, I64]
+  callImport
+    "__asterius_debugBelch2"
+    [convertUInt64ToFloat64 fmt, convertUInt64ToFloat64 str]
 
+memchrFunction _ = runEDSL "memchr" $ do
+  setReturnTypes [I64]
+  [ptr, val, num] <- params [I64, I64, I64]
+  p <-
+    callImport'
+      "__asterius_memchr"
+      (map convertUInt64ToFloat64 [ptr, val, num])
+      F64
+  emit $ truncUFloat64ToInt64 p
 
-debugBelch2Function _ =
-  runEDSL "debugBelch2"  $ do
-    [fmt, str] <- params [I64, I64]
-    callImport "__asterius_debugBelch2" [convertUInt64ToFloat64 fmt, convertUInt64ToFloat64 str]
+memcpyFunction _ = runEDSL "memcpy" $ do
+  setReturnTypes [I64]
+  [dst, src, n] <- params [I64, I64, I64]
+  callImport "__asterius_memcpy" $ map convertUInt64ToFloat64 [dst, src, n]
+  emit dst
 
-memchrFunction _ =
-  runEDSL "memchr"  $ do
-    setReturnTypes [I64]
-    [ptr, val, num] <- params [I64, I64, I64]
-    p <-
-      callImport'
-        "__asterius_memchr"
-        (map convertUInt64ToFloat64 [ptr, val, num])
-        F64
-    emit $ truncUFloat64ToInt64 p
+memsetFunction _ = runEDSL "memset" $ do
+  setReturnTypes [I64]
+  [dst, c, n] <- params [I64, I64, I64]
+  callImport "__asterius_memset" $ map convertUInt64ToFloat64 [dst, c, n]
+  emit dst
 
-memcpyFunction _ =
-  runEDSL "memcpy" $ do
-    setReturnTypes [I64]
-    [dst, src, n] <- params [I64, I64, I64]
-    callImport "__asterius_memcpy" $ map convertUInt64ToFloat64 [dst, src, n]
-    emit dst
+memcmpFunction _ = runEDSL "memcmp" $ do
+  setReturnTypes [I64]
+  [ptr1, ptr2, n] <- params [I64, I64, I64]
+  cres <-
+    callImport'
+      "__asterius_memcmp"
+      (map convertUInt64ToFloat64 [ptr1, ptr2, n])
+      I32
+  emit $ Unary ExtendSInt32 cres
 
-memsetFunction _ =
-  runEDSL "memset" $ do
-    setReturnTypes [I64]
-    [dst, c, n] <- params [I64, I64, I64]
-    callImport "__asterius_memset" $ map convertUInt64ToFloat64 [dst, c, n]
-    emit dst
-
-memcmpFunction _ =
-  runEDSL "memcmp" $ do
-    setReturnTypes [I64]
-    [ptr1, ptr2, n] <- params [I64, I64, I64]
-    cres <-
-      callImport'
-        "__asterius_memcmp"
-        (map convertUInt64ToFloat64 [ptr1, ptr2, n])
-        I32
-    emit $ Unary ExtendSInt32 cres
-
-fromJSArrayBufferFunction _ =
-  runEDSL "__asterius_fromJSArrayBuffer" $ do
-    setReturnTypes [I64]
-    [buf] <- params [I64]
-    addr <-
-      truncUFloat64ToInt64 <$>
-      callImport'
+fromJSArrayBufferFunction _ = runEDSL "__asterius_fromJSArrayBuffer" $ do
+  setReturnTypes [I64]
+  [buf] <- params [I64]
+  addr <-
+    truncUFloat64ToInt64
+      <$> callImport'
         "__asterius_fromJSArrayBuffer_imp"
         [convertUInt64ToFloat64 buf]
         F64
-    emit addr
+  emit addr
 
-toJSArrayBufferFunction _ =
-  runEDSL "__asterius_toJSArrayBuffer"  $ do
-    setReturnTypes [I64]
-    [addr, len] <- params [I64, I64]
-    r <-
-      truncUFloat64ToInt64 <$>
-      callImport'
+toJSArrayBufferFunction _ = runEDSL "__asterius_toJSArrayBuffer" $ do
+  setReturnTypes [I64]
+  [addr, len] <- params [I64, I64]
+  r <-
+    truncUFloat64ToInt64
+      <$> callImport'
         "__asterius_toJSArrayBuffer_imp"
         (map convertUInt64ToFloat64 [addr, len])
         F64
-    emit r
+  emit r
 
-fromJSStringFunction _ =
-  runEDSL "__asterius_fromJSString"  $ do
-    setReturnTypes [I64]
-    [s] <- params [I64]
-    addr <-
-      truncUFloat64ToInt64 <$>
-      callImport' "__asterius_fromJSString_imp" [convertUInt64ToFloat64 s] F64
-    emit addr
+fromJSStringFunction _ = runEDSL "__asterius_fromJSString" $ do
+  setReturnTypes [I64]
+  [s] <- params [I64]
+  addr <-
+    truncUFloat64ToInt64
+      <$> callImport'
+        "__asterius_fromJSString_imp"
+        [convertUInt64ToFloat64 s]
+        F64
+  emit addr
 
-fromJSArrayFunction _ =
-  runEDSL "__asterius_fromJSArray"  $ do
-    setReturnTypes [I64]
-    [arr] <- params [I64]
-    addr <-
-      truncUFloat64ToInt64 <$>
-      callImport' "__asterius_fromJSArray_imp" [convertUInt64ToFloat64 arr] F64
-    emit addr
+fromJSArrayFunction _ = runEDSL "__asterius_fromJSArray" $ do
+  setReturnTypes [I64]
+  [arr] <- params [I64]
+  addr <-
+    truncUFloat64ToInt64
+      <$> callImport'
+        "__asterius_fromJSArray_imp"
+        [convertUInt64ToFloat64 arr]
+        F64
+  emit addr
 
-threadPausedFunction _ =
-  runEDSL "threadPaused" $ do
-    args <- params [I64, I64]
-    callImport "__asterius_threadPaused" $ map convertUInt64ToFloat64 args
+threadPausedFunction _ = runEDSL "threadPaused" $ do
+  args <- params [I64, I64]
+  callImport "__asterius_threadPaused" $ map convertUInt64ToFloat64 args
 
-dirtyMutVarFunction _ =
-  runEDSL "dirty_MUT_VAR" $ do
-    [_, p] <- params [I64, I64]
-    if'
-      []
-      (loadI64 p 0 `eqInt64` symbol "stg_MUT_VAR_CLEAN_info")
-      (storeI64 p 0 $ symbol "stg_MUT_VAR_DIRTY_info")
-      mempty
-
-dirtyMVarFunction _ =
-  runEDSL "dirty_MVAR" $ do
-    [_basereg,_mvar] <- params [I64,I64]
+dirtyMutVarFunction _ = runEDSL "dirty_MUT_VAR" $ do
+  [_, p] <- params [I64, I64]
+  if'
+    []
+    (loadI64 p 0 `eqInt64` symbol "stg_MUT_VAR_CLEAN_info")
+    (storeI64 p 0 $ symbol "stg_MUT_VAR_DIRTY_info")
     mempty
 
-dirtyStackFunction _ =
-  runEDSL "dirty_STACK" $ do
-    [cap,stack] <- params [I64,I64]
-    dirtySTACK cap stack
+dirtyMVarFunction _ = runEDSL "dirty_MVAR" $ do
+  [_basereg, _mvar] <- params [I64, I64]
+  mempty
 
-recordClosureMutatedFunction _ =
-  runEDSL "recordClosureMutated" $ do
-    [_cap,_closure] <- params [I64,I64]
-    mempty
+dirtyStackFunction _ = runEDSL "dirty_STACK" $ do
+  [cap, stack] <- params [I64, I64]
+  dirtySTACK cap stack
 
-tryWakeupThreadFunction _ =
-  runEDSL "tryWakeupThread" $ do
-    [_cap, tso] <- params [I64, I64]
-    callImport "__asterius_enqueueTSO" [convertUInt64ToFloat64 tso]
+recordClosureMutatedFunction _ = runEDSL "recordClosureMutated" $ do
+  [_cap, _closure] <- params [I64, I64]
+  mempty
 
-raiseExceptionHelperFunction _ =
-  runEDSL "raiseExceptionHelper" $ do
-    setReturnTypes [I64]
-    args <- params [I64, I64, I64]
-    frame_type <-
-      truncUFloat64ToInt64 <$>
-      callImport'
+tryWakeupThreadFunction _ = runEDSL "tryWakeupThread" $ do
+  [_cap, tso] <- params [I64, I64]
+  callImport "__asterius_enqueueTSO" [convertUInt64ToFloat64 tso]
+
+raiseExceptionHelperFunction _ = runEDSL "raiseExceptionHelper" $ do
+  setReturnTypes [I64]
+  args <- params [I64, I64, I64]
+  frame_type <-
+    truncUFloat64ToInt64
+      <$> callImport'
         "__asterius_raiseExceptionHelper"
         (map convertUInt64ToFloat64 args)
         F64
-    emit frame_type
+  emit frame_type
 
-barfFunction _ =
-  runEDSL "barf" $ do
-    s <- param I64
-    callImport "__asterius_barf" [convertUInt64ToFloat64 s]
+barfFunction _ = runEDSL "barf" $ do
+  s <- param I64
+  callImport "__asterius_barf" [convertUInt64ToFloat64 s]
 
--- | Note that generateRTSWrapper will treat all our numbers as signed, not
+-- Note that generateRTSWrapper will treat all our numbers as signed, not
 -- unsigned.   This is OK for ASCII code, since the ints we have will not be
 -- larger than 2^15.  However, for larger numbers, it would "overflow", and
 -- would treat large unsigned  numbers as negative signed numbers.
 unicodeCBits :: [(AsteriusEntitySymbol, (FunctionImport, Function))]
-unicodeCBits = map
-    (\(func_sym, param_vts, ret_vts) ->
-       ( AsteriusEntitySymbol func_sym
-       , generateRTSWrapper "Unicode" func_sym param_vts ret_vts))
-    [ ("u_gencat", [I64], [I64])
-    , ("u_iswalpha", [I64], [I64])
-    , ("u_iswalnum", [I64], [I64])
-    , ("u_iswupper", [I64], [I64])
-    , ("u_iswlower", [I64], [I64])
-    , ("u_towlower", [I64], [I64])
-    , ("u_towupper", [I64], [I64])
-    , ("u_towtitle", [I64], [I64])
-    , ("u_iswcntrl", [I64], [I64])
-    , ("u_iswprint", [I64], [I64])
+unicodeCBits =
+  map
+    ( \(func_sym, param_vts, ret_vts) ->
+        ( AsteriusEntitySymbol func_sym,
+          generateRTSWrapper "Unicode" func_sym param_vts ret_vts
+        )
+    )
+    [ ("u_gencat", [I64], [I64]),
+      ("u_iswalpha", [I64], [I64]),
+      ("u_iswalnum", [I64], [I64]),
+      ("u_iswupper", [I64], [I64]),
+      ("u_iswlower", [I64], [I64]),
+      ("u_towlower", [I64], [I64]),
+      ("u_towupper", [I64], [I64]),
+      ("u_towtitle", [I64], [I64]),
+      ("u_iswcntrl", [I64], [I64]),
+      ("u_iswprint", [I64], [I64])
     ]
 
-getProgArgvFunction _ =
-  runEDSL "getProgArgv" $ do
-    [argc, argv] <- params [I64, I64]
-    storeI64 argc 0 $ constI64 1
-    storeI64 argv 0 $ symbol "prog_argv"
+getProgArgvFunction _ = runEDSL "getProgArgv" $ do
+  [argc, argv] <- params [I64, I64]
+  storeI64 argc 0 $ constI64 1
+  storeI64 argv 0 $ symbol "prog_argv"
 
-suspendThreadFunction _ =
-  runEDSL "suspendThread" $ do
-    setReturnTypes [I64]
-    [reg, _] <- params [I64, I64]
-    call "threadPaused" [mainCapability, getLVal $ global CurrentTSO]
-    emit reg
+suspendThreadFunction _ = runEDSL "suspendThread" $ do
+  setReturnTypes [I64]
+  [reg, _] <- params [I64, I64]
+  call "threadPaused" [mainCapability, getLVal $ global CurrentTSO]
+  emit reg
 
-scheduleThreadFunction _ =
-  runEDSL "scheduleThread" $ do
-    setReturnTypes []
-    [_cap, tso] <- params [I64, I64]
-    callImport "__asterius_enqueueTSO" [convertUInt64ToFloat64 tso]
+scheduleThreadFunction _ = runEDSL "scheduleThread" $ do
+  setReturnTypes []
+  [_cap, tso] <- params [I64, I64]
+  callImport "__asterius_enqueueTSO" [convertUInt64ToFloat64 tso]
 
-scheduleThreadOnFunction _ =
-  runEDSL "scheduleThreadOn" $ do
-    setReturnTypes []
-    [_cap, _cpu, tso] <- params [I64, I64, I64]
-    callImport "__asterius_enqueueTSO" [convertUInt64ToFloat64 tso]
+scheduleThreadOnFunction _ = runEDSL "scheduleThreadOn" $ do
+  setReturnTypes []
+  [_cap, _cpu, tso] <- params [I64, I64, I64]
+  callImport "__asterius_enqueueTSO" [convertUInt64ToFloat64 tso]
 
-resumeThreadFunction _ =
-  runEDSL "resumeThread" $ do
-    setReturnTypes [I64]
-    reg <- param I64
-    emit reg
+resumeThreadFunction _ = runEDSL "resumeThread" $ do
+  setReturnTypes [I64]
+  reg <- param I64
+  emit reg
 
 performMajorGCFunction _ =
-  runEDSL "performMajorGC" $
-  callImport
-    "__asterius_performGC" []
+  runEDSL "performMajorGC" $ callImport "__asterius_performGC" []
 
 performGCFunction _ = runEDSL "performGC" $ call "performMajorGC" []
 
-localeEncodingFunction _ =
-  runEDSL "localeEncoding" $ do
-    setReturnTypes [I64]
-    emit $ symbol "__asterius_localeEncoding"
+localeEncodingFunction _ = runEDSL "localeEncoding" $ do
+  setReturnTypes [I64]
+  emit $ symbol "__asterius_localeEncoding"
 
-isattyFunction _ =
-  runEDSL "isatty" $ do
-    setReturnTypes [I64]
-    _ <- param I64
-    emit $ constI64 0
+isattyFunction _ = runEDSL "isatty" $ do
+  setReturnTypes [I64]
+  _ <- param I64
+  emit $ constI64 0
 
-fdReadyFunction _ =
-  runEDSL "fdReady" $ do
-    setReturnTypes [I64]
-    _ <- params [I64, I64, I64, I64]
-    emit $ constI64 1
+fdReadyFunction _ = runEDSL "fdReady" $ do
+  setReturnTypes [I64]
+  _ <- params [I64, I64, I64, I64]
+  emit $ constI64 1
 
-rtsSupportsBoundThreadsFunction _ =
-  runEDSL "rtsSupportsBoundThreads" $ do
-    setReturnTypes [I64]
-    emit $ constI64 0
+rtsSupportsBoundThreadsFunction _ = runEDSL "rtsSupportsBoundThreads" $ do
+  setReturnTypes [I64]
+  emit $ constI64 0
 
 readFunction _ =
   runEDSL "ghczuwrapperZC22ZCbaseZCSystemziPosixziInternalsZCread" $ do
@@ -1400,9 +1543,10 @@ readFunction _ =
     [fd, buf, count] <- params [I64, I64, I64]
     r <-
       truncSFloat64ToInt64
-        <$> callImport' "__asterius_read"
-              (map convertUInt64ToFloat64 [fd, buf, count])
-              F64
+        <$> callImport'
+          "__asterius_read"
+          (map convertUInt64ToFloat64 [fd, buf, count])
+          F64
     emit r
 
 writeFunction _ =
@@ -1411,20 +1555,22 @@ writeFunction _ =
     [fd, buf, count] <- params [I64, I64, I64]
     r <-
       truncSFloat64ToInt64
-        <$> callImport' "__asterius_write"
-              (map convertUInt64ToFloat64 [fd, buf, count])
-              F64
+        <$> callImport'
+          "__asterius_write"
+          (map convertUInt64ToFloat64 [fd, buf, count])
+          F64
     emit r
 
 getF64GlobalRegFunction ::
-  BuiltinsOptions
-  -> AsteriusEntitySymbol  -- ^ Name of the function to be created
-  -> UnresolvedGlobalReg -- ^ Global register to be returned
-  -> AsteriusModule -- Module containing the function
-getF64GlobalRegFunction _ n gr =
-  runEDSL n $ do
-    setReturnTypes [F64]
-    emit $ convertSInt64ToFloat64 $ getLVal $ global gr
+  BuiltinsOptions ->
+  -- Name of the function to be created
+  AsteriusEntitySymbol ->
+  -- Global register to be returned
+  UnresolvedGlobalReg ->
+  AsteriusModule -- Module containing the function
+getF64GlobalRegFunction _ n gr = runEDSL n $ do
+  setReturnTypes [F64]
+  emit $ convertSInt64ToFloat64 $ getLVal $ global gr
 
 offset_StgTSO_StgStack :: Int
 offset_StgTSO_StgStack = 8 * roundup_bytes_to_words sizeof_StgTSO
@@ -1433,81 +1579,80 @@ offset_StgTSO_StgStack = 8 * roundup_bytes_to_words sizeof_StgTSO
 -- store and load, or I expose a _lot more_ from the EDSL
 -- to create the correct types of stores and loads I want.
 -- I went with the former, but we can discuss trade-offs.
--- | Generate a wrap from the input type to the output type by invoking
--- | the correct load instruction.
--- | Since we only generate wrapping from larger types to smaller types,
--- | our output can only be {32, 16, 8} bits. However, wasm has
--- | I32 as the smallest type. So, our output is _always_ I32.
--- | invariant: output type is smaller than input type.
+-- Generate a wrap from the input type to the output type by invoking
+-- the correct load instruction.
+-- Since we only generate wrapping from larger types to smaller types,
+-- our output can only be {32, 16, 8} bits. However, wasm has
+-- I32 as the smallest type. So, our output is _always_ I32.
+-- invariant: output type is smaller than input type.
 genWrap ::
-     ValueType -- ^ Input type
-  -> Int -- ^ number of bytes to load for the output type
-  -> Expression
-  -> Expression
-genWrap ti b x =
-  Block
-    { name = ""
-    , bodys =
-        [ Store
-            { bytes =
-                if ti == I32
-                  then 4
-                  else 8
-            , offset = 0
-            , ptr = wrapInt64 (symbol "__asterius_i64_slot")
-            , value = x
-            , valueType = ti
-            }
-        , Load
-            { signed = False
-            , bytes = fromIntegral b
-            , offset = 0
-            , valueType = I32
-            , ptr = wrapInt64 (symbol "__asterius_i64_slot")
-            }
-        ]
-    , blockReturnTypes = [I32]
-    }
+  -- Input type
+  ValueType ->
+  -- number of bytes to load for the output type
+  Int ->
+  Expression ->
+  Expression
+genWrap ti b x = Block
+  { name = "",
+    bodys =
+      [ Store
+          { bytes = if ti == I32 then 4 else 8,
+            offset = 0,
+            ptr = wrapInt64 (symbol "__asterius_i64_slot"),
+            value = x,
+            valueType = ti
+          },
+        Load
+          { signed = False,
+            bytes = fromIntegral b,
+            offset = 0,
+            valueType = I32,
+            ptr = wrapInt64 (symbol "__asterius_i64_slot")
+          }
+      ],
+    blockReturnTypes = [I32]
+  }
 
--- | Whether when generate a sign extended value
+-- Whether when generate a sign extended value
 data ShouldSext
   = Sext
   | NoSext
   deriving (Eq)
 
--- | generate a function to sign extend an input value into an output value.
--- | We perform the sign extension by storing the old value.
--- | Note that our input type is always I32. This is because we will only
--- | ever have to generate sign extension calls from GHC.W8, GHC.W16, GHC.W32,
--- | all of which are stored as I32, since wasm cannot store smaller types.
--- | So, our input will _always_ be an I32.
+-- generate a function to sign extend an input value into an output value.
+-- We perform the sign extension by storing the old value.
+-- Note that our input type is always I32. This is because we will only
+-- ever have to generate sign extension calls from GHC.W8, GHC.W16, GHC.W32,
+-- all of which are stored as I32, since wasm cannot store smaller types.
+-- So, our input will _always_ be an I32.
 genExtend ::
-     Int -- ^ number of bytes to load
-  -> ValueType -- ^ output value type
-  -> ShouldSext -- ^ whether the extend should sign-extend or not
-  -> Expression
-  -> Expression
-genExtend b to sext x
-        -- we will just use the i64 slot since it's large enough to hold all
-        -- the wasm datatypes we have.
- =
-  Block
-    { name = ""
-    , bodys =
-        [ Store
-            { bytes = 4
-            , offset = 0
-            , ptr = wrapInt64 (symbol "__asterius_i64_slot")
-            , value = x
-            , valueType = I32
-            }
-        , Load
-            { signed = sext == Sext
-            , bytes = fromIntegral b
-            , offset = 0
-            , valueType = to
-            , ptr = wrapInt64 (symbol "__asterius_i64_slot")
-            }
-        ]
-    , blockReturnTypes = [to]
-    }
+  -- number of bytes to load
+  Int ->
+  -- output value type
+  ValueType ->
+  -- whether the extend should sign-extend or not
+  ShouldSext ->
+  Expression ->
+  Expression
+genExtend b to sext x = Block
+  { name = "",
+    bodys =
+      [ Store
+          { bytes = 4,
+            offset = 0,
+            ptr = wrapInt64 (symbol "__asterius_i64_slot"),
+            value = x,
+            valueType = I32
+          },
+        Load
+          { signed = sext == Sext,
+            bytes = fromIntegral b,
+            offset = 0,
+            valueType = to,
+            ptr = wrapInt64 (symbol "__asterius_i64_slot")
+          }
+      ],
+    blockReturnTypes = [to]
+  }
+-- we will just use the i64 slot since it's large enough to hold all
+-- the wasm datatypes we have.

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -7,15 +7,17 @@
 {-# OPTIONS_GHC -Wno-overflowed-literals #-}
 
 module Asterius.CodeGen
-  ( marshalToModuleSymbol
-  , CodeGen
-  , runCodeGen
-  , marshalHaskellIR
-  , marshalCmmIR
-  , marshalRawCmm
-  ) where
+  ( marshalToModuleSymbol,
+    CodeGen,
+    runCodeGen,
+    marshalHaskellIR,
+    marshalCmmIR,
+    marshalRawCmm,
+  )
+where
 
 import Asterius.Builtins
+import Asterius.EDSL
 import Asterius.Internals
 import Asterius.Passes.All
 import Asterius.Passes.Barf
@@ -24,7 +26,6 @@ import Asterius.Passes.SafeCCall
 import Asterius.Resolve
 import Asterius.Types
 import Asterius.TypesConv
-import Asterius.EDSL
 import qualified CLabel as GHC
 import qualified Cmm as GHC
 import qualified CmmSwitch as GHC
@@ -43,41 +44,43 @@ import qualified Hoopl.Block as GHC
 import qualified Hoopl.Graph as GHC
 import qualified Hoopl.Label as GHC
 import Language.Haskell.GHC.Toolkit.Compiler
-import Language.Haskell.GHC.Toolkit.Orphans.Show ()
-import Prelude hiding (IO)
+import Language.Haskell.GHC.Toolkit.Orphans.Show
+  (
+  )
 import qualified Unique as GHC
+import Prelude hiding (IO)
 
 type CodeGenContext = (GHC.DynFlags, String)
 
-newtype CodeGen a =
-  CodeGen (ReaderT CodeGenContext (Except AsteriusCodeGenError) a)
-  deriving ( Functor
-           , Applicative
-           , Monad
-           , MonadReader CodeGenContext
-           , MonadError AsteriusCodeGenError
-           )
+newtype CodeGen a
+  = CodeGen (ReaderT CodeGenContext (Except AsteriusCodeGenError) a)
+  deriving
+    ( Functor,
+      Applicative,
+      Monad,
+      MonadReader CodeGenContext,
+      MonadError AsteriusCodeGenError
+    )
 
 unCodeGen :: CodeGen a -> CodeGen (Either AsteriusCodeGenError a)
 unCodeGen (CodeGen m) = asks $ runExcept . runReaderT m
 
 {-# INLINEABLE runCodeGen #-}
 runCodeGen ::
-     CodeGen a -> GHC.DynFlags -> GHC.Module -> Either AsteriusCodeGenError a
+  CodeGen a -> GHC.DynFlags -> GHC.Module -> Either AsteriusCodeGenError a
 runCodeGen (CodeGen m) dflags def_mod =
   runExcept $ runReaderT m (dflags, asmPpr dflags def_mod <> "_")
 
 marshalCLabel :: GHC.CLabel -> CodeGen AsteriusEntitySymbol
 marshalCLabel clbl = do
   (dflags, def_mod_prefix) <- ask
-  pure
-    AsteriusEntitySymbol
-      { entityName =
-          fromString $
+  pure AsteriusEntitySymbol
+    { entityName =
+        fromString $
           if GHC.externallyVisibleCLabel clbl
             then asmPpr dflags clbl
             else def_mod_prefix <> asmPpr dflags clbl
-      }
+    }
 
 marshalLabel :: GHC.Label -> CodeGen SBS.ShortByteString
 marshalLabel lbl = do
@@ -86,63 +89,72 @@ marshalLabel lbl = do
 
 marshalCmmType :: GHC.CmmType -> CodeGen ValueType
 marshalCmmType t
-  | GHC.b8 `GHC.cmmEqType_ignoring_ptrhood` t ||
-      GHC.b16 `GHC.cmmEqType_ignoring_ptrhood` t ||
-      GHC.b32 `GHC.cmmEqType_ignoring_ptrhood` t = pure I32
-  | GHC.b64 `GHC.cmmEqType_ignoring_ptrhood` t = pure I64
-  | GHC.f32 `GHC.cmmEqType_ignoring_ptrhood` t = pure F32
-  | GHC.f64 `GHC.cmmEqType_ignoring_ptrhood` t = pure F64
-  | otherwise = throwError $ UnsupportedCmmType $ showSBS t
+  | GHC.b8
+      `GHC.cmmEqType_ignoring_ptrhood` t
+      || GHC.b16
+      `GHC.cmmEqType_ignoring_ptrhood` t
+      || GHC.b32
+      `GHC.cmmEqType_ignoring_ptrhood` t =
+    pure I32
+  | GHC.b64 `GHC.cmmEqType_ignoring_ptrhood` t =
+    pure I64
+  | GHC.f32 `GHC.cmmEqType_ignoring_ptrhood` t =
+    pure F32
+  | GHC.f64 `GHC.cmmEqType_ignoring_ptrhood` t =
+    pure F64
+  | otherwise =
+    throwError $ UnsupportedCmmType $ showSBS t
 
 dispatchCmmWidth :: GHC.Width -> a -> a -> CodeGen a
 dispatchCmmWidth w r32 = dispatchAllCmmWidth w r32 r32 r32
 
 dispatchAllCmmWidth :: GHC.Width -> a -> a -> a -> a -> CodeGen a
-dispatchAllCmmWidth w r8 r16 r32 r64 =
-  case w of
-    GHC.W8 -> pure r8
-    GHC.W16 -> pure r16
-    GHC.W32 -> pure r32
-    GHC.W64 -> pure r64
-    _ -> throwError $ UnsupportedCmmWidth $ showSBS w
+dispatchAllCmmWidth w r8 r16 r32 r64 = case w of
+  GHC.W8 -> pure r8
+  GHC.W16 -> pure r16
+  GHC.W32 -> pure r32
+  GHC.W64 -> pure r64
+  _ -> throwError $ UnsupportedCmmWidth $ showSBS w
 
 marshalCmmStatic :: GHC.CmmStatic -> CodeGen AsteriusStatic
-marshalCmmStatic st =
-  case st of
-    GHC.CmmStaticLit lit ->
-      case lit of
-        GHC.CmmInt x w ->
-          Serialized <$>
-          dispatchAllCmmWidth
-            w
-            (if x < 0
-               then encodeStorable (fromIntegral x :: Int8)
-               else encodeStorable (fromIntegral x :: Word8))
-            (if x < 0
-               then encodeStorable (fromIntegral x :: Int16)
-               else encodeStorable (fromIntegral x :: Word16))
-            (if x < 0
-               then encodeStorable (fromIntegral x :: Int32)
-               else encodeStorable (fromIntegral x :: Word32))
-            (if x < 0
-               then encodeStorable (fromIntegral x :: Int64)
-               else encodeStorable (fromIntegral x :: Word64))
-        GHC.CmmFloat x w ->
-          Serialized <$>
-          dispatchCmmWidth
-            w
-            (encodeStorable (fromRational x :: Float))
-            (encodeStorable (fromRational x :: Double))
-        GHC.CmmLabel clbl -> flip SymbolStatic 0 <$> marshalCLabel clbl
-        GHC.CmmLabelOff clbl o -> do
-          sym <- marshalCLabel clbl
-          pure $ SymbolStatic sym o
-        _ -> throwError $ UnsupportedCmmLit $ showSBS lit
-    GHC.CmmUninitialised s -> pure $ Uninitialized s
-    GHC.CmmString s -> pure $ Serialized $ SBS.pack $ s <> [0]
+marshalCmmStatic st = case st of
+  GHC.CmmStaticLit lit -> case lit of
+    GHC.CmmInt x w ->
+      Serialized
+        <$> dispatchAllCmmWidth
+          w
+          ( if x < 0
+              then encodeStorable (fromIntegral x :: Int8)
+              else encodeStorable (fromIntegral x :: Word8)
+          )
+          ( if x < 0
+              then encodeStorable (fromIntegral x :: Int16)
+              else encodeStorable (fromIntegral x :: Word16)
+          )
+          ( if x < 0
+              then encodeStorable (fromIntegral x :: Int32)
+              else encodeStorable (fromIntegral x :: Word32)
+          )
+          ( if x < 0
+              then encodeStorable (fromIntegral x :: Int64)
+              else encodeStorable (fromIntegral x :: Word64)
+          )
+    GHC.CmmFloat x w ->
+      Serialized
+        <$> dispatchCmmWidth
+          w
+          (encodeStorable (fromRational x :: Float))
+          (encodeStorable (fromRational x :: Double))
+    GHC.CmmLabel clbl -> flip SymbolStatic 0 <$> marshalCLabel clbl
+    GHC.CmmLabelOff clbl o -> do
+      sym <- marshalCLabel clbl
+      pure $ SymbolStatic sym o
+    _ -> throwError $ UnsupportedCmmLit $ showSBS lit
+  GHC.CmmUninitialised s -> pure $ Uninitialized s
+  GHC.CmmString s -> pure $ Serialized $ SBS.pack $ s <> [0]
 
 marshalCmmSectionType ::
-     AsteriusEntitySymbol -> GHC.Section -> AsteriusStaticsType
+  AsteriusEntitySymbol -> GHC.Section -> AsteriusStaticsType
 marshalCmmSectionType sym sec@(GHC.Section _ clbl)
   | GHC.isGcPtrLabel clbl = Closure
   | "_info" `BS.isSuffixOf` SBS.fromShort (entityName sym) = InfoTable
@@ -150,15 +162,16 @@ marshalCmmSectionType sym sec@(GHC.Section _ clbl)
   | otherwise = Bytes
 
 marshalCmmData ::
-     AsteriusEntitySymbol
-  -> GHC.Section
-  -> GHC.CmmStatics
-  -> CodeGen AsteriusStatics
+  AsteriusEntitySymbol ->
+  GHC.Section ->
+  GHC.CmmStatics ->
+  CodeGen AsteriusStatics
 marshalCmmData sym sec (GHC.Statics _ ss) = do
   ass <- for ss marshalCmmStatic
-  pure
-    AsteriusStatics
-      {staticsType = marshalCmmSectionType sym sec, asteriusStatics = ass}
+  pure AsteriusStatics
+    { staticsType = marshalCmmSectionType sym sec,
+      asteriusStatics = ass
+    }
 
 marshalCmmLocalReg :: GHC.LocalReg -> CodeGen (UnresolvedLocalReg, ValueType)
 marshalCmmLocalReg (GHC.LocalReg u t) = do
@@ -166,54 +179,50 @@ marshalCmmLocalReg (GHC.LocalReg u t) = do
   pure (UniqueLocalReg (GHC.getKey u) vt, vt)
 
 marshalTypedCmmLocalReg ::
-     GHC.LocalReg -> ValueType -> CodeGen UnresolvedLocalReg
+  GHC.LocalReg -> ValueType -> CodeGen UnresolvedLocalReg
 marshalTypedCmmLocalReg r vt = do
   (lr, vt') <- marshalCmmLocalReg r
-  if vt == vt'
-    then pure lr
-    else throwError $ UnsupportedCmmExpr $ showSBS r
+  if vt == vt' then pure lr else throwError $ UnsupportedCmmExpr $ showSBS r
 
 marshalCmmGlobalReg :: GHC.GlobalReg -> CodeGen UnresolvedGlobalReg
-marshalCmmGlobalReg r =
-  case r of
-    GHC.VanillaReg i _ -> pure $ VanillaReg i
-    GHC.FloatReg i -> pure $ FloatReg i
-    GHC.DoubleReg i -> pure $ DoubleReg i
-    GHC.LongReg i -> pure $ LongReg i
-    GHC.Sp -> pure Sp
-    GHC.SpLim -> pure SpLim
-    GHC.Hp -> pure Hp
-    GHC.HpLim -> pure HpLim
-    GHC.CCCS -> pure CCCS
-    GHC.CurrentTSO -> pure CurrentTSO
-    GHC.CurrentNursery -> pure CurrentNursery
-    GHC.HpAlloc -> pure HpAlloc
-    GHC.EagerBlackholeInfo -> pure EagerBlackholeInfo
-    GHC.GCEnter1 -> pure GCEnter1
-    GHC.GCFun -> pure GCFun
-    GHC.BaseReg -> pure BaseReg
-    _ -> throwError $ UnsupportedCmmGlobalReg $ showSBS r
+marshalCmmGlobalReg r = case r of
+  GHC.VanillaReg i _ -> pure $ VanillaReg i
+  GHC.FloatReg i -> pure $ FloatReg i
+  GHC.DoubleReg i -> pure $ DoubleReg i
+  GHC.LongReg i -> pure $ LongReg i
+  GHC.Sp -> pure Sp
+  GHC.SpLim -> pure SpLim
+  GHC.Hp -> pure Hp
+  GHC.HpLim -> pure HpLim
+  GHC.CCCS -> pure CCCS
+  GHC.CurrentTSO -> pure CurrentTSO
+  GHC.CurrentNursery -> pure CurrentNursery
+  GHC.HpAlloc -> pure HpAlloc
+  GHC.EagerBlackholeInfo -> pure EagerBlackholeInfo
+  GHC.GCEnter1 -> pure GCEnter1
+  GHC.GCFun -> pure GCFun
+  GHC.BaseReg -> pure BaseReg
+  _ -> throwError $ UnsupportedCmmGlobalReg $ showSBS r
 
 marshalCmmLit :: GHC.CmmLit -> CodeGen (Expression, ValueType)
-marshalCmmLit lit =
-  case lit of
-    GHC.CmmInt x w ->
-      dispatchCmmWidth
-        w
-        (ConstI32 $ fromIntegral x, I32)
-        (ConstI64 $ fromIntegral x, I64)
-    GHC.CmmFloat x w ->
-      dispatchCmmWidth
-        w
-        (ConstF32 $ fromRational x, F32)
-        (ConstF64 $ fromRational x, F64)
-    GHC.CmmLabel clbl -> do
-      sym <- marshalCLabel clbl
-      pure (Symbol {unresolvedSymbol = sym, symbolOffset = 0}, I64)
-    GHC.CmmLabelOff clbl o -> do
-      sym <- marshalCLabel clbl
-      pure (Symbol {unresolvedSymbol = sym, symbolOffset = o}, I64)
-    _ -> throwError $ UnsupportedCmmLit $ showSBS lit
+marshalCmmLit lit = case lit of
+  GHC.CmmInt x w ->
+    dispatchCmmWidth
+      w
+      (ConstI32 $ fromIntegral x, I32)
+      (ConstI64 $ fromIntegral x, I64)
+  GHC.CmmFloat x w ->
+    dispatchCmmWidth
+      w
+      (ConstF32 $ fromRational x, F32)
+      (ConstF64 $ fromRational x, F64)
+  GHC.CmmLabel clbl -> do
+    sym <- marshalCLabel clbl
+    pure (Symbol {unresolvedSymbol = sym, symbolOffset = 0}, I64)
+  GHC.CmmLabelOff clbl o -> do
+    sym <- marshalCLabel clbl
+    pure (Symbol {unresolvedSymbol = sym, symbolOffset = o}, I64)
+  _ -> throwError $ UnsupportedCmmLit $ showSBS lit
 
 marshalCmmLoad :: GHC.CmmExpr -> GHC.CmmType -> CodeGen (Expression, ValueType)
 marshalCmmLoad p t = do
@@ -221,44 +230,63 @@ marshalCmmLoad p t = do
   join $
     dispatchAllCmmWidth
       (GHC.typeWidth t)
-      (pure
-         ( Load
-             {signed = False, bytes = 1, offset = 0, valueType = I32, ptr = pv}
-         , I32))
-      (pure
-         ( Load
-             {signed = False, bytes = 2, offset = 0, valueType = I32, ptr = pv}
-         , I32))
-      (do vt <- marshalCmmType t
+      ( pure
+          ( Load
+              { signed = False,
+                bytes = 1,
+                offset = 0,
+                valueType = I32,
+                ptr = pv
+              },
+            I32
+          )
+      )
+      ( pure
+          ( Load
+              { signed = False,
+                bytes = 2,
+                offset = 0,
+                valueType = I32,
+                ptr = pv
+              },
+            I32
+          )
+      )
+      ( do
+          vt <- marshalCmmType t
           pure
             ( Load
-                { signed = False
-                , bytes = 4
-                , offset = 0
-                , valueType = vt
-                , ptr = pv
-                }
-            , vt))
-      (do vt <- marshalCmmType t
+                { signed = False,
+                  bytes = 4,
+                  offset = 0,
+                  valueType = vt,
+                  ptr = pv
+                },
+              vt
+            )
+      )
+      ( do
+          vt <- marshalCmmType t
           pure
             ( Load
-                { signed = False
-                , bytes = 8
-                , offset = 0
-                , valueType = vt
-                , ptr = pv
-                }
-            , vt))
+                { signed = False,
+                  bytes = 8,
+                  offset = 0,
+                  valueType = vt,
+                  ptr = pv
+                },
+              vt
+            )
+      )
 
 marshalCmmReg :: GHC.CmmReg -> CodeGen (Expression, ValueType)
-marshalCmmReg r =
-  case r of
-    GHC.CmmLocal lr -> do
-      (lr_k, lr_vt) <- marshalCmmLocalReg lr
-      pure (UnresolvedGetLocal {unresolvedLocalReg = lr_k}, lr_vt)
-    GHC.CmmGlobal gr -> do
-      gr_k <- marshalCmmGlobalReg gr
-      pure (unresolvedGetGlobal gr_k, unresolvedGlobalRegType gr_k)
+marshalCmmReg r = case r of
+  GHC.CmmLocal lr -> do
+    (lr_k, lr_vt) <- marshalCmmLocalReg lr
+    pure (UnresolvedGetLocal {unresolvedLocalReg = lr_k}, lr_vt)
+  GHC.CmmGlobal gr -> do
+    gr_k <- marshalCmmGlobalReg gr
+    pure (unresolvedGetGlobal gr_k, unresolvedGlobalRegType gr_k)
 
 marshalCmmRegOff :: GHC.CmmReg -> Int -> CodeGen (Expression, ValueType)
 marshalCmmRegOff r o = do
@@ -267,107 +295,104 @@ marshalCmmRegOff r o = do
     I32 ->
       pure
         ( Binary
-            { binaryOp = AddInt32
-            , operand0 = re
-            , operand1 = ConstI32 $ fromIntegral o
-            }
-        , vt)
+            { binaryOp = AddInt32,
+              operand0 = re,
+              operand1 = ConstI32 $ fromIntegral o
+            },
+          vt
+        )
     I64 ->
       pure
         ( Binary
-            { binaryOp = AddInt64
-            , operand0 = re
-            , operand1 = ConstI64 $ fromIntegral o
-            }
-        , vt)
+            { binaryOp = AddInt64,
+              operand0 = re,
+              operand1 = ConstI64 $ fromIntegral o
+            },
+          vt
+        )
     _ -> throwError $ UnsupportedCmmExpr $ showSBS $ GHC.CmmRegOff r o
 
 marshalCmmBinMachOp ::
-     BinaryOp
-  -> ValueType
-  -> ValueType
-  -> ValueType
-  -> BinaryOp
-  -> ValueType
-  -> ValueType
-  -> ValueType
-  -> GHC.Width
-  -> GHC.CmmExpr
-  -> GHC.CmmExpr
-  -> CodeGen (Expression, ValueType)
+  BinaryOp ->
+  ValueType ->
+  ValueType ->
+  ValueType ->
+  BinaryOp ->
+  ValueType ->
+  ValueType ->
+  ValueType ->
+  GHC.Width ->
+  GHC.CmmExpr ->
+  GHC.CmmExpr ->
+  CodeGen (Expression, ValueType)
 marshalCmmBinMachOp o32 tx32 ty32 tr32 o64 tx64 ty64 tr64 w x y =
   join $
-  dispatchCmmWidth
-    w
-    (do xe <- marshalAndCastCmmExpr x tx32
-        ye <- marshalAndCastCmmExpr y ty32
-        pure (Binary {binaryOp = o32, operand0 = xe, operand1 = ye}, tr32))
-    (do xe <- marshalAndCastCmmExpr x tx64
-        ye <- marshalAndCastCmmExpr y ty64
-        pure (Binary {binaryOp = o64, operand0 = xe, operand1 = ye}, tr64))
+    dispatchCmmWidth
+      w
+      ( do
+          xe <- marshalAndCastCmmExpr x tx32
+          ye <- marshalAndCastCmmExpr y ty32
+          pure (Binary {binaryOp = o32, operand0 = xe, operand1 = ye}, tr32)
+      )
+      ( do
+          xe <- marshalAndCastCmmExpr x tx64
+          ye <- marshalAndCastCmmExpr y ty64
+          pure (Binary {binaryOp = o64, operand0 = xe, operand1 = ye}, tr64)
+      )
 
 -- Should this logic be pushed into `marshalAndCastCmmExpr?
 marshalCmmHomoConvMachOp ::
-     UnaryOp
-  -> UnaryOp
-  -> ValueType
-  -> ValueType
-  -> GHC.Width
-  -> GHC.Width
-  -> ShouldSext
-  -> GHC.CmmExpr
-  -> CodeGen (Expression, ValueType)
+  UnaryOp ->
+  UnaryOp ->
+  ValueType ->
+  ValueType ->
+  GHC.Width ->
+  GHC.Width ->
+  ShouldSext ->
+  GHC.CmmExpr ->
+  CodeGen (Expression, ValueType)
 marshalCmmHomoConvMachOp o36 o63 t32 t64 w0 w1 sext x
-  | (w0 == GHC.W8 || w0 == GHC.W16) && (w1 == GHC.W32 || w1 == GHC.W64)
+  | (w0 == GHC.W8 || w0 == GHC.W16) && (w1 == GHC.W32 || w1 == GHC.W64) =
     -- we are extending from {W8, W16} to {W32, W64}. Sign extension
     -- semantics matters here.
-   = do
-    (xe, _) <- marshalCmmExpr x
-    pure
-      ( genExtend
-          (if w0 == GHC.W8
-             then 1
-             else 2)
-          (if w1 == GHC.W32
-             then I32
-             else I64)
-          sext
-          xe
-      , if w1 == GHC.W64
-          then I64
-          else I32)
-  | (w0 == GHC.W32 || w0 == GHC.W64) && (w1 == GHC.W8 || w1 == GHC.W16)
+    do
+      (xe, _) <- marshalCmmExpr x
+      pure
+        ( genExtend
+            (if w0 == GHC.W8 then 1 else 2)
+            (if w1 == GHC.W32 then I32 else I64)
+            sext
+            xe,
+          if w1 == GHC.W64 then I64 else I32
+        )
+  | (w0 == GHC.W32 || w0 == GHC.W64) && (w1 == GHC.W8 || w1 == GHC.W16) =
     -- we are wrapping from {32, 64} to {8, 16}
-   = do
-    (xe, _) <- marshalCmmExpr x
-    pure
-      ( genWrap
-          (if w0 == GHC.W32
-             then I32
-             else I64)
-          (GHC.widthInBytes w1)
-          xe
-      , I32)
-  | otherwise
+    do
+      (xe, _) <- marshalCmmExpr x
+      pure
+        ( genWrap (if w0 == GHC.W32 then I32 else I64) (GHC.widthInBytes w1) xe,
+          I32
+        )
+  | otherwise =
     -- we are converting from {32, 64} to {32, 64} of floating point / int
-   = do
-    (o, t, tr) <- dispatchCmmWidth w1 (o63, t64, t32) (o36, t32, t64)
-    xe <- marshalAndCastCmmExpr x t
-    pure (Unary {unaryOp = o, operand0 = xe}, tr)
+    do
+      (o, t, tr) <- dispatchCmmWidth w1 (o63, t64, t32) (o36, t32, t64)
+      xe <- marshalAndCastCmmExpr x t
+      pure (Unary {unaryOp = o, operand0 = xe}, tr)
 
 marshalCmmHeteroConvMachOp ::
-     UnaryOp
-  -> UnaryOp
-  -> UnaryOp
-  -> UnaryOp
-  -> ValueType
-  -> ValueType
-  -> ValueType
-  -> ValueType
-  -> GHC.Width
-  -> GHC.Width
-  -> GHC.CmmExpr
-  -> CodeGen (Expression, ValueType)
+  UnaryOp ->
+  UnaryOp ->
+  UnaryOp ->
+  UnaryOp ->
+  ValueType ->
+  ValueType ->
+  ValueType ->
+  ValueType ->
+  GHC.Width ->
+  GHC.Width ->
+  GHC.CmmExpr ->
+  CodeGen (Expression, ValueType)
 marshalCmmHeteroConvMachOp o33 o36 o63 o66 tx32 ty32 tx64 ty64 w0 w1 x = do
   (g0, g1) <-
     dispatchCmmWidth
@@ -379,7 +404,7 @@ marshalCmmHeteroConvMachOp o33 o36 o63 o66 tx32 ty32 tx64 ty64 w0 w1 x = do
   pure (Unary {unaryOp = o, operand0 = xe}, tr)
 
 marshalCmmMachOp ::
-     GHC.MachOp -> [GHC.CmmExpr] -> CodeGen (Expression, ValueType)
+  GHC.MachOp -> [GHC.CmmExpr] -> CodeGen (Expression, ValueType)
 marshalCmmMachOp (GHC.MO_Add w) [x, y] =
   marshalCmmBinMachOp AddInt32 I32 I32 I32 AddInt64 I64 I64 I64 w x y
 marshalCmmMachOp (GHC.MO_Sub w) [x, y] =
@@ -396,16 +421,22 @@ marshalCmmMachOp (GHC.MO_S_Rem w) [x, y] =
   marshalCmmBinMachOp RemSInt32 I32 I32 I32 RemSInt64 I64 I64 I64 w x y
 marshalCmmMachOp (GHC.MO_S_Neg w) [x] =
   join $
-  dispatchCmmWidth
-    w
-    (do xe <- marshalAndCastCmmExpr x I32
-        pure
-          ( Binary {binaryOp = SubInt32, operand0 = ConstI32 0, operand1 = xe}
-          , I32))
-    (do xe <- marshalAndCastCmmExpr x I64
-        pure
-          ( Binary {binaryOp = SubInt64, operand0 = ConstI64 0, operand1 = xe}
-          , I64))
+    dispatchCmmWidth
+      w
+      ( do
+          xe <- marshalAndCastCmmExpr x I32
+          pure
+            ( Binary {binaryOp = SubInt32, operand0 = ConstI32 0, operand1 = xe},
+              I32
+            )
+      )
+      ( do
+          xe <- marshalAndCastCmmExpr x I64
+          pure
+            ( Binary {binaryOp = SubInt64, operand0 = ConstI64 0, operand1 = xe},
+              I64
+            )
+      )
 marshalCmmMachOp (GHC.MO_U_Quot w) [x, y] =
   marshalCmmBinMachOp DivUInt32 I32 I32 I32 DivUInt64 I64 I64 I64 w x y
 marshalCmmMachOp (GHC.MO_U_Rem w) [x, y] =
@@ -432,14 +463,16 @@ marshalCmmMachOp (GHC.MO_F_Sub w) [x, y] =
   marshalCmmBinMachOp SubFloat32 F32 F32 F32 SubFloat64 F64 F64 F64 w x y
 marshalCmmMachOp (GHC.MO_F_Neg w) [x] =
   join $
-  dispatchCmmWidth
-    w
-    (do xe <- marshalAndCastCmmExpr x F32
-        pure
-          (Unary { unaryOp = NegFloat32, operand0 = xe }, F32))
-    (do xe <- marshalAndCastCmmExpr x F64
-        pure
-          (Unary { unaryOp= NegFloat64, operand0 = xe }, F64))
+    dispatchCmmWidth
+      w
+      ( do
+          xe <- marshalAndCastCmmExpr x F32
+          pure (Unary {unaryOp = NegFloat32, operand0 = xe}, F32)
+      )
+      ( do
+          xe <- marshalAndCastCmmExpr x F64
+          pure (Unary {unaryOp = NegFloat64, operand0 = xe}, F64)
+      )
 marshalCmmMachOp (GHC.MO_F_Mul w) [x, y] =
   marshalCmmBinMachOp MulFloat32 F32 F32 F32 MulFloat64 F64 F64 F64 w x y
 marshalCmmMachOp (GHC.MO_F_Quot w) [x, y] =
@@ -464,24 +497,30 @@ marshalCmmMachOp (GHC.MO_Xor w) [x, y] =
   marshalCmmBinMachOp XorInt32 I32 I32 I32 XorInt64 I64 I64 I64 w x y
 marshalCmmMachOp (GHC.MO_Not w) [x] =
   join $
-  dispatchCmmWidth
-    w
-    (do xe <- marshalAndCastCmmExpr x I32
-        pure
-          ( Binary
-              { binaryOp = XorInt32
-              , operand0 = xe
-              , operand1 = ConstI32 0xFFFFFFFF
-              }
-          , I32))
-    (do xe <- marshalAndCastCmmExpr x I64
-        pure
-          ( Binary
-              { binaryOp = XorInt64
-              , operand0 = xe
-              , operand1 = ConstI64 0xFFFFFFFFFFFFFFFF
-              }
-          , I64))
+    dispatchCmmWidth
+      w
+      ( do
+          xe <- marshalAndCastCmmExpr x I32
+          pure
+            ( Binary
+                { binaryOp = XorInt32,
+                  operand0 = xe,
+                  operand1 = ConstI32 0xFFFFFFFF
+                },
+              I32
+            )
+      )
+      ( do
+          xe <- marshalAndCastCmmExpr x I64
+          pure
+            ( Binary
+                { binaryOp = XorInt64,
+                  operand0 = xe,
+                  operand1 = ConstI64 0xFFFFFFFFFFFFFFFF
+                },
+              I64
+            )
+      )
 marshalCmmMachOp (GHC.MO_Shl w) [x, y] =
   marshalCmmBinMachOp ShlInt32 I32 I32 I32 ShlInt64 I64 I64 I64 w x y
 marshalCmmMachOp (GHC.MO_U_Shr w) [x, y] =
@@ -524,204 +563,184 @@ marshalCmmMachOp op xs =
   throwError $ UnsupportedCmmExpr $ showSBS $ GHC.CmmMachOp op xs
 
 marshalCmmExpr :: GHC.CmmExpr -> CodeGen (Expression, ValueType)
-marshalCmmExpr cmm_expr =
-  case cmm_expr of
-    GHC.CmmLit lit -> marshalCmmLit lit
-    GHC.CmmLoad p t -> marshalCmmLoad p t
-    GHC.CmmReg r -> marshalCmmReg r
-    GHC.CmmMachOp op xs -> marshalCmmMachOp op xs
-    GHC.CmmRegOff r o -> marshalCmmRegOff r o
-    _ -> throwError $ UnsupportedCmmExpr $ showSBS cmm_expr
+marshalCmmExpr cmm_expr = case cmm_expr of
+  GHC.CmmLit lit -> marshalCmmLit lit
+  GHC.CmmLoad p t -> marshalCmmLoad p t
+  GHC.CmmReg r -> marshalCmmReg r
+  GHC.CmmMachOp op xs -> marshalCmmMachOp op xs
+  GHC.CmmRegOff r o -> marshalCmmRegOff r o
+  _ -> throwError $ UnsupportedCmmExpr $ showSBS cmm_expr
 
 marshalAndCastCmmExpr :: GHC.CmmExpr -> ValueType -> CodeGen Expression
 marshalAndCastCmmExpr cmm_expr dest_vt = do
   (src_expr, src_vt) <- marshalCmmExpr cmm_expr
   case (# src_vt, dest_vt #) of
-    (# I32, I64 #) -> pure Unary {unaryOp = ExtendSInt32, operand0 = src_expr}
+    (# I32, I64 #) ->
+      pure Unary {unaryOp = ExtendSInt32, operand0 = src_expr}
     (# I64, I32 #) -> pure Unary {unaryOp = WrapInt64, operand0 = src_expr}
     (# I64, F64 #) ->
       pure Unary {unaryOp = ConvertSInt64ToFloat64, operand0 = src_expr}
     _
       | src_vt == dest_vt -> pure src_expr
       | otherwise ->
-        throwError $ UnsupportedImplicitCasting src_expr src_vt dest_vt
+        throwError $
+          UnsupportedImplicitCasting src_expr src_vt dest_vt
 
-marshalCmmUnPrimCall
-     :: ValueType    -- result type
-     -> GHC.LocalReg -- result destination
-     -> ValueType    -- operand type
-     -> GHC.CmmExpr  -- operand
-     -> (Expression -> Expression) -- operation
-     -> CodeGen [Expression]
+marshalCmmUnPrimCall ::
+  ValueType -> -- result type
+  GHC.LocalReg -> -- result destination
+  ValueType -> -- operand type
+  GHC.CmmExpr -> -- operand
+  (Expression -> Expression) -> -- operation
+  CodeGen [Expression]
 marshalCmmUnPrimCall retTyp ret vTyp v op = do
   lr <- marshalTypedCmmLocalReg ret retTyp
   xe <- marshalAndCastCmmExpr v vTyp
-  pure
-    [ UnresolvedSetLocal
-        {unresolvedLocalReg = lr, value = op xe}
-    ]
+  pure [UnresolvedSetLocal {unresolvedLocalReg = lr, value = op xe}]
 
 marshalCmmQuotRemPrimCall ::
-     UnresolvedLocalReg
-  -> UnresolvedLocalReg
-  -> BinaryOp
-  -> BinaryOp
-  -> ValueType
-  -> GHC.LocalReg
-  -> GHC.LocalReg
-  -> GHC.CmmExpr
-  -> GHC.CmmExpr
-  -> CodeGen [Expression]
+  UnresolvedLocalReg ->
+  UnresolvedLocalReg ->
+  BinaryOp ->
+  BinaryOp ->
+  ValueType ->
+  GHC.LocalReg ->
+  GHC.LocalReg ->
+  GHC.CmmExpr ->
+  GHC.CmmExpr ->
+  CodeGen [Expression]
 marshalCmmQuotRemPrimCall tmp0 tmp1 qop rop vt qr rr x y = do
   qlr <- marshalTypedCmmLocalReg qr vt
   rlr <- marshalTypedCmmLocalReg rr vt
   xe <- marshalAndCastCmmExpr x vt
   ye <- marshalAndCastCmmExpr y vt
   pure
-    [ UnresolvedSetLocal {unresolvedLocalReg = tmp0, value = xe}
-    , UnresolvedSetLocal {unresolvedLocalReg = tmp1, value = ye}
-    , UnresolvedSetLocal
-        { unresolvedLocalReg = qlr
-        , value =
-            Binary
-              { binaryOp = qop
-              , operand0 = UnresolvedGetLocal {unresolvedLocalReg = tmp0}
-              , operand1 = UnresolvedGetLocal {unresolvedLocalReg = tmp1}
-              }
-        }
-    , UnresolvedSetLocal
-        { unresolvedLocalReg = rlr
-        , value =
-            Binary
-              { binaryOp = rop
-              , operand0 = UnresolvedGetLocal {unresolvedLocalReg = tmp0}
-              , operand1 = UnresolvedGetLocal {unresolvedLocalReg = tmp1}
-              }
+    [ UnresolvedSetLocal {unresolvedLocalReg = tmp0, value = xe},
+      UnresolvedSetLocal {unresolvedLocalReg = tmp1, value = ye},
+      UnresolvedSetLocal
+        { unresolvedLocalReg = qlr,
+          value = Binary
+            { binaryOp = qop,
+              operand0 = UnresolvedGetLocal {unresolvedLocalReg = tmp0},
+              operand1 = UnresolvedGetLocal {unresolvedLocalReg = tmp1}
+            }
+        },
+      UnresolvedSetLocal
+        { unresolvedLocalReg = rlr,
+          value = Binary
+            { binaryOp = rop,
+              operand0 = UnresolvedGetLocal {unresolvedLocalReg = tmp0},
+              operand1 = UnresolvedGetLocal {unresolvedLocalReg = tmp1}
+            }
         }
     ]
 
 marshalCmmUnMathPrimCall ::
-     SBS.ShortByteString
-  -> ValueType
-  -> GHC.LocalReg
-  -> GHC.CmmExpr
-  -> CodeGen [Expression]
+  SBS.ShortByteString ->
+  ValueType ->
+  GHC.LocalReg ->
+  GHC.CmmExpr ->
+  CodeGen [Expression]
 marshalCmmUnMathPrimCall op vt r x = do
   lr <- marshalTypedCmmLocalReg r vt
   xe <- marshalAndCastCmmExpr x vt
   pure
     [ UnresolvedSetLocal
-        { unresolvedLocalReg = lr
-        , value =
-            CallImport
-              { target' = "__asterius_" <> op <> "_" <> showSBS vt
-              , operands = [xe]
-              , callImportReturnTypes = [vt]
-              }
+        { unresolvedLocalReg = lr,
+          value = CallImport
+            { target' = "__asterius_" <> op <> "_" <> showSBS vt,
+              operands = [xe],
+              callImportReturnTypes = [vt]
+            }
         }
     ]
 
 marshalCmmBinMathPrimCall ::
-     SBS.ShortByteString
-  -> ValueType
-  -> GHC.LocalReg
-  -> GHC.CmmExpr
-  -> GHC.CmmExpr
-  -> CodeGen [Expression]
+  SBS.ShortByteString ->
+  ValueType ->
+  GHC.LocalReg ->
+  GHC.CmmExpr ->
+  GHC.CmmExpr ->
+  CodeGen [Expression]
 marshalCmmBinMathPrimCall op vt r x y = do
   lr <- marshalTypedCmmLocalReg r vt
   xe <- marshalAndCastCmmExpr x vt
   ye <- marshalAndCastCmmExpr y vt
   pure
     [ UnresolvedSetLocal
-        { unresolvedLocalReg = lr
-        , value =
-            CallImport
-              { target' = "__asterius_" <> op <> "_" <> showSBS vt
-              , operands = [xe, ye]
-              , callImportReturnTypes = [vt]
-              }
+        { unresolvedLocalReg = lr,
+          value = CallImport
+            { target' = "__asterius_" <> op <> "_" <> showSBS vt,
+              operands = [xe, ye],
+              callImportReturnTypes = [vt]
+            }
         }
     ]
 
--- | We follow the order of definition from:
+-- We follow the order of definition from:
 -- https://github.com/ghc/ghc/blob/master/compiler/cmm/CmmMachOp.hs
 marshalCmmPrimCall ::
-     GHC.CallishMachOp
-  -> [GHC.LocalReg]
-  -> [GHC.CmmExpr]
-  -> CodeGen [Expression]
+  GHC.CallishMachOp ->
+  [GHC.LocalReg] ->
+  [GHC.CmmExpr] ->
+  CodeGen [Expression]
 marshalCmmPrimCall GHC.MO_F64_Pwr [r] [x, y] =
   marshalCmmBinMathPrimCall "pow" F64 r x y
-
 marshalCmmPrimCall GHC.MO_F64_Sin [r] [x] =
   marshalCmmUnMathPrimCall "sin" F64 r x
 marshalCmmPrimCall GHC.MO_F64_Cos [r] [x] =
   marshalCmmUnMathPrimCall "cos" F64 r x
 marshalCmmPrimCall GHC.MO_F64_Tan [r] [x] =
   marshalCmmUnMathPrimCall "tan" F64 r x
-
 marshalCmmPrimCall GHC.MO_F64_Sinh [r] [x] =
   marshalCmmUnMathPrimCall "sinh" F64 r x
 marshalCmmPrimCall GHC.MO_F64_Cosh [r] [x] =
   marshalCmmUnMathPrimCall "cosh" F64 r x
 marshalCmmPrimCall GHC.MO_F64_Tanh [r] [x] =
   marshalCmmUnMathPrimCall "tanh" F64 r x
-
 marshalCmmPrimCall GHC.MO_F64_Asin [r] [x] =
   marshalCmmUnMathPrimCall "asin" F64 r x
 marshalCmmPrimCall GHC.MO_F64_Acos [r] [x] =
   marshalCmmUnMathPrimCall "acos" F64 r x
 marshalCmmPrimCall GHC.MO_F64_Atan [r] [x] =
   marshalCmmUnMathPrimCall "atan" F64 r x
-
 marshalCmmPrimCall GHC.MO_F64_Log [r] [x] =
   marshalCmmUnMathPrimCall "log" F64 r x
 marshalCmmPrimCall GHC.MO_F64_Exp [r] [x] =
   marshalCmmUnMathPrimCall "exp" F64 r x
-
 marshalCmmPrimCall GHC.MO_F64_Fabs [r] [x] =
   marshalCmmUnPrimCall F64 r F64 x (Unary AbsFloat64)
-
 marshalCmmPrimCall GHC.MO_F64_Sqrt [r] [x] =
   marshalCmmUnPrimCall F64 r F64 x (Unary SqrtFloat64)
-
--- | 32 bit
+-- 32 bit
 marshalCmmPrimCall GHC.MO_F32_Pwr [r] [x, y] =
   marshalCmmBinMathPrimCall "pow" F32 r x y
-
 marshalCmmPrimCall GHC.MO_F32_Sin [r] [x] =
   marshalCmmUnMathPrimCall "sin" F32 r x
 marshalCmmPrimCall GHC.MO_F32_Cos [r] [x] =
   marshalCmmUnMathPrimCall "cos" F32 r x
 marshalCmmPrimCall GHC.MO_F32_Tan [r] [x] =
   marshalCmmUnMathPrimCall "tan" F32 r x
-
 marshalCmmPrimCall GHC.MO_F32_Sinh [r] [x] =
   marshalCmmUnMathPrimCall "sinh" F32 r x
 marshalCmmPrimCall GHC.MO_F32_Cosh [r] [x] =
   marshalCmmUnMathPrimCall "cosh" F32 r x
 marshalCmmPrimCall GHC.MO_F32_Tanh [r] [x] =
   marshalCmmUnMathPrimCall "tanh" F32 r x
-
 marshalCmmPrimCall GHC.MO_F32_Asin [r] [x] =
   marshalCmmUnMathPrimCall "asin" F32 r x
 marshalCmmPrimCall GHC.MO_F32_Acos [r] [x] =
   marshalCmmUnMathPrimCall "acos" F32 r x
 marshalCmmPrimCall GHC.MO_F32_Atan [r] [x] =
   marshalCmmUnMathPrimCall "atan" F32 r x
-
 marshalCmmPrimCall GHC.MO_F32_Log [r] [x] =
   marshalCmmUnMathPrimCall "log" F32 r x
 marshalCmmPrimCall GHC.MO_F32_Exp [r] [x] =
   marshalCmmUnMathPrimCall "exp" F32 r x
-
 marshalCmmPrimCall GHC.MO_F32_Fabs [r] [x] =
   marshalCmmUnPrimCall F32 r F32 x (Unary AbsFloat32)
-
 marshalCmmPrimCall GHC.MO_F32_Sqrt [r] [x] =
   marshalCmmUnPrimCall F32 r F32 x (Unary SqrtFloat32)
-
 marshalCmmPrimCall (GHC.MO_UF_Conv w) [r] [x] = do
   (op, ft) <-
     dispatchCmmWidth
@@ -732,56 +751,62 @@ marshalCmmPrimCall (GHC.MO_UF_Conv w) [r] [x] = do
   xe <- marshalAndCastCmmExpr x I64
   pure
     [ UnresolvedSetLocal
-        {unresolvedLocalReg = lr, value = Unary {unaryOp = op, operand0 = xe}}
+        { unresolvedLocalReg = lr,
+          value = Unary {unaryOp = op, operand0 = xe}
+        }
     ]
 marshalCmmPrimCall (GHC.MO_S_QuotRem w) [qr, rr] [x, y] =
   join $
-  dispatchCmmWidth
-    w
-    (marshalCmmQuotRemPrimCall
-       QuotRemI32X
-       QuotRemI32Y
-       DivSInt32
-       RemSInt32
-       I32
-       qr
-       rr
-       x
-       y)
-    (marshalCmmQuotRemPrimCall
-       QuotRemI64X
-       QuotRemI64Y
-       DivSInt64
-       RemSInt64
-       I64
-       qr
-       rr
-       x
-       y)
+    dispatchCmmWidth
+      w
+      ( marshalCmmQuotRemPrimCall
+          QuotRemI32X
+          QuotRemI32Y
+          DivSInt32
+          RemSInt32
+          I32
+          qr
+          rr
+          x
+          y
+      )
+      ( marshalCmmQuotRemPrimCall
+          QuotRemI64X
+          QuotRemI64Y
+          DivSInt64
+          RemSInt64
+          I64
+          qr
+          rr
+          x
+          y
+      )
 marshalCmmPrimCall (GHC.MO_U_QuotRem w) [qr, rr] [x, y] =
   join $
-  dispatchCmmWidth
-    w
-    (marshalCmmQuotRemPrimCall
-       QuotRemI32X
-       QuotRemI32Y
-       DivUInt32
-       RemUInt32
-       I32
-       qr
-       rr
-       x
-       y)
-    (marshalCmmQuotRemPrimCall
-       QuotRemI64X
-       QuotRemI64Y
-       DivUInt64
-       RemUInt64
-       I64
-       qr
-       rr
-       x
-       y)
+    dispatchCmmWidth
+      w
+      ( marshalCmmQuotRemPrimCall
+          QuotRemI32X
+          QuotRemI32Y
+          DivUInt32
+          RemUInt32
+          I32
+          qr
+          rr
+          x
+          y
+      )
+      ( marshalCmmQuotRemPrimCall
+          QuotRemI64X
+          QuotRemI64Y
+          DivUInt64
+          RemUInt64
+          I64
+          qr
+          rr
+          x
+          y
+      )
 marshalCmmPrimCall GHC.MO_WriteBarrier _ _ = pure []
 marshalCmmPrimCall GHC.MO_Touch _ _ = pure []
 marshalCmmPrimCall (GHC.MO_Prefetch_Data _) _ _ = pure []
@@ -791,9 +816,9 @@ marshalCmmPrimCall (GHC.MO_Memcpy _) [] [_dst, _src, _n] = do
   n <- marshalAndCastCmmExpr _n F64
   pure
     [ CallImport
-        { target' = "__asterius_memcpy"
-        , operands = [dst, src, n]
-        , callImportReturnTypes = []
+        { target' = "__asterius_memcpy",
+          operands = [dst, src, n],
+          callImportReturnTypes = []
         }
     ]
 marshalCmmPrimCall (GHC.MO_Memset _) [] [_dst, _c, _n] = do
@@ -802,9 +827,9 @@ marshalCmmPrimCall (GHC.MO_Memset _) [] [_dst, _c, _n] = do
   n <- marshalAndCastCmmExpr _n F64
   pure
     [ CallImport
-        { target' = "__asterius_memset"
-        , operands = [dst, c, n]
-        , callImportReturnTypes = []
+        { target' = "__asterius_memset",
+          operands = [dst, c, n],
+          callImportReturnTypes = []
         }
     ]
 marshalCmmPrimCall (GHC.MO_Memmove _) [] [_dst, _src, _n] = do
@@ -813,9 +838,9 @@ marshalCmmPrimCall (GHC.MO_Memmove _) [] [_dst, _src, _n] = do
   n <- marshalAndCastCmmExpr _n F64
   pure
     [ CallImport
-        { target' = "__asterius_memmove"
-        , operands = [dst, src, n]
-        , callImportReturnTypes = []
+        { target' = "__asterius_memmove",
+          operands = [dst, src, n],
+          callImportReturnTypes = []
         }
     ]
 marshalCmmPrimCall (GHC.MO_Memcmp _) [_cres] [_ptr1, _ptr2, _n] = do
@@ -825,13 +850,12 @@ marshalCmmPrimCall (GHC.MO_Memcmp _) [_cres] [_ptr1, _ptr2, _n] = do
   n <- marshalAndCastCmmExpr _n F64
   pure
     [ UnresolvedSetLocal
-        { unresolvedLocalReg = cres
-        , value =
-            CallImport
-              { target' = "__asterius_memcmp"
-              , operands = [ptr1, ptr2, n]
-              , callImportReturnTypes = [I32]
-              }
+        { unresolvedLocalReg = cres,
+          value = CallImport
+            { target' = "__asterius_memcmp",
+              operands = [ptr1, ptr2, n],
+              callImportReturnTypes = [I32]
+            }
         }
     ]
 marshalCmmPrimCall (GHC.MO_PopCnt GHC.W64) [r] [x] =
@@ -839,539 +863,537 @@ marshalCmmPrimCall (GHC.MO_PopCnt GHC.W64) [r] [x] =
 marshalCmmPrimCall (GHC.MO_PopCnt GHC.W32) [r] [x] = do
   marshalCmmUnPrimCall I64 r I32 x (extendSInt32 . popCntInt32)
 marshalCmmPrimCall (GHC.MO_PopCnt GHC.W16) [r] [x] = do
-  marshalCmmUnPrimCall I64 r I32 x (extendSInt32 . popCntInt32 . andInt32 (constI32 0xFFFF))
+  marshalCmmUnPrimCall
+    I64
+    r
+    I32
+    x
+    (extendSInt32 . popCntInt32 . andInt32 (constI32 0xFFFF))
 marshalCmmPrimCall (GHC.MO_PopCnt GHC.W8) [r] [x] = do
-  marshalCmmUnPrimCall I64 r I32 x (extendSInt32 . popCntInt32 . andInt32 (constI32 0xFF))
-
+  marshalCmmUnPrimCall
+    I64
+    r
+    I32
+    x
+    (extendSInt32 . popCntInt32 . andInt32 (constI32 0xFF))
 marshalCmmPrimCall (GHC.MO_Clz GHC.W64) [r] [x] =
   marshalCmmUnPrimCall I64 r I64 x clzInt64
 marshalCmmPrimCall (GHC.MO_Clz GHC.W32) [r] [x] =
   marshalCmmUnPrimCall I64 r I32 x (extendSInt32 . clzInt32)
 marshalCmmPrimCall (GHC.MO_Clz GHC.W16) [r] [x] =
-  marshalCmmUnPrimCall I64 r I32 x (extendSInt32 . clzInt32 . orInt32 (constI32 0x8000) . (`shlInt32` constI32 16))
+  marshalCmmUnPrimCall
+    I64
+    r
+    I32
+    x
+    ( extendSInt32
+        . clzInt32
+        . orInt32 (constI32 0x8000)
+        . (`shlInt32` constI32 16)
+    )
 marshalCmmPrimCall (GHC.MO_Clz GHC.W8) [r] [x] =
-  marshalCmmUnPrimCall I64 r I32 x (extendSInt32 . clzInt32 . orInt32 (constI32 0x800000) . (`shlInt32` constI32 24))
-
+  marshalCmmUnPrimCall
+    I64
+    r
+    I32
+    x
+    ( extendSInt32
+        . clzInt32
+        . orInt32 (constI32 0x800000)
+        . (`shlInt32` constI32 24)
+    )
 marshalCmmPrimCall (GHC.MO_Ctz GHC.W64) [r] [x] =
   marshalCmmUnPrimCall I64 r I64 x ctzInt64
 marshalCmmPrimCall (GHC.MO_Ctz GHC.W32) [r] [x] =
   marshalCmmUnPrimCall I64 r I32 x (extendSInt32 . ctzInt32)
 marshalCmmPrimCall (GHC.MO_Ctz GHC.W16) [r] [x] =
-  marshalCmmUnPrimCall I64 r I32 x (extendSInt32 . ctzInt32 . orInt32 (constI32 0x10000))
+  marshalCmmUnPrimCall
+    I64
+    r
+    I32
+    x
+    (extendSInt32 . ctzInt32 . orInt32 (constI32 0x10000))
 marshalCmmPrimCall (GHC.MO_Ctz GHC.W8) [r] [x] =
-  marshalCmmUnPrimCall I64 r I32 x (extendSInt32 . ctzInt32 . orInt32 (constI32 0x100))
-
-
--- | r = result, o = overflow
--- | see also: GHC.Prim.subWordC#
+  marshalCmmUnPrimCall
+    I64
+    r
+    I32
+    x
+    (extendSInt32 . ctzInt32 . orInt32 (constI32 0x100))
+-- r = result, o = overflow
+-- see also: GHC.Prim.subWordC#
 marshalCmmPrimCall (GHC.MO_SubWordC GHC.W64) [r, o] [x, y] = do
   (xr, _) <- marshalCmmExpr x
   (yr, _) <- marshalCmmExpr y
-
   lr <- marshalTypedCmmLocalReg r I64
   lo <- marshalTypedCmmLocalReg o I64
-
-  let x_minus_y = Binary { binaryOp = SubInt64
-                     , operand0 = xr
-                     , operand1 = yr
-                     }
-
-  let overflow = Binary { binaryOp = LtUInt64
-                        , operand0 = xr
-                        , operand1 = yr
-                        }
-  let overflow_sext = Unary { unaryOp = ExtendUInt32
-                              , operand0 = overflow
-                              }
-
+  let x_minus_y = Binary {binaryOp = SubInt64, operand0 = xr, operand1 = yr}
+  let overflow = Binary {binaryOp = LtUInt64, operand0 = xr, operand1 = yr}
+  let overflow_sext = Unary {unaryOp = ExtendUInt32, operand0 = overflow}
   pure
-    [ UnresolvedSetLocal { unresolvedLocalReg = lr, value = x_minus_y }
-    , UnresolvedSetLocal
-        {  unresolvedLocalReg = lo, value = overflow_sext }
+    [ UnresolvedSetLocal {unresolvedLocalReg = lr, value = x_minus_y},
+      UnresolvedSetLocal {unresolvedLocalReg = lo, value = overflow_sext}
     ]
-
--- | r = result, o = overflow
--- | see also: GHC.Prim.addWordC#
+-- r = result, o = overflow
+-- see also: GHC.Prim.addWordC#
 marshalCmmPrimCall (GHC.MO_AddWordC GHC.W64) [r, o] [x, y] = do
   (xr, _) <- marshalCmmExpr x
   (yr, _) <- marshalCmmExpr y
-
   lr <- marshalTypedCmmLocalReg r I64
-  -- | x + y > maxbound
-  -- | y + x > maxbound
-  -- | y > maxbound - x
+  -- x + y > maxbound
+  -- y + x > maxbound
+  -- y > maxbound - x
   lo <- marshalTypedCmmLocalReg o I64
-
-  let x_plus_y = Binary { binaryOp = AddInt64
-                     , operand0 = xr
-                     , operand1 = yr
-                     }
-
-  let maxbound_minus_x = Binary { binaryOp = SubInt64
-                              , operand0 = ConstI64 0xFFFFFFFFFFFFFFFF
-                              , operand1 = xr
-                              }
-
-  let overflow = Binary { binaryOp = GtUInt64
-                                     , operand0 = yr
-                                     , operand1 = maxbound_minus_x
-                                     }
-  let overflow_sext = Unary { unaryOp = ExtendUInt32
-                            , operand0 = overflow
-                            }
-
-
+  let x_plus_y = Binary {binaryOp = AddInt64, operand0 = xr, operand1 = yr}
+  let maxbound_minus_x = Binary
+        { binaryOp = SubInt64,
+          operand0 = ConstI64 0xFFFFFFFFFFFFFFFF,
+          operand1 = xr
+        }
+  let overflow = Binary
+        { binaryOp = GtUInt64,
+          operand0 = yr,
+          operand1 = maxbound_minus_x
+        }
+  let overflow_sext = Unary {unaryOp = ExtendUInt32, operand0 = overflow}
   pure
-    [ UnresolvedSetLocal { unresolvedLocalReg = lr, value = x_plus_y }
-    , UnresolvedSetLocal
-        {  unresolvedLocalReg = lo, value = overflow_sext }
+    [ UnresolvedSetLocal {unresolvedLocalReg = lr, value = x_plus_y},
+      UnresolvedSetLocal {unresolvedLocalReg = lo, value = overflow_sext}
     ]
-
--- | See also: GHC.Prim.plusWord2
--- | add unsigned: return (carry, result)
+-- See also: GHC.Prim.plusWord2
+-- add unsigned: return (carry, result)
 marshalCmmPrimCall (GHC.MO_Add2 GHC.W64) [o, r] [x, y] = do
   (xr, _) <- marshalCmmExpr x
   (yr, _) <- marshalCmmExpr y
-
   lr <- marshalTypedCmmLocalReg r I64
-  -- | y + x > maxbound
-  -- | y > maxbound - x
+  -- y + x > maxbound
+  -- y > maxbound - x
   lo <- marshalTypedCmmLocalReg o I64
-
-  let x_plus_y = Binary { binaryOp = AddInt64
-                     , operand0 = xr
-                     , operand1 = yr
-                     }
-
-  let x_minus_maxbound = Binary { binaryOp = SubInt64
-                              , operand0 = ConstI64 0xFFFFFFFFFFFFFFFF
-                              , operand1 = xr
-                              }
-
-  let overflow = Binary { binaryOp = GtUInt64
-                                     , operand0 = yr
-                                     , operand1 = x_minus_maxbound
-                                     }
-  let overflow_sext = Unary { unaryOp = ExtendUInt32
-                                         , operand0 = overflow
-                                         }
-
-
+  let x_plus_y = Binary {binaryOp = AddInt64, operand0 = xr, operand1 = yr}
+  let x_minus_maxbound = Binary
+        { binaryOp = SubInt64,
+          operand0 = ConstI64 0xFFFFFFFFFFFFFFFF,
+          operand1 = xr
+        }
+  let overflow = Binary
+        { binaryOp = GtUInt64,
+          operand0 = yr,
+          operand1 = x_minus_maxbound
+        }
+  let overflow_sext = Unary {unaryOp = ExtendUInt32, operand0 = overflow}
   pure
-    [ UnresolvedSetLocal { unresolvedLocalReg = lr, value = x_plus_y }
-    , UnresolvedSetLocal
-        {  unresolvedLocalReg = lo, value = overflow_sext }
+    [ UnresolvedSetLocal {unresolvedLocalReg = lr, value = x_plus_y},
+      UnresolvedSetLocal {unresolvedLocalReg = lo, value = overflow_sext}
     ]
-
--- | See also: GHC.Prim.addIntC#
--- | add signed: return (result, overflow)
+-- See also: GHC.Prim.addIntC#
+-- add signed: return (result, overflow)
 marshalCmmPrimCall (GHC.MO_AddIntC GHC.W64) [r, o] [x, y] = do
   (xr, _) <- marshalCmmExpr x
   (yr, _) <- marshalCmmExpr y
-
   -- Copied from ghc-testsuite/numeric/CarryOverflow.hs:
   -- where ltTest x y =
   --         let r = x + y in (y > 0 && r < x) || (y < 0 && r > x)
-
   lr <- marshalTypedCmmLocalReg r I64
-  -- | y + x > maxbound
-  -- | y > maxbound - x
+  -- y + x > maxbound
+  -- y > maxbound - x
   lo <- marshalTypedCmmLocalReg o I64
-
-  let x_plus_y = Binary { binaryOp = AddInt64
-                     , operand0 = xr
-                     , operand1 = yr
-                     }
-
-  let y_positive_test = Binary { binaryOp = GtSInt64
-                               , operand0 = yr
-                               , operand1 = (ConstI64 0)
-                               }
-  let y_negative_test = Binary { binaryOp = LtSInt64
-                               , operand0 = yr
-                               , operand1 = (ConstI64 0)
-                               }
+  let x_plus_y = Binary {binaryOp = AddInt64, operand0 = xr, operand1 = yr}
+  let y_positive_test =
+        Binary {binaryOp = GtSInt64, operand0 = yr, operand1 = (ConstI64 0)}
+  let y_negative_test =
+        Binary {binaryOp = LtSInt64, operand0 = yr, operand1 = (ConstI64 0)}
   let x_plus_y_gt_x = Binary GtSInt64 x_plus_y xr
   let x_plus_y_lt_x = Binary LtSInt64 x_plus_y xr
-
   let clause_1 = Binary MulInt32 y_positive_test x_plus_y_lt_x
   let clause_2 = Binary MulInt32 y_negative_test x_plus_y_gt_x
-
-  -- | Addition is OK to express OR since only of the clauses can be
+  -- Addition is OK to express OR since only of the clauses can be
   -- true as they are mutually exclusive.
   let overflow = Binary AddInt32 clause_1 clause_2
-
-  let overflow_sext = Unary { unaryOp = ExtendUInt32
-                            , operand0 = overflow
-                            }
-
-
+  let overflow_sext = Unary {unaryOp = ExtendUInt32, operand0 = overflow}
   pure
-    [ UnresolvedSetLocal { unresolvedLocalReg = lr, value = x_plus_y }
-    , UnresolvedSetLocal
-        {  unresolvedLocalReg = lo, value = overflow_sext }
+    [ UnresolvedSetLocal {unresolvedLocalReg = lr, value = x_plus_y},
+      UnresolvedSetLocal {unresolvedLocalReg = lo, value = overflow_sext}
     ]
-
--- | subtract signed, reporting overflow:
+-- subtract signed, reporting overflow:
 -- see also: GHC.Prim.SubIntC#
 -- returns (result, overflow)
 marshalCmmPrimCall (GHC.MO_SubIntC GHC.W64) [r, o] [x, y] = do
   (xr, _) <- marshalCmmExpr x
   (yr, _) <- marshalCmmExpr y
-
   lr <- marshalTypedCmmLocalReg r I64
   lo <- marshalTypedCmmLocalReg o I64
-
   -- Copied from ghc-testsuite/numeric/CarryOverflow.hs:
   --  where ltTest x y =
   --        let r = x - y in (y > 0 && r > x) || (y < 0 && r < x)
-
-  let x_minus_y = Binary { binaryOp = SubInt64
-                     , operand0 = xr
-                     , operand1 = yr
-                     }
-  let y_positive_test = Binary { binaryOp = GtSInt64
-                               , operand0 = yr
-                               , operand1 = (ConstI64 0)
-                               }
-  let y_negative_test = Binary { binaryOp = LtSInt64
-                               , operand0 = yr
-                               , operand1 = (ConstI64 0)
-                               }
+  let x_minus_y = Binary {binaryOp = SubInt64, operand0 = xr, operand1 = yr}
+  let y_positive_test =
+        Binary {binaryOp = GtSInt64, operand0 = yr, operand1 = (ConstI64 0)}
+  let y_negative_test =
+        Binary {binaryOp = LtSInt64, operand0 = yr, operand1 = (ConstI64 0)}
   let x_minus_y_gt_x = Binary GtSInt64 x_minus_y xr
   let x_minus_y_lt_x = Binary LtSInt64 x_minus_y xr
-
   let clause_1 = Binary MulInt32 y_positive_test x_minus_y_gt_x
-  let clause_2 = Binary MulInt32 y_negative_test  x_minus_y_lt_x
-
-  -- | Addition is OK to express OR since only of the clauses can be
+  let clause_2 = Binary MulInt32 y_negative_test x_minus_y_lt_x
+  -- Addition is OK to express OR since only of the clauses can be
   -- true as they are mutually exclusive.
   let overflow = Binary AddInt32 clause_1 clause_2
-
-
-  let overflow_sext = Unary { unaryOp = ExtendUInt32
-                            , operand0 = overflow
-                            }
-
+  let overflow_sext = Unary {unaryOp = ExtendUInt32, operand0 = overflow}
   pure
-    [ UnresolvedSetLocal { unresolvedLocalReg = lr, value = x_minus_y }
-    , UnresolvedSetLocal
-        {  unresolvedLocalReg = lo, value = overflow_sext }
+    [ UnresolvedSetLocal {unresolvedLocalReg = lr, value = x_minus_y},
+      UnresolvedSetLocal {unresolvedLocalReg = lo, value = overflow_sext}
     ]
-
-
-
--- | high = high bits of result, low = low bits of result.
--- | see also: GHC.Prim.timesWord2#
+-- high = high bits of result, low = low bits of result.
+-- see also: GHC.Prim.timesWord2#
 marshalCmmPrimCall (GHC.MO_U_Mul2 GHC.W64) [hi, lo] [x, y] = do
   (xr, _) <- marshalCmmExpr x
   (yr, _) <- marshalCmmExpr y
-
   hir <- marshalTypedCmmLocalReg hi I64
   lor <- marshalTypedCmmLocalReg lo I64
-
-  -- | Smash the high and low 32 bits together to create a 64 bit
+  -- Smash the high and low 32 bits together to create a 64 bit
   -- number.
   let smash32IntTo64 hi32 lo32 =
-          Binary OrInt64
-              (Binary ShlInt64
-                 (Unary ExtendUInt32 hi32) (ConstI64 32))
-              (Unary ExtendUInt32 lo32)
-
- -- | mask the `n32`th block of v, counting blocks from the lowest bit.
+        Binary
+          OrInt64
+          (Binary ShlInt64 (Unary ExtendUInt32 hi32) (ConstI64 32))
+          (Unary ExtendUInt32 lo32)
+  -- mask the `n32`th block of v, counting blocks from the lowest bit.
   let mask32 v n32 =
-          Unary WrapInt64 $
-              Binary AndInt64
-                (Binary ShrUInt64 v (ConstI64 (n32 * 32)))
-                (ConstI64 0xFFFFFFFF)
-
-
-  let hiout =
-          UnresolvedSetLocal
-              { unresolvedLocalReg = hir
-              , value = smash32IntTo64
-                          CallImport
-                              { target' =  "__asterius_mul2"
-                              , operands = [mask32 xr 1, mask32 xr 0,
-                                            mask32 yr 1, mask32 yr 0,
-                                            ConstI32 3]
-                              , callImportReturnTypes = [I32]
-                              }
-                          CallImport
-                              { target' = "__asterius_mul2"
-                              , operands = [mask32 xr 1, mask32 xr 0,
-                                            mask32 yr 1, mask32 yr 0,
-                                            ConstI32 2]
-                              , callImportReturnTypes = [I32]
-                              }
+        Unary WrapInt64 $
+          Binary
+            AndInt64
+            (Binary ShrUInt64 v (ConstI64 (n32 * 32)))
+            (ConstI64 0xFFFFFFFF)
+  let hiout = UnresolvedSetLocal
+        { unresolvedLocalReg = hir,
+          value = smash32IntTo64
+            CallImport
+              { target' = "__asterius_mul2",
+                operands =
+                  [ mask32 xr 1,
+                    mask32 xr 0,
+                    mask32 yr 1,
+                    mask32 yr 0,
+                    ConstI32 3
+                  ],
+                callImportReturnTypes = [I32]
               }
-
-  let loout =
-          UnresolvedSetLocal
-              { unresolvedLocalReg = lor
-              , value = smash32IntTo64
-                          CallImport
-                              { target' = "__asterius_mul2"
-                              , operands = [mask32 xr 1, mask32 xr 0,
-                                            mask32 yr 1, mask32 yr 0,
-                                            ConstI32 1]
-                              , callImportReturnTypes = [I32]
-                              }
-                          CallImport
-                              { target' = "__asterius_mul2"
-                              , operands = [mask32 xr 1, mask32 xr 0,
-                                            mask32 yr 1, mask32 yr 0,
-                                            ConstI32 0]
-                              , callImportReturnTypes = [I32]
-                              }
+            CallImport
+              { target' = "__asterius_mul2",
+                operands =
+                  [ mask32 xr 1,
+                    mask32 xr 0,
+                    mask32 yr 1,
+                    mask32 yr 0,
+                    ConstI32 2
+                  ],
+                callImportReturnTypes = [I32]
               }
+        }
+  let loout = UnresolvedSetLocal
+        { unresolvedLocalReg = lor,
+          value = smash32IntTo64
+            CallImport
+              { target' = "__asterius_mul2",
+                operands =
+                  [ mask32 xr 1,
+                    mask32 xr 0,
+                    mask32 yr 1,
+                    mask32 yr 0,
+                    ConstI32 1
+                  ],
+                callImportReturnTypes = [I32]
+              }
+            CallImport
+              { target' = "__asterius_mul2",
+                operands =
+                  [ mask32 xr 1,
+                    mask32 xr 0,
+                    mask32 yr 1,
+                    mask32 yr 0,
+                    ConstI32 0
+                  ],
+                callImportReturnTypes = [I32]
+              }
+        }
   pure [hiout, loout]
-
-
 -- See also: QuotRemWord2#
 marshalCmmPrimCall (GHC.MO_U_QuotRem2 GHC.W64) [q, r] [lhsHi, lhsLo, rhs] = do
   quotr <- marshalTypedCmmLocalReg q I64
   remr <- marshalTypedCmmLocalReg r I64
-
   (lhsHir, _) <- marshalCmmExpr lhsHi
   (lhsLor, _) <- marshalCmmExpr lhsLo
   (rhsr, _) <- marshalCmmExpr rhs
-
-  -- | Smash the high and low 32 bits together to create a 64 bit
+  -- Smash the high and low 32 bits together to create a 64 bit
   -- number.
   let smash32IntTo64 hi32 lo32 =
-          Binary OrInt64
-              (Binary ShlInt64
-                 (Unary ExtendUInt32 hi32) (ConstI64 32))
-              (Unary ExtendUInt32 lo32)
-
- -- | mask the `n32`th block of v, counting blocks from the lowest bit.
+        Binary
+          OrInt64
+          (Binary ShlInt64 (Unary ExtendUInt32 hi32) (ConstI64 32))
+          (Unary ExtendUInt32 lo32)
+  -- mask the `n32`th block of v, counting blocks from the lowest bit.
   let mask32 v n32 =
-          Unary WrapInt64 $
-              Binary AndInt64
-                (Binary ShrUInt64 v (ConstI64 (n32 * 32)))
-                (ConstI64 0xFFFFFFFF)
-
-
-  let quotout =
-          UnresolvedSetLocal
-              { unresolvedLocalReg = quotr
-              ,  value = smash32IntTo64
-                           CallImport
-                              { target' = "__asterius_quotrem2_quotient"
-                              , operands = [mask32 lhsHir 1, mask32 lhsHir 0,
-                                            mask32 lhsLor 1, mask32 lhsLor 0,
-                                            mask32 rhsr 1, mask32 rhsr 0,
-                                            ConstI32 1]
-                              , callImportReturnTypes = [I32]
-                              }
-                           CallImport
-                              { target' = "__asterius_quotrem2_quotient"
-                              , operands = [mask32 lhsHir 1, mask32 lhsHir 0,
-                                            mask32 lhsLor 1, mask32 lhsLor 0,
-                                            mask32 rhsr 1, mask32 rhsr 0,
-                                            ConstI32 0]
-                              , callImportReturnTypes = [I32]
-                              }
+        Unary WrapInt64 $
+          Binary
+            AndInt64
+            (Binary ShrUInt64 v (ConstI64 (n32 * 32)))
+            (ConstI64 0xFFFFFFFF)
+  let quotout = UnresolvedSetLocal
+        { unresolvedLocalReg = quotr,
+          value = smash32IntTo64
+            CallImport
+              { target' = "__asterius_quotrem2_quotient",
+                operands =
+                  [ mask32 lhsHir 1,
+                    mask32 lhsHir 0,
+                    mask32 lhsLor 1,
+                    mask32 lhsLor 0,
+                    mask32 rhsr 1,
+                    mask32 rhsr 0,
+                    ConstI32 1
+                  ],
+                callImportReturnTypes = [I32]
               }
-  let remout =
-          UnresolvedSetLocal
-              { unresolvedLocalReg = remr
-              , value = smash32IntTo64
-                          CallImport
-                              { target' = "__asterius_quotrem2_remainder"
-                              , operands = [mask32 lhsHir 1, mask32 lhsHir 0,
-                                            mask32 lhsLor 1, mask32 lhsLor 0,
-                                            mask32 rhsr 1, mask32 rhsr 0,
-                                            ConstI32 1]
-                              , callImportReturnTypes = [I32]
-                              }
-                          CallImport
-                              { target' = "__asterius_quotrem2_remainder"
-                              , operands = [mask32 lhsHir 1, mask32 lhsHir 0,
-                                            mask32 lhsLor 1, mask32 lhsLor 0,
-                                            mask32 rhsr 1, mask32 rhsr 0,
-                                            ConstI32 0]
-                              , callImportReturnTypes = [I32]
-                              }
+            CallImport
+              { target' = "__asterius_quotrem2_quotient",
+                operands =
+                  [ mask32 lhsHir 1,
+                    mask32 lhsHir 0,
+                    mask32 lhsLor 1,
+                    mask32 lhsLor 0,
+                    mask32 rhsr 1,
+                    mask32 rhsr 0,
+                    ConstI32 0
+                  ],
+                callImportReturnTypes = [I32]
               }
-
+        }
+  let remout = UnresolvedSetLocal
+        { unresolvedLocalReg = remr,
+          value = smash32IntTo64
+            CallImport
+              { target' = "__asterius_quotrem2_remainder",
+                operands =
+                  [ mask32 lhsHir 1,
+                    mask32 lhsHir 0,
+                    mask32 lhsLor 1,
+                    mask32 lhsLor 0,
+                    mask32 rhsr 1,
+                    mask32 rhsr 0,
+                    ConstI32 1
+                  ],
+                callImportReturnTypes = [I32]
+              }
+            CallImport
+              { target' = "__asterius_quotrem2_remainder",
+                operands =
+                  [ mask32 lhsHir 1,
+                    mask32 lhsHir 0,
+                    mask32 lhsLor 1,
+                    mask32 lhsLor 0,
+                    mask32 rhsr 1,
+                    mask32 rhsr 0,
+                    ConstI32 0
+                  ],
+                callImportReturnTypes = [I32]
+              }
+        }
   pure [quotout, remout]
-
 marshalCmmPrimCall op rs xs =
-  throwError $
-  UnsupportedCmmInstr $
-  showSBS $ GHC.CmmUnsafeForeignCall (GHC.PrimTarget op) rs xs
+  throwError $ UnsupportedCmmInstr $ showSBS $
+    GHC.CmmUnsafeForeignCall
+      (GHC.PrimTarget op)
+      rs
+      xs
 
 marshalCmmUnsafeCall ::
-     GHC.CmmExpr
-  -> GHC.ForeignConvention
-  -> [GHC.LocalReg]
-  -> [GHC.CmmExpr]
-  -> CodeGen [Expression]
+  GHC.CmmExpr ->
+  GHC.ForeignConvention ->
+  [GHC.LocalReg] ->
+  [GHC.CmmExpr] ->
+  CodeGen [Expression]
 marshalCmmUnsafeCall p@(GHC.CmmLit (GHC.CmmLabel clbl)) f rs xs = do
   sym <- marshalCLabel clbl
-  xes <-
-    for xs $ \x -> do
-      (xe, _) <- marshalCmmExpr x
-      pure xe
+  xes <- for xs $ \x -> do
+    (xe, _) <- marshalCmmExpr x
+    pure xe
   case rs of
     [] -> pure [Call {target = sym, operands = xes, callReturnTypes = []}]
     [r] -> do
       (lr, vt) <- marshalCmmLocalReg r
       pure
         [ UnresolvedSetLocal
-            { unresolvedLocalReg = lr
-            , value =
-                Call {target = sym, operands = xes, callReturnTypes = [vt]}
+            { unresolvedLocalReg = lr,
+              value = Call
+                { target = sym,
+                  operands = xes,
+                  callReturnTypes = [vt]
+                }
             }
         ]
     _ ->
-      throwError $
-      UnsupportedCmmInstr $
-      showSBS $ GHC.CmmUnsafeForeignCall (GHC.ForeignTarget p f) rs xs
-
+      throwError $ UnsupportedCmmInstr $ showSBS $
+        GHC.CmmUnsafeForeignCall
+          (GHC.ForeignTarget p f)
+          rs
+          xs
 marshalCmmUnsafeCall p f rs xs =
-  throwError $
-  UnsupportedCmmInstr $
-  showSBS $ GHC.CmmUnsafeForeignCall (GHC.ForeignTarget p f) rs xs
+  throwError $ UnsupportedCmmInstr $ showSBS $
+    GHC.CmmUnsafeForeignCall
+      (GHC.ForeignTarget p f)
+      rs
+      xs
 
 marshalCmmInstr :: GHC.CmmNode GHC.O GHC.O -> CodeGen [Expression]
-marshalCmmInstr instr =
-  case instr of
-    GHC.CmmComment {} -> pure []
-    GHC.CmmTick {} -> pure []
-    GHC.CmmUnsafeForeignCall (GHC.PrimTarget op) rs xs ->
-      marshalCmmPrimCall op rs xs
-    GHC.CmmUnsafeForeignCall (GHC.ForeignTarget t c) rs xs ->
-      marshalCmmUnsafeCall t c rs xs
-    GHC.CmmAssign (GHC.CmmLocal r) e -> do
-      (lr, vt) <- marshalCmmLocalReg r
-      v <- marshalAndCastCmmExpr e vt
-      pure [UnresolvedSetLocal {unresolvedLocalReg = lr, value = v}]
-    GHC.CmmAssign (GHC.CmmGlobal r) e -> do
-      gr <- marshalCmmGlobalReg r
-      v <- marshalAndCastCmmExpr e $ unresolvedGlobalRegType gr
-      pure [unresolvedSetGlobal gr v]
-    GHC.CmmStore p e -> do
-      pv <- marshalAndCastCmmExpr p I32
-      (dflags, _) <- ask
-      store_instr <-
-        join $
+marshalCmmInstr instr = case instr of
+  GHC.CmmComment {} -> pure []
+  GHC.CmmTick {} -> pure []
+  GHC.CmmUnsafeForeignCall (GHC.PrimTarget op) rs xs ->
+    marshalCmmPrimCall op rs xs
+  GHC.CmmUnsafeForeignCall (GHC.ForeignTarget t c) rs xs ->
+    marshalCmmUnsafeCall t c rs xs
+  GHC.CmmAssign (GHC.CmmLocal r) e -> do
+    (lr, vt) <- marshalCmmLocalReg r
+    v <- marshalAndCastCmmExpr e vt
+    pure [UnresolvedSetLocal {unresolvedLocalReg = lr, value = v}]
+  GHC.CmmAssign (GHC.CmmGlobal r) e -> do
+    gr <- marshalCmmGlobalReg r
+    v <- marshalAndCastCmmExpr e $ unresolvedGlobalRegType gr
+    pure [unresolvedSetGlobal gr v]
+  GHC.CmmStore p e -> do
+    pv <- marshalAndCastCmmExpr p I32
+    (dflags, _) <- ask
+    store_instr <-
+      join $
         dispatchAllCmmWidth
           (GHC.cmmExprWidth dflags e)
-          (do xe <- marshalAndCastCmmExpr e I32
-              pure
-                Store
-                  {bytes = 1, offset = 0, ptr = pv, value = xe, valueType = I32})
-          (do xe <- marshalAndCastCmmExpr e I32
-              pure
-                Store
-                  {bytes = 2, offset = 0, ptr = pv, value = xe, valueType = I32})
-          (do (xe, vt) <- marshalCmmExpr e
-              pure
-                Store
-                  {bytes = 4, offset = 0, ptr = pv, value = xe, valueType = vt})
-          (do (xe, vt) <- marshalCmmExpr e
-              pure
-                Store
-                  {bytes = 8, offset = 0, ptr = pv, value = xe, valueType = vt})
-      pure [store_instr]
-    _ -> throwError $ UnsupportedCmmInstr $ showSBS instr
+          ( do
+              xe <- marshalAndCastCmmExpr e I32
+              pure Store
+                { bytes = 1,
+                  offset = 0,
+                  ptr = pv,
+                  value = xe,
+                  valueType = I32
+                }
+          )
+          ( do
+              xe <- marshalAndCastCmmExpr e I32
+              pure Store
+                { bytes = 2,
+                  offset = 0,
+                  ptr = pv,
+                  value = xe,
+                  valueType = I32
+                }
+          )
+          ( do
+              (xe, vt) <- marshalCmmExpr e
+              pure Store
+                { bytes = 4,
+                  offset = 0,
+                  ptr = pv,
+                  value = xe,
+                  valueType = vt
+                }
+          )
+          ( do
+              (xe, vt) <- marshalCmmExpr e
+              pure Store
+                { bytes = 8,
+                  offset = 0,
+                  ptr = pv,
+                  value = xe,
+                  valueType = vt
+                }
+          )
+    pure [store_instr]
+  _ -> throwError $ UnsupportedCmmInstr $ showSBS instr
 
 marshalCmmBlockBody :: [GHC.CmmNode GHC.O GHC.O] -> CodeGen [Expression]
 marshalCmmBlockBody instrs = concat <$> for instrs marshalCmmInstr
 
 marshalCmmBlockBranch ::
-     GHC.CmmNode GHC.O GHC.C
-  -> CodeGen ([Expression], Maybe Expression, [RelooperAddBranch])
-marshalCmmBlockBranch instr =
-  case instr of
-    GHC.CmmBranch lbl -> do
-      k <- marshalLabel lbl
-      pure ([], Nothing, [AddBranch {to = k, addBranchCondition = Nothing}])
-    GHC.CmmCondBranch {..} -> do
-      c <- marshalAndCastCmmExpr cml_pred I32
-      kf <- marshalLabel cml_false
-      kt <- marshalLabel cml_true
-      pure
-        ( []
-        , Nothing
-        , [AddBranch {to = kt, addBranchCondition = Just c} | kt /= kf] <>
-          [AddBranch {to = kf, addBranchCondition = Nothing}])
-    GHC.CmmSwitch cml_arg st -> do
-      a <- marshalAndCastCmmExpr cml_arg I64
-      brs <-
-        for (GHC.switchTargetsCases st) $ \(idx, lbl) -> do
-          dest <- marshalLabel lbl
-          pure (dest, [fromIntegral $ idx - fst (GHC.switchTargetsRange st)])
-      dest_def <-
-        case GHC.switchTargetsDefault st of
-          Just lbl -> marshalLabel lbl
-          _ -> pure "__asterius_unreachable"
-      pure
-        ( []
-        , Just
-            Unary
-              { unaryOp = WrapInt64
-              , operand0 =
-                  case GHC.switchTargetsRange st of
-                    (0, _) -> a
-                    (l, _) ->
-                      Binary
-                        { binaryOp = SubInt64
-                        , operand0 = a
-                        , operand1 = ConstI64 $ fromIntegral l
-                        }
-              }
-        , [ AddBranchForSwitch {to = dest, indexes = tags}
-          | (dest, tags) <- M.toList $ M.fromListWith (<>) brs
-          , dest /= dest_def
-          ] <>
-          [AddBranch {to = dest_def, addBranchCondition = Nothing}])
-    GHC.CmmCall {..} -> do
-      t <- marshalAndCastCmmExpr cml_target I64
-      pure
-        ( [ case t of
-              Symbol {..} -> ReturnCall {returnCallTarget64 = unresolvedSymbol}
-              _ -> ReturnCallIndirect {returnCallIndirectTarget64 = t}
-          ]
-        , Nothing
-        , [])
-    _ -> throwError $ UnsupportedCmmBranch $ showSBS instr
+  GHC.CmmNode GHC.O GHC.C ->
+  CodeGen ([Expression], Maybe Expression, [RelooperAddBranch])
+marshalCmmBlockBranch instr = case instr of
+  GHC.CmmBranch lbl -> do
+    k <- marshalLabel lbl
+    pure ([], Nothing, [AddBranch {to = k, addBranchCondition = Nothing}])
+  GHC.CmmCondBranch {..} -> do
+    c <- marshalAndCastCmmExpr cml_pred I32
+    kf <- marshalLabel cml_false
+    kt <- marshalLabel cml_true
+    pure
+      ( [],
+        Nothing,
+        [AddBranch {to = kt, addBranchCondition = Just c} | kt /= kf]
+          <> [AddBranch {to = kf, addBranchCondition = Nothing}]
+      )
+  GHC.CmmSwitch cml_arg st -> do
+    a <- marshalAndCastCmmExpr cml_arg I64
+    brs <- for (GHC.switchTargetsCases st) $ \(idx, lbl) -> do
+      dest <- marshalLabel lbl
+      pure (dest, [fromIntegral $ idx - fst (GHC.switchTargetsRange st)])
+    dest_def <- case GHC.switchTargetsDefault st of
+      Just lbl -> marshalLabel lbl
+      _ -> pure "__asterius_unreachable"
+    pure
+      ( [],
+        Just Unary
+          { unaryOp = WrapInt64,
+            operand0 = case GHC.switchTargetsRange st of
+              (0, _) -> a
+              (l, _) -> Binary
+                { binaryOp = SubInt64,
+                  operand0 = a,
+                  operand1 = ConstI64 $ fromIntegral l
+                }
+          },
+        [ AddBranchForSwitch {to = dest, indexes = tags}
+          | (dest, tags) <- M.toList $ M.fromListWith (<>) brs,
+            dest /= dest_def
+        ]
+          <> [AddBranch {to = dest_def, addBranchCondition = Nothing}]
+      )
+  GHC.CmmCall {..} -> do
+    t <- marshalAndCastCmmExpr cml_target I64
+    pure
+      ( [ case t of
+            Symbol {..} -> ReturnCall {returnCallTarget64 = unresolvedSymbol}
+            _ -> ReturnCallIndirect {returnCallIndirectTarget64 = t}
+        ],
+        Nothing,
+        []
+      )
+  _ -> throwError $ UnsupportedCmmBranch $ showSBS instr
 
 marshalCmmBlock ::
-     [GHC.CmmNode GHC.O GHC.O]
-  -> GHC.CmmNode GHC.O GHC.C
-  -> CodeGen RelooperBlock
+  [GHC.CmmNode GHC.O GHC.O] ->
+  GHC.CmmNode GHC.O GHC.C ->
+  CodeGen RelooperBlock
 marshalCmmBlock inner_nodes exit_node = do
   inner_exprs <- marshalCmmBlockBody inner_nodes
   (br_helper_exprs, maybe_switch_cond_expr, br_branches) <-
     marshalCmmBlockBranch exit_node
-  pure $
-    case maybe_switch_cond_expr of
-      Just switch_cond_expr ->
-        RelooperBlock
-          { addBlock =
-              AddBlockWithSwitch
-                { code = concatExpressions $ inner_exprs <> br_helper_exprs
-                , condition = switch_cond_expr
-                }
-          , addBranches = br_branches
-          }
-      _ ->
-        RelooperBlock
-          { addBlock =
-              AddBlock
-                {code = concatExpressions $ inner_exprs <> br_helper_exprs}
-          , addBranches = br_branches
-          }
+  pure $ case maybe_switch_cond_expr of
+    Just switch_cond_expr -> RelooperBlock
+      { addBlock = AddBlockWithSwitch
+          { code = concatExpressions $ inner_exprs <> br_helper_exprs,
+            condition = switch_cond_expr
+          },
+        addBranches = br_branches
+      }
+    _ -> RelooperBlock
+      { addBlock = AddBlock
+          { code = concatExpressions $ inner_exprs <> br_helper_exprs
+          },
+        addBranches = br_branches
+      }
   where
-    concatExpressions es =
-      case es of
-        [] -> Nop
-        [e] -> e
-        _ -> Block {name = "", bodys = es, blockReturnTypes = []}
+    concatExpressions es = case es of
+      [] -> Nop
+      [e] -> e
+      _ -> Block {name = "", bodys = es, blockReturnTypes = []}
 
 marshalCmmProc :: AsteriusEntitySymbol -> GHC.CmmGraph -> CodeGen Function
 marshalCmmProc sym GHC.CmmGraph {g_graph = GHC.GMany _ body _, ..} = do
@@ -1382,62 +1404,51 @@ marshalCmmProc sym GHC.CmmGraph {g_graph = GHC.GMany _ body _, ..} = do
       b <- marshalCmmBlock (GHC.blockToList inner_nodes) exit_node
       pure (k, b)
   let blocks_unresolved =
-        ( "__asterius_unreachable"
-        , RelooperBlock
-            { addBlock =
-                AddBlock
-                  { code =
-                      Barf
-                        { barfMessage = "unreachable block"
-                        , barfReturnTypes = []
-                        }
-                  }
-            , addBranches = []
-            }) :
-        rbs
-  pure $
-    splitFunction sym $ adjustLocalRegs
-      Function
-        { functionType = FunctionType {paramTypes = [], returnTypes = []}
-        , varTypes = []
-        , body =
-            CFG
-              RelooperRun
-                { entry = entry_k
-                , blockMap = M.fromList blocks_unresolved
-                , labelHelper = 0
-                }
+        ( "__asterius_unreachable",
+          RelooperBlock
+            { addBlock = AddBlock
+                { code = Barf
+                    { barfMessage = "unreachable block",
+                      barfReturnTypes = []
+                    }
+                },
+              addBranches = []
+            }
+        )
+          : rbs
+  pure $ splitFunction sym $ adjustLocalRegs Function
+    { functionType = FunctionType {paramTypes = [], returnTypes = []},
+      varTypes = [],
+      body = CFG RelooperRun
+        { entry = entry_k,
+          blockMap = M.fromList blocks_unresolved,
+          labelHelper = 0
         }
+    }
 
 marshalCmmDecl ::
-     GHC.GenCmmDecl GHC.CmmStatics h GHC.CmmGraph -> CodeGen AsteriusModule
-marshalCmmDecl decl =
-  case decl of
-    GHC.CmmData sec d@(GHC.Statics clbl _) -> do
-      sym <- marshalCLabel clbl
-      r <- unCodeGen $ marshalCmmData sym sec d
-      pure $
-        case r of
-          Left err -> mempty {staticsErrorMap = M.fromList [(sym, err)]}
-          Right ass -> mempty {staticsMap = M.fromList [(sym, ass)]}
-    GHC.CmmProc _ clbl _ g -> do
-      sym <- marshalCLabel clbl
-      r <- unCodeGen $ marshalCmmProc sym g
-      let f =
-            case r of
-              Left err ->
-                Function
-                  { functionType =
-                      FunctionType {paramTypes = [], returnTypes = []}
-                  , varTypes = []
-                  , body =
-                      Barf
-                        { barfMessage = fromString $ show err
-                        , barfReturnTypes = []
-                        }
-                  }
-              Right f' -> f'
-      pure $ processBarf sym f
+  GHC.GenCmmDecl GHC.CmmStatics h GHC.CmmGraph -> CodeGen AsteriusModule
+marshalCmmDecl decl = case decl of
+  GHC.CmmData sec d@(GHC.Statics clbl _) -> do
+    sym <- marshalCLabel clbl
+    r <- unCodeGen $ marshalCmmData sym sec d
+    pure $ case r of
+      Left err -> mempty {staticsErrorMap = M.fromList [(sym, err)]}
+      Right ass -> mempty {staticsMap = M.fromList [(sym, ass)]}
+  GHC.CmmProc _ clbl _ g -> do
+    sym <- marshalCLabel clbl
+    r <- unCodeGen $ marshalCmmProc sym g
+    let f = case r of
+          Left err -> Function
+            { functionType = FunctionType {paramTypes = [], returnTypes = []},
+              varTypes = [],
+              body = Barf
+                { barfMessage = fromString $ show err,
+                  barfReturnTypes = []
+                }
+            }
+          Right f' -> f'
+    pure $ processBarf sym f
 
 marshalHaskellIR :: GHC.Module -> HaskellIR -> CodeGen AsteriusModule
 marshalHaskellIR this_mod HaskellIR {..} = marshalRawCmm this_mod cmmRaw

--- a/asterius/src/Asterius/EDSL.hs
+++ b/asterius/src/Asterius/EDSL.hs
@@ -5,108 +5,109 @@
 {-# LANGUAGE StrictData #-}
 
 module Asterius.EDSL
-  ( EDSL
-  , emit
-  , runEDSL
-  , LVal
-  , getLVal
-  , putLVal
-  , setReturnTypes
-  , mutParam
-  , mutLocal
-  , param
-  , params
-  , local
-  , i64Local
-  , i32Local
-  , i64MutLocal
-  , global
-  , pointer
-  , pointerI64
-  , pointerI32
-  , pointerI16
-  , pointerI8
-  , pointerF64
-  , pointerF32
-  , loadI64
-  , loadI32
-  , loadI16
-  , loadI8
-  , loadF64
-  , loadF32
-  , storeI64
-  , storeI32
-  , storeI16
-  , storeI8
-  , storeF64
-  , storeF32
-  , call
-  , call'
-  , callImport
-  , callImport'
-  , callIndirect
-  , Label
-  , block'
-  , loop'
-  , if'
-  , break'
-  , whileLoop
-  , switchI64
-  , notInt64
-  , notInt32
-  , eqZInt64
-  , eqZInt32
-  , extendUInt32
-  , extendSInt32
-  , wrapInt64
-  , convertUInt64ToFloat64
-  , truncUFloat64ToInt64
-  , convertSInt64ToFloat64
-  , truncSFloat64ToInt64
-  , roundupBytesToWords
-  , popCntInt32
-  , clzInt32
-  , ctzInt32
-  , popCntInt64
-  , clzInt64
-  , ctzInt64
-  , addInt64
-  , subInt64
-  , mulInt64
-  , divUInt64
-  , gtUInt64
-  , geUInt64
-  , shlInt64
-  , shrUInt64
-  , geUInt32
-  , addInt32
-  , subInt32
-  , mulInt32
-  , shlInt32
-  , eqInt64
-  , eqInt32
-  , ltUInt64
-  , leUInt64
-  , ltUInt32
-  , neInt64
-  , neInt32
-  , andInt64
-  , orInt64
-  , andInt32
-  , orInt32
-  , symbol
-  , symbol'
-  , constI32
-  , constI64
-  , constF64
-  , baseReg
-  , r1
-  , currentNursery
-  , currentTSO
-  , currentTID
-  , hpAlloc
-  , mainCapability
-  ) where
+  ( EDSL,
+    emit,
+    runEDSL,
+    LVal,
+    getLVal,
+    putLVal,
+    setReturnTypes,
+    mutParam,
+    mutLocal,
+    param,
+    params,
+    local,
+    i64Local,
+    i32Local,
+    i64MutLocal,
+    global,
+    pointer,
+    pointerI64,
+    pointerI32,
+    pointerI16,
+    pointerI8,
+    pointerF64,
+    pointerF32,
+    loadI64,
+    loadI32,
+    loadI16,
+    loadI8,
+    loadF64,
+    loadF32,
+    storeI64,
+    storeI32,
+    storeI16,
+    storeI8,
+    storeF64,
+    storeF32,
+    call,
+    call',
+    callImport,
+    callImport',
+    callIndirect,
+    Label,
+    block',
+    loop',
+    if',
+    break',
+    whileLoop,
+    switchI64,
+    notInt64,
+    notInt32,
+    eqZInt64,
+    eqZInt32,
+    extendUInt32,
+    extendSInt32,
+    wrapInt64,
+    convertUInt64ToFloat64,
+    truncUFloat64ToInt64,
+    convertSInt64ToFloat64,
+    truncSFloat64ToInt64,
+    roundupBytesToWords,
+    popCntInt32,
+    clzInt32,
+    ctzInt32,
+    popCntInt64,
+    clzInt64,
+    ctzInt64,
+    addInt64,
+    subInt64,
+    mulInt64,
+    divUInt64,
+    gtUInt64,
+    geUInt64,
+    shlInt64,
+    shrUInt64,
+    geUInt32,
+    addInt32,
+    subInt32,
+    mulInt32,
+    shlInt32,
+    eqInt64,
+    eqInt32,
+    ltUInt64,
+    leUInt64,
+    ltUInt32,
+    neInt64,
+    neInt32,
+    andInt64,
+    orInt64,
+    andInt32,
+    orInt32,
+    symbol,
+    symbol',
+    constI32,
+    constI64,
+    constF64,
+    baseReg,
+    r1,
+    currentNursery,
+    currentTSO,
+    currentTID,
+    hpAlloc,
+    mainCapability,
+  )
+where
 
 import Asterius.Internals
 import Asterius.Passes.All
@@ -133,29 +134,29 @@ fromDList :: DList a -> [a]
 fromDList = ($ []) . appEndo
 
 -- | State maintained by the EDSL builder.
-data EDSLState = EDSLState
-  { retTypes :: [ValueType]
-  , paramBuf :: DList ValueType
-  , paramNum, localNum, labelNum :: Int
-  , exprBuf :: DList Expression
-  , staticsBuf :: [(AsteriusEntitySymbol, AsteriusStatics)]
-  -- ^ Static variables to be added into the module
-  }
+data EDSLState
+  = EDSLState
+      { retTypes :: [ValueType],
+        paramBuf :: DList ValueType,
+        paramNum, localNum, labelNum :: Int,
+        exprBuf :: DList Expression,
+        -- | Static variables to be added into the module
+        staticsBuf :: [(AsteriusEntitySymbol, AsteriusStatics)]
+      }
 
 initialEDSLState :: EDSLState
-initialEDSLState =
-  EDSLState
-    { retTypes = []
-    , paramBuf = mempty
-    , paramNum = 0
-    , localNum = 0
-    , labelNum = 0
-    , exprBuf = mempty
-    , staticsBuf = mempty
-    }
+initialEDSLState = EDSLState
+  { retTypes = [],
+    paramBuf = mempty,
+    paramNum = 0,
+    localNum = 0,
+    labelNum = 0,
+    exprBuf = mempty,
+    staticsBuf = mempty
+  }
 
-newtype EDSL a =
-  EDSL (State EDSLState a)
+newtype EDSL a
+  = EDSL (State EDSLState a)
   deriving (Functor, Applicative, Monad)
 
 instance MonadFail EDSL where
@@ -172,67 +173,73 @@ emit e =
   EDSL $ modify' $ \s@EDSLState {..} -> s {exprBuf = exprBuf `dListSnoc` e}
 
 --  | Create a block from the list of expressions returning the given values.
-bundleExpressions :: [ValueType] -- ^ Return values of the block
-  -> [Expression] -- ^ Expressions in the block
-  -> Expression
-bundleExpressions vts el =
-  case el of
-    [] -> Nop
-    [e] -> e
-    _ -> Block {name = mempty, bodys = el, blockReturnTypes = vts}
+bundleExpressions ::
+  -- | Return values of the block
+  [ValueType] ->
+  -- | Expressions in the block
+  [Expression] ->
+  Expression
+bundleExpressions vts el = case el of
+  [] -> Nop
+  [e] -> e
+  _ -> Block {name = mempty, bodys = el, blockReturnTypes = vts}
 
 -- | Build a module containing the function and some auxiliary data
 -- | given its name and a builder.
-runEDSL :: AsteriusEntitySymbol  -- ^ Function name
-  -> EDSL ()  -- ^ Builder
-  -> AsteriusModule -- ^ Final module
-runEDSL n (EDSL m) = m1 {staticsMap = LM.fromList staticsBuf <> staticsMap m1}
+runEDSL ::
+  -- | Function name
+  AsteriusEntitySymbol ->
+  -- | Builder
+  EDSL () ->
+  -- | Final module
+  AsteriusModule
+runEDSL n (EDSL m) =
+  m1
+    { staticsMap = LM.fromList staticsBuf <> staticsMap m1
+    }
   where
     EDSLState {..} = execState m initialEDSLState
-    f0 =
-      adjustLocalRegs $
-      Function
-        { functionType =
-            FunctionType
-              {paramTypes = fromDList paramBuf, returnTypes = retTypes}
-        , varTypes = []
-        , body = bundleExpressions retTypes $ fromDList exprBuf
-        }
+    f0 = adjustLocalRegs $ Function
+      { functionType = FunctionType
+          { paramTypes = fromDList paramBuf,
+            returnTypes = retTypes
+          },
+        varTypes = [],
+        body = bundleExpressions retTypes $ fromDList exprBuf
+      }
     m1 = processBarf n f0
 
 -- | Any value that can be read from and wrtten to is an LVal
-data LVal = LVal
-  { getLVal :: Expression -- ^ Read from the LVal
-  , putLVal :: Expression -> EDSL () -- ^ Write into the LVal
-  }
+data LVal
+  = LVal
+      { -- | Read from the LVal
+        getLVal :: Expression,
+        -- | Write into the LVal
+        putLVal :: Expression -> EDSL ()
+      }
 
 -- | set the return type of the EDSL expression
 setReturnTypes :: [ValueType] -> EDSL ()
 setReturnTypes vts = EDSL $ modify' $ \s -> s {retTypes = vts}
 
 mutParam, mutLocal :: ValueType -> EDSL LVal
-mutParam vt =
-  EDSL $ do
-    i <-
-      state $ \s@EDSLState {..} ->
-        ( fromIntegral paramNum
-        , s {paramBuf = paramBuf `dListSnoc` vt, paramNum = succ paramNum})
-    pure
-      LVal
-        { getLVal = GetLocal {index = i, valueType = vt}
-        , putLVal = \v -> emit SetLocal {index = i, value = v}
-        }
-
-mutLocal vt =
-  EDSL $ do
-    i <- state $ \s@EDSLState {..} -> (localNum, s {localNum = succ localNum})
-    let lr = UniqueLocalReg i vt
-    pure
-      LVal
-        { getLVal = UnresolvedGetLocal {unresolvedLocalReg = lr}
-        , putLVal =
-            \v -> emit UnresolvedSetLocal {unresolvedLocalReg = lr, value = v}
-        }
+mutParam vt = EDSL $ do
+  i <- state $ \s@EDSLState {..} ->
+    ( fromIntegral paramNum,
+      s {paramBuf = paramBuf `dListSnoc` vt, paramNum = succ paramNum}
+    )
+  pure LVal
+    { getLVal = GetLocal {index = i, valueType = vt},
+      putLVal = \v -> emit SetLocal {index = i, value = v}
+    }
+mutLocal vt = EDSL $ do
+  i <- state $ \s@EDSLState {..} -> (localNum, s {localNum = succ localNum})
+  let lr = UniqueLocalReg i vt
+  pure LVal
+    { getLVal = UnresolvedGetLocal {unresolvedLocalReg = lr},
+      putLVal = \v ->
+        emit UnresolvedSetLocal {unresolvedLocalReg = lr, value = v}
+    }
 
 param :: ValueType -> EDSL Expression
 param vt = do
@@ -250,80 +257,75 @@ local vt v = do
 
 i64Local, i32Local :: Expression -> EDSL Expression
 i64Local = local I64
-
 i32Local = local I32
 
 i64MutLocal :: EDSL LVal
 i64MutLocal = mutLocal I64
 
 global :: UnresolvedGlobalReg -> LVal
-global gr =
-  LVal
-    {getLVal = unresolvedGetGlobal gr, putLVal = emit . unresolvedSetGlobal gr}
+global gr = LVal
+  { getLVal = unresolvedGetGlobal gr,
+    putLVal = emit . unresolvedSetGlobal gr
+  }
 
 pointer :: ValueType -> BinaryenIndex -> Expression -> Int -> LVal
-pointer vt b bp o =
-  LVal
-    { getLVal =
-        Load
-          { signed = False
-          , bytes = b
-          , offset = fromIntegral o
-          , valueType = vt
-          , ptr = wrapInt64 bp
-          }
-    , putLVal =
-        \v ->
-          emit $
-          Store
-            { bytes = b
-            , offset = fromIntegral o
-            , ptr = wrapInt64 bp
-            , value = v
-            , valueType = vt
-            }
-    }
+pointer vt b bp o = LVal
+  { getLVal = Load
+      { signed = False,
+        bytes = b,
+        offset = fromIntegral o,
+        valueType = vt,
+        ptr = wrapInt64 bp
+      },
+    putLVal = \v -> emit $ Store
+      { bytes = b,
+        offset = fromIntegral o,
+        ptr = wrapInt64 bp,
+        value = v,
+        valueType = vt
+      }
+  }
 
-pointerI64, pointerI32, pointerI16, pointerI8, pointerF64, pointerF32 ::
-     Expression -> Int -> LVal
+pointerI64,
+  pointerI32,
+  pointerI16,
+  pointerI8,
+  pointerF64,
+  pointerF32 ::
+    Expression -> Int -> LVal
 pointerI64 = pointer I64 8
-
 pointerI32 = pointer I32 4
-
 pointerI16 = pointer I32 2
-
 pointerI8 = pointer I32 1
-
 pointerF64 = pointer F64 8
-
 pointerF32 = pointer F32 4
 
-loadI64, loadI32, loadI16, loadI8, loadF64, loadF32 ::
-     Expression -> Int -> Expression
+loadI64,
+  loadI32,
+  loadI16,
+  loadI8,
+  loadF64,
+  loadF32 ::
+    Expression -> Int -> Expression
 loadI64 bp o = getLVal $ pointerI64 bp o
-
 loadI32 bp o = getLVal $ pointerI32 bp o
-
 loadI16 bp o = getLVal $ pointerI16 bp o
-
 loadI8 bp o = getLVal $ pointerI8 bp o
-
 loadF64 bp o = getLVal $ pointerF64 bp o
-
 loadF32 bp o = getLVal $ pointerF32 bp o
 
-storeI64, storeI32, storeI16, storeI8, storeF64, storeF32 ::
-     Expression -> Int -> Expression -> EDSL ()
+storeI64,
+  storeI32,
+  storeI16,
+  storeI8,
+  storeF64,
+  storeF32 ::
+    Expression -> Int -> Expression -> EDSL ()
 storeI64 bp o = putLVal $ pointerI64 bp o
-
 storeI32 bp o = putLVal $ pointerI32 bp o
-
 storeI16 bp o = putLVal $ pointerI16 bp o
-
 storeI8 bp o = putLVal $ pointerI8 bp o
-
 storeF64 bp o = putLVal $ pointerF64 bp o
-
 storeF32 bp o = putLVal $ pointerF32 bp o
 
 call :: AsteriusEntitySymbol -> [Expression] -> EDSL ()
@@ -336,18 +338,24 @@ call' f xs vt = do
   pure $ getLVal lr
 
 -- | Call a function with no return value
-callImport :: SBS.ShortByteString -- ^ Function name
-  -> [Expression] -- ^ Parameter list
-  -> EDSL ()
+callImport ::
+  -- | Function name
+  SBS.ShortByteString ->
+  -- | Parameter list
+  [Expression] ->
+  EDSL ()
 callImport f xs =
   emit CallImport {target' = f, operands = xs, callImportReturnTypes = []}
 
 -- | Call a function with a return value
 callImport' ::
-     SBS.ShortByteString -- ^ Function name
-     -> [Expression] -- ^ Arguments
-     -> ValueType -- ^ Return type of function
-     -> EDSL Expression
+  -- | Function name
+  SBS.ShortByteString ->
+  -- | Arguments
+  [Expression] ->
+  -- | Return type of function
+  ValueType ->
+  EDSL Expression
 callImport' f xs vt = do
   lr <- mutLocal vt
   putLVal
@@ -356,28 +364,25 @@ callImport' f xs vt = do
   pure $ getLVal lr
 
 callIndirect :: Expression -> EDSL ()
-callIndirect f =
-  emit
-    CallIndirect
-      { indirectTarget = wrapInt64 f
-      , operands = []
-      , functionType = FunctionType {paramTypes = [], returnTypes = []}
-      }
-
-newtype Label = Label
-  { unLabel :: SBS.ShortByteString
+callIndirect f = emit CallIndirect
+  { indirectTarget = wrapInt64 f,
+    operands = [],
+    functionType = FunctionType {paramTypes = [], returnTypes = []}
   }
 
+newtype Label
+  = Label
+      { unLabel :: SBS.ShortByteString
+      }
+
 newLabel :: EDSL Label
-newLabel =
-  EDSL $
-  state $ \s@EDSLState {..} ->
-    (Label $ showSBS labelNum, s {labelNum = succ labelNum})
+newLabel = EDSL $ state $ \s@EDSLState {..} ->
+  (Label $ showSBS labelNum, s {labelNum = succ labelNum})
 
 newScope :: EDSL () -> EDSL (DList Expression)
 newScope m = do
-  orig_buf <-
-    EDSL $ state $ \s@EDSLState {..} -> (exprBuf, s {exprBuf = mempty})
+  orig_buf <- EDSL $ state $ \s@EDSLState {..} ->
+    (exprBuf, s {exprBuf = mempty})
   m
   EDSL $ state $ \s@EDSLState {..} -> (exprBuf, s {exprBuf = orig_buf})
 
@@ -385,12 +390,20 @@ block', loop' :: [ValueType] -> (Label -> EDSL ()) -> EDSL ()
 block' vts cont = do
   lbl <- newLabel
   es <- newScope $ cont lbl
-  emit Block {name = unLabel lbl, bodys = fromDList es, blockReturnTypes = vts}
+  emit Block
+    { name = unLabel lbl,
+      bodys = fromDList es,
+      blockReturnTypes = vts
+    }
 
 blockWithLabel :: [ValueType] -> Label -> EDSL () -> EDSL ()
 blockWithLabel vts lbl m = do
   es <- newScope m
-  emit Block {name = unLabel lbl, bodys = fromDList es, blockReturnTypes = vts}
+  emit Block
+    { name = unLabel lbl,
+      bodys = fromDList es,
+      blockReturnTypes = vts
+    }
 
 loop' vts cont = do
   lbl <- newLabel
@@ -401,12 +414,11 @@ if' :: [ValueType] -> Expression -> EDSL () -> EDSL () -> EDSL ()
 if' vts cond t f = do
   t_es <- newScope t
   f_es <- newScope f
-  emit
-    If
-      { condition = cond
-      , ifTrue = bundleExpressions vts $ fromDList t_es
-      , ifFalse = Just $ bundleExpressions vts $ fromDList f_es
-      }
+  emit If
+    { condition = cond,
+      ifTrue = bundleExpressions vts $ fromDList t_es,
+      ifFalse = Just $ bundleExpressions vts $ fromDList f_es
+    }
 
 break' :: Label -> Maybe Expression -> EDSL ()
 break' (Label lbl) cond = emit Break {name = lbl, breakCondition = cond}
@@ -416,30 +428,31 @@ whileLoop vts cond body =
   loop' vts $ \lbl -> if' vts cond (body *> break' lbl Nothing) mempty
 
 switchI64 :: Expression -> (EDSL () -> ([(Int, EDSL ())], EDSL ())) -> EDSL ()
-switchI64 cond make_clauses =
-  block' [] $ \switch_lbl ->
-    let exit_switch = break' switch_lbl Nothing
-        (clauses, def_clause) = make_clauses exit_switch
-        switch_block = do
-          switch_def_lbl <- newLabel
-          blockWithLabel [] switch_def_lbl $ do
-            clause_seq <-
-              for (reverse clauses) $ \(clause_i, clause_m) -> do
-                clause_lbl <- newLabel
-                pure (clause_i, clause_lbl, clause_m)
-            foldr
-              (\(_, clause_lbl, clause_m) tot_m -> do
-                 blockWithLabel [] clause_lbl tot_m
-                 clause_m)
-              (foldr
-                 (\(clause_i, clause_lbl, _) br_m -> do
+switchI64 cond make_clauses = block' [] $ \switch_lbl ->
+  let exit_switch = break' switch_lbl Nothing
+      (clauses, def_clause) = make_clauses exit_switch
+      switch_block = do
+        switch_def_lbl <- newLabel
+        blockWithLabel [] switch_def_lbl $ do
+          clause_seq <- for (reverse clauses) $ \(clause_i, clause_m) -> do
+            clause_lbl <- newLabel
+            pure (clause_i, clause_lbl, clause_m)
+          foldr
+            ( \(_, clause_lbl, clause_m) tot_m -> do
+                blockWithLabel [] clause_lbl tot_m
+                clause_m
+            )
+            ( foldr
+                ( \(clause_i, clause_lbl, _) br_m -> do
                     break' clause_lbl $ Just $ cond `eqInt64` constI64 clause_i
-                    br_m)
-                 (break' switch_def_lbl Nothing)
-                 clause_seq)
-              clause_seq
-          def_clause
-     in switch_block
+                    br_m
+                )
+                (break' switch_def_lbl Nothing)
+                clause_seq
+            )
+            clause_seq
+        def_clause
+   in switch_block
 
 -- | Allocate a static region of bytes in the global section. Returns a
 -- | reference to the variable (symbol).
@@ -452,100 +465,108 @@ switchI64 cond make_clauses =
 -- |
 -- |   y <- allocStaticBytes "y" (Uninitialized 8)
 -- |   storei64 x 0 (constI32 32)
-allocStaticBytes :: AsteriusEntitySymbol -- ^ Name of the static region
-  -> AsteriusStatic -- ^ Initializer
-  -> EDSL Expression -- ^ Expression to access the static, referenced by name.
-allocStaticBytes n v  = EDSL $ state $ \st ->
-  let st' = st {
-     staticsBuf =
-       (n, AsteriusStatics { staticsType = Bytes
-                           , asteriusStatics = [v]
-                           }):staticsBuf st
-     }
-  in (symbol n, st')
+allocStaticBytes ::
+  -- | Name of the static region
+  AsteriusEntitySymbol ->
+  -- | Initializer
+  AsteriusStatic ->
+  -- | Expression to access the static, referenced by name.
+  EDSL Expression
+allocStaticBytes n v = EDSL $ state $ \st ->
+  let st' =
+        st
+          { staticsBuf =
+              (n, AsteriusStatics {staticsType = Bytes, asteriusStatics = [v]})
+                : staticsBuf st
+          }
+   in (symbol n, st')
 
-notInt64, notInt32, eqZInt64, eqZInt32, extendUInt32, extendSInt32, wrapInt64, convertUInt64ToFloat64, truncUFloat64ToInt64, convertSInt64ToFloat64, truncSFloat64ToInt64, roundupBytesToWords, popCntInt32, clzInt32, ctzInt32, popCntInt64, clzInt64, ctzInt64 ::
-     Expression -> Expression
+notInt64,
+  notInt32,
+  eqZInt64,
+  eqZInt32,
+  extendUInt32,
+  extendSInt32,
+  wrapInt64,
+  convertUInt64ToFloat64,
+  truncUFloat64ToInt64,
+  convertSInt64ToFloat64,
+  truncSFloat64ToInt64,
+  roundupBytesToWords,
+  popCntInt32,
+  clzInt32,
+  ctzInt32,
+  popCntInt64,
+  clzInt64,
+  ctzInt64 ::
+    Expression -> Expression
 notInt64 = eqZInt64
-
 notInt32 = eqZInt32
-
 eqZInt64 = Unary EqZInt64
-
 eqZInt32 = Unary EqZInt32
-
 extendUInt32 = Unary ExtendUInt32
-
 extendSInt32 = Unary ExtendSInt32
-
 wrapInt64 = Unary WrapInt64
-
 convertUInt64ToFloat64 = Unary ConvertUInt64ToFloat64
-
 truncUFloat64ToInt64 = Unary TruncUFloat64ToInt64
-
 convertSInt64ToFloat64 = Unary ConvertSInt64ToFloat64
-
 truncSFloat64ToInt64 = Unary TruncSFloat64ToInt64
-
 roundupBytesToWords n = (n `addInt64` constI64 7) `divUInt64` constI64 8
-
 popCntInt32 = Unary PopcntInt32
-clzInt32    = Unary ClzInt32
-ctzInt32    = Unary CtzInt32
-
+clzInt32 = Unary ClzInt32
+ctzInt32 = Unary CtzInt32
 popCntInt64 = Unary PopcntInt64
-clzInt64    = Unary ClzInt64
-ctzInt64    = Unary CtzInt64
+clzInt64 = Unary ClzInt64
+ctzInt64 = Unary CtzInt64
 
-addInt64, subInt64, mulInt64, divUInt64, gtUInt64, geUInt64, shlInt64, shrUInt64, geUInt32, addInt32, subInt32, mulInt32, eqInt64, eqInt32, ltUInt64, leUInt64, ltUInt32, neInt64, neInt32, andInt64, orInt64, andInt32, orInt32, shlInt32 ::
-     Expression -> Expression -> Expression
+addInt64,
+  subInt64,
+  mulInt64,
+  divUInt64,
+  gtUInt64,
+  geUInt64,
+  shlInt64,
+  shrUInt64,
+  geUInt32,
+  addInt32,
+  subInt32,
+  mulInt32,
+  eqInt64,
+  eqInt32,
+  ltUInt64,
+  leUInt64,
+  ltUInt32,
+  neInt64,
+  neInt32,
+  andInt64,
+  orInt64,
+  andInt32,
+  orInt32,
+  shlInt32 ::
+    Expression -> Expression -> Expression
 addInt64 = Binary AddInt64
-
 subInt64 = Binary SubInt64
-
 mulInt64 = Binary MulInt64
-
 divUInt64 = Binary DivUInt64
-
 gtUInt64 = Binary GtUInt64
-
 geUInt64 = Binary GeUInt64
-
 shlInt64 = Binary ShlInt64
-
 shrUInt64 = Binary ShrUInt64
-
 geUInt32 = Binary GeUInt32
-
 addInt32 = Binary AddInt32
-
 subInt32 = Binary SubInt32
-
 mulInt32 = Binary MulInt32
-
 shlInt32 = Binary ShlInt32
-
 eqInt64 = Binary EqInt64
-
 eqInt32 = Binary EqInt32
-
 ltUInt64 = Binary LtUInt64
-
 leUInt64 = Binary LeUInt64
-
 ltUInt32 = Binary LtUInt32
-
 neInt64 = Binary NeInt64
-
 neInt32 = Binary NeInt32
-
 andInt64 = Binary AndInt64
-
 orInt64 = Binary OrInt64
-
 andInt32 = Binary AndInt32
-
 orInt32 = Binary OrInt32
 
 symbol :: AsteriusEntitySymbol -> Expression
@@ -556,20 +577,14 @@ symbol' sym o = Symbol {unresolvedSymbol = sym, symbolOffset = o}
 
 constI32, constI64, constF64 :: Int -> Expression
 constI32 = ConstI32 . fromIntegral
-
 constI64 = ConstI64 . fromIntegral
-
 constF64 = ConstF64 . fromIntegral
 
 baseReg, r1, currentNursery, currentTSO, hpAlloc :: LVal
 baseReg = global BaseReg
-
 r1 = global $ VanillaReg 1
-
 currentNursery = global CurrentNursery
-
 currentTSO = global CurrentTSO
-
 hpAlloc = global HpAlloc
 
 mainCapability :: Expression

--- a/asterius/src/Asterius/FrontendPlugin.hs
+++ b/asterius/src/Asterius/FrontendPlugin.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Asterius.FrontendPlugin
-  ( frontendPlugin
-    )
+  ( frontendPlugin,
+  )
 where
 
 import Asterius.CodeGen
@@ -29,38 +29,38 @@ frontendPlugin = makeFrontendPlugin $ do
   is_debug <- liftIO $ isJust <$> getEnv "ASTERIUS_DEBUG"
   do
     dflags <- GHC.getSessionDynFlags
-    void
-      $ GHC.setSessionDynFlags
-          dflags
-            { GHC.hooks =
-                (GHC.hooks dflags)
-                  { GHC.dsForeignsHook = Just asteriusDsForeigns,
-                    GHC.tcForeignImportsHook = Just asteriusTcForeignImports,
-                    GHC.tcForeignExportsHook = Just asteriusTcForeignExports,
-                    GHC.hscCompileCoreExprHook = Just asteriusHscCompileCoreExpr,
-                    GHC.startIServHook = Just asteriusStartIServ,
-                    GHC.iservCallHook = Just asteriusIservCall,
-                    GHC.readIServHook = Just asteriusReadIServ,
-                    GHC.writeIServHook = Just asteriusWriteIServ,
-                    GHC.stopIServHook = Just asteriusStopIServ
-                    }
-              }
+    void $
+      GHC.setSessionDynFlags
+        dflags
+          { GHC.hooks =
+              (GHC.hooks dflags)
+                { GHC.dsForeignsHook = Just asteriusDsForeigns,
+                  GHC.tcForeignImportsHook = Just asteriusTcForeignImports,
+                  GHC.tcForeignExportsHook = Just asteriusTcForeignExports,
+                  GHC.hscCompileCoreExprHook = Just asteriusHscCompileCoreExpr,
+                  GHC.startIServHook = Just asteriusStartIServ,
+                  GHC.iservCallHook = Just asteriusIservCall,
+                  GHC.readIServHook = Just asteriusReadIServ,
+                  GHC.writeIServHook = Just asteriusWriteIServ,
+                  GHC.stopIServHook = Just asteriusStopIServ
+                }
+          }
   do
     dflags <- GHC.getSessionDynFlags
     void
       $ GHC.setSessionDynFlags
       $ dflags {GHC.settings = (GHC.settings dflags) {GHC.sPgm_i = "false"}}
-      `GHC.gopt_set` GHC.Opt_ExternalInterpreter
+        `GHC.gopt_set` GHC.Opt_ExternalInterpreter
   when is_debug $ do
     dflags <- GHC.getSessionDynFlags
     void
       $ GHC.setSessionDynFlags
       $ dflags
-      `GHC.gopt_set` GHC.Opt_DoCoreLinting
-      `GHC.gopt_set` GHC.Opt_DoStgLinting
-      `GHC.gopt_set` GHC.Opt_DoCmmLinting
-  pure
-    $ mempty
+        `GHC.gopt_set` GHC.Opt_DoCoreLinting
+        `GHC.gopt_set` GHC.Opt_DoStgLinting
+        `GHC.gopt_set` GHC.Opt_DoCmmLinting
+  pure $
+    mempty
       { withHaskellIR = \GHC.ModSummary {..} ir@HaskellIR {..} obj_path -> do
           dflags <- GHC.getDynFlags
           setDynFlagsRef dflags
@@ -93,4 +93,4 @@ frontendPlugin = makeFrontendPlugin $ do
                 writeFile (p "dump-wasm-ast") $ show m
                 writeFile (p "dump-cmm-raw-ast") $ show cmmRaw
                 asmPrint dflags (p "dump-cmm-raw") cmmRaw
-        }
+      }

--- a/asterius/src/Asterius/Internals.hs
+++ b/asterius/src/Asterius/Internals.hs
@@ -4,16 +4,17 @@
 {-# LANGUAGE UnboxedTuples #-}
 
 module Asterius.Internals
-  ( IO
-  , encodeStorable
-  , reinterpretCast
-  , encodeFile
-  , decodeFile
-  , tryDecodeFile
-  , showSBS
-  , c8SBS
-  , (!)
-  ) where
+  ( IO,
+    encodeStorable,
+    reinterpretCast,
+    encodeFile,
+    decodeFile,
+    tryDecodeFile,
+    showSBS,
+    c8SBS,
+    (!),
+  )
+where
 
 import Control.Exception
 import qualified Data.Binary as Binary
@@ -26,9 +27,7 @@ import GHC.Stack
 import qualified GHC.Types
 import Prelude hiding (IO)
 
-type IO a
-   = HasCallStack =>
-       GHC.Types.IO a
+type IO a = HasCallStack => GHC.Types.IO a
 
 unI# :: Int -> Int#
 unI# (I# x) = x
@@ -40,32 +39,29 @@ unIO (GHC.Types.IO m) = m
 encodeStorable :: Storable a => a -> SBS.ShortByteString
 encodeStorable a =
   case runRW#
-         (\s0 ->
-            case newAlignedPinnedByteArray#
-                   (unI# (sizeOf a))
-                   (unI# (alignment a))
-                   s0 of
-              (# s1, mba #) ->
-                case unsafeFreezeByteArray# mba s1 of
-                  (# s2, ba #) ->
-                    let addr = byteArrayContents# ba
-                     in case unIO (poke (Ptr addr) a) s2 of
-                          (# s3, _ #) -> (# s3, SBS.SBS ba #)) of
+    ( \s0 ->
+        case newAlignedPinnedByteArray#
+          (unI# (sizeOf a))
+          (unI# (alignment a))
+          s0 of
+          (# s1, mba #) -> case unsafeFreezeByteArray# mba s1 of
+            (# s2, ba #) ->
+              let addr = byteArrayContents# ba
+               in case unIO (poke (Ptr addr) a) s2 of
+                    (# s3, _ #) -> (# s3, SBS.SBS ba #)
+    ) of
     (# _, r #) -> r
 
 {-# INLINE reinterpretCast #-}
 reinterpretCast :: (Storable a, Storable b) => a -> b
 reinterpretCast a =
   case runRW#
-         (\s0 ->
-            case newPinnedByteArray# (unI# (sizeOf a)) s0 of
-              (# s1, mba #) ->
-                case unsafeFreezeByteArray# mba s1 of
-                  (# s2, ba #) ->
-                    case byteArrayContents# ba of
-                      addr ->
-                        case unIO (poke (Ptr addr) a) s2 of
-                          (# s3, _ #) -> unIO (peek (Ptr addr)) s3) of
+    ( \s0 -> case newPinnedByteArray# (unI# (sizeOf a)) s0 of
+        (# s1, mba #) -> case unsafeFreezeByteArray# mba s1 of
+          (# s2, ba #) -> case byteArrayContents# ba of
+            addr -> case unIO (poke (Ptr addr) a) s2 of
+              (# s3, _ #) -> unIO (peek (Ptr addr)) s3
+    ) of
     (# _, r #) -> r
 
 {-# INLINE encodeFile #-}
@@ -80,11 +76,10 @@ decodeFile = Binary.decodeFile
 tryDecodeFile :: Binary.Binary a => FilePath -> IO (Either SomeException a)
 tryDecodeFile p = do
   r <- try $ Binary.decodeFileOrFail p
-  pure $
-    case r of
-      Left err -> Left err
-      Right (Left err) -> Left $ toException $ userError $ show err
-      Right (Right v) -> Right v
+  pure $ case r of
+    Left err -> Left err
+    Right (Left err) -> Left $ toException $ userError $ show err
+    Right (Right v) -> Right v
 
 {-# INLINE showSBS #-}
 showSBS :: Show a => a -> SBS.ShortByteString
@@ -96,7 +91,6 @@ c8SBS = CBS.unpack . SBS.fromShort
 
 {-# INLINE (!) #-}
 (!) :: (HasCallStack, Ord k, Show k) => LM.Map k v -> k -> v
-(!) m k =
-  case LM.lookup k m of
-    Just v -> v
-    _ -> error $ show k <> " not found"
+(!) m k = case LM.lookup k m of
+  Just v -> v
+  _ -> error $ show k <> " not found"

--- a/asterius/src/Asterius/Internals/Barf.hs
+++ b/asterius/src/Asterius/Internals/Barf.hs
@@ -1,20 +1,25 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Asterius.Internals.Barf
-  ( barf
-  ) where
+  ( barf,
+  )
+where
 
 import Asterius.Types
 
 barf :: AsteriusEntitySymbol -> [ValueType] -> Expression
-barf sym [] =
-  Call
-    { target = "barf"
-    , operands =
-        [ Symbol
-            {unresolvedSymbol = "__asterius_barf_" <> sym, symbolOffset = 0}
-        ]
-    , callReturnTypes = []
-    }
-barf sym vts =
-  Block {name = "", bodys = [barf sym [], Unreachable], blockReturnTypes = vts}
+barf sym [] = Call
+  { target = "barf",
+    operands =
+      [ Symbol
+          { unresolvedSymbol = "__asterius_barf_" <> sym,
+            symbolOffset = 0
+          }
+      ],
+    callReturnTypes = []
+  }
+barf sym vts = Block
+  { name = "",
+    bodys = [barf sym [], Unreachable],
+    blockReturnTypes = vts
+  }

--- a/asterius/src/Asterius/Internals/Binary.hs
+++ b/asterius/src/Asterius/Internals/Binary.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE BangPatterns #-}
 
 module Asterius.Internals.Binary
-  ( decodeMaybe
-  , lazyMapPut
-  , lazyMapGet
-  ) where
+  ( decodeMaybe,
+    lazyMapPut,
+    lazyMapGet,
+  )
+where
 
 import Control.Monad
 import Data.Binary
@@ -15,30 +16,26 @@ import qualified Data.Map.Lazy as LMap
 
 {-# INLINE decode' #-}
 decode' :: Binary a => BS.ByteString -> a
-decode' buf =
-  case runGetIncremental get of
-    Partial k ->
-      case k (Just buf) of
-        Done _ _ r -> r
-        _ -> error "Asterius.Internals.Binary.decode': failed to deserialize"
-    _ ->
-      error "Asterius.Internals.Binary.decode': failed to start deserialization"
+decode' buf = case runGetIncremental get of
+  Partial k -> case k (Just buf) of
+    Done _ _ r -> r
+    _ -> error "Asterius.Internals.Binary.decode': failed to deserialize"
+  _ ->
+    error "Asterius.Internals.Binary.decode': failed to start deserialization"
 
 {-# INLINE decodeMaybe #-}
 decodeMaybe :: Binary a => BS.ByteString -> Maybe a
-decodeMaybe buf =
-  case runGetIncremental get of
-    Partial k ->
-      case k (Just buf) of
-        Done _ _ !r -> Just r
-        _ -> Nothing
+decodeMaybe buf = case runGetIncremental get of
+  Partial k -> case k (Just buf) of
+    Done _ _ !r -> Just r
     _ -> Nothing
+  _ -> Nothing
 
 {-# INLINE lazyMapPut #-}
 lazyMapPut :: (Binary k, Binary v) => Map k v -> Put
 lazyMapPut m =
-  put (LMap.size m) *>
-  LMap.foldrWithKey' (\k v acc -> put k *> put (encode v) *> acc) mempty m
+  put (LMap.size m)
+    *> LMap.foldrWithKey' (\k v acc -> put k *> put (encode v) *> acc) mempty m
 
 {-# INLINE lazyMapGet #-}
 lazyMapGet :: (Binary k, Binary v) => Get (Map k v)

--- a/asterius/src/Asterius/Internals/DList.hs
+++ b/asterius/src/Asterius/Internals/DList.hs
@@ -2,30 +2,37 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Asterius.Internals.DList
-  ( DList
-  , fromList
-  , toList
-  , singleton
-  , cons
-  , foldr
-  , map
-  ) where
+  ( DList,
+    fromList,
+    toList,
+    singleton,
+    cons,
+    foldr,
+    map,
+  )
+where
 
 import Control.Monad
 import Data.Coerce
 import Data.Monoid
 import qualified GHC.Exts
-import Prelude hiding (foldr, map)
+import Prelude hiding
+  ( foldr,
+    map,
+  )
 import qualified Prelude
 
-newtype DList a =
-  DList (Endo [a])
+newtype DList a
+  = DList (Endo [a])
   deriving (Semigroup, Monoid)
 
 instance GHC.Exts.IsList (DList a) where
+
   type Item (DList a) = a
+
   {-# INLINE fromList #-}
   fromList = fromList
+
   {-# INLINE toList #-}
   toList = toList
 

--- a/asterius/src/Asterius/Internals/Directory.hs
+++ b/asterius/src/Asterius/Internals/Directory.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE TupleSections #-}
 
 module Asterius.Internals.Directory
-  ( listFilesRecursive
-  ) where
+  ( listFilesRecursive,
+  )
+where
 
 import Data.Foldable
 import Data.Traversable
@@ -14,11 +15,8 @@ listFilesRecursive = w []
   where
     w acc bp = do
       fds <- map (normalise . (bp </>)) <$> listDirectory bp
-      tagged_fds <- for fds $ \fd -> (fd, ) <$> doesFileExist fd
+      tagged_fds <- for fds $ \fd -> (fd,) <$> doesFileExist fd
       foldrM
-        (\(fd, is_f) acc' ->
-           if is_f
-             then pure (fd : acc')
-             else w acc' fd)
+        (\(fd, is_f) acc' -> if is_f then pure (fd : acc') else w acc' fd)
         acc
         tagged_fds

--- a/asterius/src/Asterius/Internals/FList.hs
+++ b/asterius/src/Asterius/Internals/FList.hs
@@ -2,11 +2,12 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Asterius.Internals.FList
-  ( FList
-  , cons
-  , snoc
-  , concat
-  ) where
+  ( FList,
+    cons,
+    snoc,
+    concat,
+  )
+where
 
 import Data.Binary
 import GHC.Exts
@@ -35,39 +36,40 @@ instance Monoid (FList a) where
   mempty = Empty
 
 instance Foldable FList where
-  foldr f b l =
-    case l of
-      Empty -> b
-      Singleton a -> f a b
-      Cons a l0 -> f a (foldr f b l0)
-      Snoc l0 a -> foldr f (f a b) l0
-      Append l0 l1 -> foldr f (foldr f b l1) l0
-      FromFoldable l0 -> Prelude.foldr f b l0
-      Map g l0 -> foldr (f . g) b l0
-      Join l0 -> foldr (flip (foldr f)) b l0
-  null l =
-    case l of
-      Empty -> True
-      Singleton {} -> False
-      Cons {} -> False
-      Snoc {} -> False
-      Append l0 l1 -> null l0 && null l1
-      FromFoldable l0 -> null l0
-      Map _ l0 -> null l0
-      Join l0 -> and (fmap null l0)
+
+  foldr f b l = case l of
+    Empty -> b
+    Singleton a -> f a b
+    Cons a l0 -> f a (foldr f b l0)
+    Snoc l0 a -> foldr f (f a b) l0
+    Append l0 l1 -> foldr f (foldr f b l1) l0
+    FromFoldable l0 -> Prelude.foldr f b l0
+    Map g l0 -> foldr (f . g) b l0
+    Join l0 -> foldr (flip (foldr f)) b l0
+
+  null l = case l of
+    Empty -> True
+    Singleton {} -> False
+    Cons {} -> False
+    Snoc {} -> False
+    Append l0 l1 -> null l0 && null l1
+    FromFoldable l0 -> null l0
+    Map _ l0 -> null l0
+    Join l0 -> and (fmap null l0)
 
 instance Functor FList where
   {-# INLINE fmap #-}
-  fmap f l =
-    case l of
-      Empty -> Empty
-      Singleton a -> Singleton (f a)
-      Map g l0 -> Map (f . g) l0
-      _ -> Map f l
+  fmap f l = case l of
+    Empty -> Empty
+    Singleton a -> Singleton (f a)
+    Map g l0 -> Map (f . g) l0
+    _ -> Map f l
 
 instance Applicative FList where
+
   {-# INLINE pure #-}
   pure = Singleton
+
   {-# INLINE (<*>) #-}
   f <*> a = Join (fmap (`fmap` a) f)
 
@@ -76,9 +78,12 @@ instance Monad FList where
   l >>= f = Join (fmap f l)
 
 instance IsList (FList a) where
+
   type Item (FList a) = a
+
   {-# INLINE fromList #-}
   fromList = FromFoldable
+
   {-# INLINE toList #-}
   toList = foldr (:) []
 
@@ -87,7 +92,9 @@ instance Show a => Show (FList a) where
   showsPrec i = showsPrec i . toList
 
 instance Binary a => Binary (FList a) where
+
   get = fromList <$> get
+
   put = put . toList
 
 {-# INLINE cons #-}

--- a/asterius/src/Asterius/Internals/MagicNumber.hs
+++ b/asterius/src/Asterius/Internals/MagicNumber.hs
@@ -1,14 +1,13 @@
 module Asterius.Internals.MagicNumber
-  ( dataTag
-  , functionTag
-  , invalidAddress
-  ) where
+  ( dataTag,
+    functionTag,
+    invalidAddress,
+  )
+where
 
 import Data.Int
 
 dataTag, functionTag, invalidAddress :: Int64
 dataTag = 2097143
-
 functionTag = 2097133
-
 invalidAddress = 0x1fffffffff0000

--- a/asterius/src/Asterius/Internals/Marshal.hs
+++ b/asterius/src/Asterius/Internals/Marshal.hs
@@ -4,9 +4,10 @@
 {-# LANGUAGE UnboxedTuples #-}
 
 module Asterius.Internals.Marshal
-  ( marshalSBS
-  , marshalV
-  ) where
+  ( marshalSBS,
+    marshalV,
+  )
+where
 
 import Control.Monad.Cont
 import Data.ByteString.Short (ShortByteString)
@@ -24,29 +25,24 @@ import GHC.Types
 marshalSBS :: ShortByteString -> (forall r. ContT r IO (Ptr CChar))
 marshalSBS buf@(SBS.SBS ba)
   | SBS.null buf = pure nullPtr
-  | otherwise =
-    case SBS.length buf of
-      len@(I# l) ->
-        ContT $ \c -> do
-          fp <- mallocPlainForeignPtrBytes (len + 1)
-          withForeignPtr fp $ \ptr@(Ptr p) -> do
-            IO $ \s0 -> (# copyByteArrayToAddr# ba 0# p l s0, () #)
-            pokeByteOff ptr len (0 :: Word8)
-            c ptr
+  | otherwise = case SBS.length buf of
+    len@(I# l) -> ContT $ \c -> do
+      fp <- mallocPlainForeignPtrBytes (len + 1)
+      withForeignPtr fp $ \ptr@(Ptr p) -> do
+        IO $ \s0 -> (# copyByteArrayToAddr# ba 0# p l s0, () #)
+        pokeByteOff ptr len (0 :: Word8)
+        c ptr
 
 marshalV ::
-     forall a. Storable a
-  => [a]
-  -> (forall r. ContT r IO (Ptr a, Int))
+  forall a. Storable a => [a] -> (forall r. ContT r IO (Ptr a, Int))
 marshalV v
   | null v = pure (nullPtr, 0)
-  | otherwise =
-    ContT $ \c -> do
-      let len = length v
-      fp <-
-        mallocPlainForeignPtrAlignedBytes
-          (sizeOf (undefined :: a) * len)
-          (alignment (undefined :: a))
-      withForeignPtr fp $ \p -> do
-        pokeArray p v
-        c (p, len)
+  | otherwise = ContT $ \c -> do
+    let len = length v
+    fp <-
+      mallocPlainForeignPtrAlignedBytes
+        (sizeOf (undefined :: a) * len)
+        (alignment (undefined :: a))
+    withForeignPtr fp $ \p -> do
+      pokeArray p v
+      c (p, len)

--- a/asterius/src/Asterius/Internals/Name.hs
+++ b/asterius/src/Asterius/Internals/Name.hs
@@ -1,6 +1,6 @@
 module Asterius.Internals.Name
-  ( fakeClosureSymbol
-    )
+  ( fakeClosureSymbol,
+  )
 where
 
 import Asterius.Types (AsteriusEntitySymbol)
@@ -16,12 +16,12 @@ import qualified Packages as GHC
 import qualified SrcLoc as GHC
 import qualified Unique as GHC
 
-fakeName
-  :: GHC.DynFlags
-  -> GHC.PackageName
-  -> GHC.ModuleName
-  -> GHC.OccName
-  -> GHC.Name
+fakeName ::
+  GHC.DynFlags ->
+  GHC.PackageName ->
+  GHC.ModuleName ->
+  GHC.OccName ->
+  GHC.Name
 fakeName dflags pkg_name mod_name occ_name = name
   where
     dummy_uniq = GHC.mkUniqueGrimily 0
@@ -32,12 +32,13 @@ fakeName dflags pkg_name mod_name occ_name = name
     m = GHC.mkModule unit_id mod_name
     name = GHC.mkExternalName dummy_uniq m occ_name GHC.noSrcSpan
 
-fakeClosureSymbol
-  :: GHC.DynFlags -> String -> String -> String -> AsteriusEntitySymbol
+fakeClosureSymbol ::
+  GHC.DynFlags -> String -> String -> String -> AsteriusEntitySymbol
 fakeClosureSymbol dflags pkg_name mod_name occ_name = sym
   where
     name =
-      fakeName dflags
+      fakeName
+        dflags
         (GHC.PackageName (GHC.mkFastString pkg_name))
         (GHC.mkModuleName mod_name)
         (GHC.mkVarOcc occ_name)

--- a/asterius/src/Asterius/Internals/SYB.hs
+++ b/asterius/src/Asterius/Internals/SYB.hs
@@ -2,21 +2,20 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Asterius.Internals.SYB
-  ( GenericM
-  , everywhereM
-  ) where
+  ( GenericM,
+    everywhereM,
+  )
+where
 
-import Data.Data (Data, gmapM)
+import Data.Data
+  ( Data,
+    gmapM,
+  )
 
-type GenericM m
-   = forall a. Data a =>
-                 a -> m a
+type GenericM m = forall a. Data a => a -> m a
 
 {-# INLINE everywhereM #-}
-everywhereM ::
-     forall m. Monad m
-  => GenericM m
-  -> GenericM m
+everywhereM :: forall m. Monad m => GenericM m -> GenericM m
 everywhereM f = w
   where
     w :: GenericM m

--- a/asterius/src/Asterius/Internals/Session.hs
+++ b/asterius/src/Asterius/Internals/Session.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Asterius.Internals.Session
-  ( fakeSession
-    )
+  ( fakeSession,
+  )
 where
 
 import qualified Asterius.BuildInfo as A
@@ -26,12 +26,12 @@ fakeSession m = do
     $ GHC.runGhc (Just (A.dataDir </> ".boot" </> "asterius_lib"))
     $ do
       dflags0 <- GHC.getSessionDynFlags
-      void
-        $ GHC.setSessionDynFlags
-            dflags0
-              { GHC.ghcMode = GHC.CompManager,
-                GHC.hscTarget = GHC.HscAsm,
-                GHC.integerLibrary = GHC.IntegerSimple,
-                GHC.tablesNextToCode = False
-                }
+      void $
+        GHC.setSessionDynFlags
+          dflags0
+            { GHC.ghcMode = GHC.CompManager,
+              GHC.hscTarget = GHC.HscAsm,
+              GHC.integerLibrary = GHC.IntegerSimple,
+              GHC.tablesNextToCode = False
+            }
       m

--- a/asterius/src/Asterius/Internals/Temp.hs
+++ b/asterius/src/Asterius/Internals/Temp.hs
@@ -1,7 +1,8 @@
 module Asterius.Internals.Temp
-  ( temp
-  , withTempDir
-  ) where
+  ( temp,
+    withTempDir,
+  )
+where
 
 import Distribution.Simple.Utils
 import Distribution.Verbosity

--- a/asterius/src/Asterius/JSGen/Constants.hs
+++ b/asterius/src/Asterius/JSGen/Constants.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Asterius.JSGen.Constants
-  ( rtsConstants
-  ) where
+  ( rtsConstants,
+  )
+where
 
 import Asterius.Internals.ByteString
 import Asterius.Internals.MagicNumber
@@ -12,118 +13,123 @@ import Language.Haskell.GHC.Toolkit.Constants
 rtsConstants :: Builder
 rtsConstants =
   mconcat $
-  [ "export const dataTag = "
-  , intHex dataTag
-  , ";\nexport const functionTag = "
-  , intHex functionTag
-  , ";\nexport const mblock_size = "
-  , intHex mblock_size
-  , ";\nexport const block_size = "
-  , intHex block_size
-  , ";\nexport const blocks_per_mblock = "
-  , intHex blocks_per_mblock
-  , ";\nexport const sizeof_bdescr = "
-  , intHex sizeof_bdescr
-  , ";\nexport const offset_first_bdescr = "
-  , intHex offset_first_bdescr
-  , ";\nexport const offset_first_block = "
-  , intHex offset_first_block
-  , ";\nexport const sizeof_first_mblock = "
-  , intHex $ mblock_size - offset_first_block
-  , ";\nexport const offset_bdescr_start = "
-  , intHex offset_bdescr_start
-  , ";\nexport const offset_bdescr_free = "
-  , intHex offset_bdescr_free
-  , ";\nexport const offset_bdescr_link = "
-  , intHex offset_bdescr_link
-  , ";\nexport const offset_bdescr_node = "
-  , intHex offset_bdescr_node
-  , ";\nexport const offset_bdescr_flags = "
-  , intHex offset_bdescr_flags
-  , ";\nexport const offset_bdescr_blocks = "
-  , intHex offset_bdescr_blocks
-  , ";\nexport const BF_PINNED = "
-  , intHex bf_PINNED
-  , ";\nexport const pageSize = 65536;\n"
-  ] <>
-  [ "export const " <> k <> " = " <> intHex v <> ";\n"
-  | (k, v) <-
-      [ ("offset_Capability_r", offset_Capability_r)
-      , ("sizeof_StgAP", sizeof_StgAP)
-      , ("offset_StgAP_arity", offset_StgAP_arity)
-      , ("offset_StgAP_n_args", offset_StgAP_n_args)
-      , ("offset_StgAP_fun", offset_StgAP_fun)
-      , ("offset_StgAP_payload", offset_StgAP_payload)
-      , ("sizeof_StgAP_STACK", sizeof_StgAP_STACK)
-      , ("offset_StgAP_STACK_size", offset_StgAP_STACK_size)
-      , ("offset_StgAP_STACK_fun", offset_StgAP_STACK_fun)
-      , ("offset_StgAP_STACK_payload", offset_StgAP_STACK_payload)
-      , ("sizeof_StgArrBytes", sizeof_StgArrBytes)
-      , ("offset_StgArrBytes_bytes", offset_StgArrBytes_bytes)
-      , ( "offset_StgFunInfoExtraFwd_fun_type"
-        , offset_StgFunInfoExtraFwd_fun_type)
-      , ("offset_StgFunInfoExtraFwd_srt", offset_StgFunInfoExtraFwd_srt)
-      , ("offset_StgFunInfoExtraFwd_b", offset_StgFunInfoExtraFwd_b)
-      , ("offset_StgFunInfoTable_i", offset_StgFunInfoTable_i)
-      , ("offset_StgFunInfoTable_f", offset_StgFunInfoTable_f)
-      , ("sizeof_StgInd", sizeof_StgInd)
-      , ("offset_StgInd_indirectee", offset_StgInd_indirectee)
-      , ("sizeof_StgIndStatic", sizeof_StgIndStatic)
-      , ("offset_StgIndStatic_indirectee", offset_StgIndStatic_indirectee)
-      , ("offset_StgInfoTable_layout", offset_StgInfoTable_layout)
-      , ("offset_StgInfoTable_type", offset_StgInfoTable_type)
-      , ("offset_StgInfoTable_srt", offset_StgInfoTable_srt)
-      , ("offset_StgLargeBitmap_size", offset_StgLargeBitmap_size)
-      , ("offset_StgLargeBitmap_bitmap", offset_StgLargeBitmap_bitmap)
-      , ("sizeof_StgMutArrPtrs", sizeof_StgMutArrPtrs)
-      , ("offset_StgMutArrPtrs_ptrs", offset_StgMutArrPtrs_ptrs)
-      , ("offset_StgMutArrPtrs_payload", offset_StgMutArrPtrs_payload)
-      , ("offset_StgMVar_head", offset_StgMVar_head)
-      , ("offset_StgMVar_tail", offset_StgMVar_tail)
-      , ("offset_StgMVar_value", offset_StgMVar_value)
-      , ("sizeof_StgPAP", sizeof_StgPAP)
-      , ("offset_StgPAP_arity", offset_StgPAP_arity)
-      , ("offset_StgPAP_n_args", offset_StgPAP_n_args)
-      , ("offset_StgPAP_fun", offset_StgPAP_fun)
-      , ("offset_StgPAP_payload", offset_StgPAP_payload)
-      , ("offset_StgRegTable_rR1", offset_StgRegTable_rR1)
-      , ("offset_StgRegTable_rCurrentNursery", offset_StgRegTable_rCurrentNursery)
-      , ("offset_StgRegTable_rHpAlloc", offset_StgRegTable_rHpAlloc)
-      , ("offset_StgRegTable_rRet", offset_StgRegTable_rRet)
-      , ("sizeof_StgRetFun", sizeof_StgRetFun)
-      , ("offset_StgRetFun_size", offset_StgRetFun_size)
-      , ("offset_StgRetFun_fun", offset_StgRetFun_fun)
-      , ("offset_StgRetFun_payload", offset_StgRetFun_payload)
-      , ("offset_StgRetInfoTable_i", offset_StgRetInfoTable_i)
-      , ("offset_StgRetInfoTable_srt", offset_StgRetInfoTable_srt)
-      , ("sizeof_StgSelector", sizeof_StgSelector)
-      , ("offset_StgSelector_selectee", offset_StgSelector_selectee)
-      , ("sizeof_StgSmallMutArrPtrs", sizeof_StgSmallMutArrPtrs)
-      , ("offset_StgSmallMutArrPtrs_ptrs", offset_StgSmallMutArrPtrs_ptrs)
-      , ("offset_StgSmallMutArrPtrs_payload", offset_StgSmallMutArrPtrs_payload)
-      , ("sizeof_StgThunk", sizeof_StgThunk)
-      , ("offset_StgThunk_payload", offset_StgThunk_payload)
-      , ("offset_StgThunkInfoTable_i", offset_StgThunkInfoTable_i)
-      , ("offset_StgThunkInfoTable_srt", offset_StgThunkInfoTable_srt)
-      , ("offset_StgTSO_id", offset_StgTSO_id)
-      , ("offset_StgTSO_stackobj", offset_StgTSO_stackobj)
-      , ("offset_StgTSO_what_next", offset_StgTSO_what_next)
-      , ("offset_StgTSO_why_blocked", offset_StgTSO_why_blocked)
-      , ("offset_StgTSO_block_info", offset_StgTSO_block_info)
-      , ("offset_StgTSO_ffi_func", offset_StgTSO_ffi_func)
-      , ("offset_StgTSO_ffi_return", offset_StgTSO_ffi_return)
-      , ("offset_StgTSO_saved_regs", offset_StgTSO_saved_regs)
-      , ("offset_StgStack_stack_size", offset_StgStack_stack_size)
-      , ("offset_StgStack_sp", offset_StgStack_sp)
-      , ("offset_StgStack_stack", offset_StgStack_stack)
-      , ("offset_StgUpdateFrame_updatee", offset_StgUpdateFrame_updatee)
-      , ("offset_StgWeak_cfinalizers", offset_StgWeak_cfinalizers)
-      , ("offset_StgWeak_key", offset_StgWeak_key)
-      , ("offset_StgWeak_value", offset_StgWeak_value)
-      , ("offset_StgWeak_finalizer", offset_StgWeak_finalizer)
-      , ("offset_StgWeak_link", offset_StgWeak_link)
-      , ("sizeof_StgStableName", sizeof_StgStableName)
-      , ("offset_StgStableName_header", offset_StgStableName_header)
-      , ("offset_StgStableName_sn", offset_StgStableName_sn)
-      ]
-  ]
+    [ "export const dataTag = ",
+      intHex dataTag,
+      ";\nexport const functionTag = ",
+      intHex functionTag,
+      ";\nexport const mblock_size = ",
+      intHex mblock_size,
+      ";\nexport const block_size = ",
+      intHex block_size,
+      ";\nexport const blocks_per_mblock = ",
+      intHex blocks_per_mblock,
+      ";\nexport const sizeof_bdescr = ",
+      intHex sizeof_bdescr,
+      ";\nexport const offset_first_bdescr = ",
+      intHex offset_first_bdescr,
+      ";\nexport const offset_first_block = ",
+      intHex offset_first_block,
+      ";\nexport const sizeof_first_mblock = ",
+      intHex $ mblock_size - offset_first_block,
+      ";\nexport const offset_bdescr_start = ",
+      intHex offset_bdescr_start,
+      ";\nexport const offset_bdescr_free = ",
+      intHex offset_bdescr_free,
+      ";\nexport const offset_bdescr_link = ",
+      intHex offset_bdescr_link,
+      ";\nexport const offset_bdescr_node = ",
+      intHex offset_bdescr_node,
+      ";\nexport const offset_bdescr_flags = ",
+      intHex offset_bdescr_flags,
+      ";\nexport const offset_bdescr_blocks = ",
+      intHex offset_bdescr_blocks,
+      ";\nexport const BF_PINNED = ",
+      intHex bf_PINNED,
+      ";\nexport const pageSize = 65536;\n"
+    ]
+      <> [ "export const " <> k <> " = " <> intHex v <> ";\n"
+           | (k, v) <-
+               [ ("offset_Capability_r", offset_Capability_r),
+                 ("sizeof_StgAP", sizeof_StgAP),
+                 ("offset_StgAP_arity", offset_StgAP_arity),
+                 ("offset_StgAP_n_args", offset_StgAP_n_args),
+                 ("offset_StgAP_fun", offset_StgAP_fun),
+                 ("offset_StgAP_payload", offset_StgAP_payload),
+                 ("sizeof_StgAP_STACK", sizeof_StgAP_STACK),
+                 ("offset_StgAP_STACK_size", offset_StgAP_STACK_size),
+                 ("offset_StgAP_STACK_fun", offset_StgAP_STACK_fun),
+                 ("offset_StgAP_STACK_payload", offset_StgAP_STACK_payload),
+                 ("sizeof_StgArrBytes", sizeof_StgArrBytes),
+                 ("offset_StgArrBytes_bytes", offset_StgArrBytes_bytes),
+                 ( "offset_StgFunInfoExtraFwd_fun_type",
+                   offset_StgFunInfoExtraFwd_fun_type
+                 ),
+                 ("offset_StgFunInfoExtraFwd_srt", offset_StgFunInfoExtraFwd_srt),
+                 ("offset_StgFunInfoExtraFwd_b", offset_StgFunInfoExtraFwd_b),
+                 ("offset_StgFunInfoTable_i", offset_StgFunInfoTable_i),
+                 ("offset_StgFunInfoTable_f", offset_StgFunInfoTable_f),
+                 ("sizeof_StgInd", sizeof_StgInd),
+                 ("offset_StgInd_indirectee", offset_StgInd_indirectee),
+                 ("sizeof_StgIndStatic", sizeof_StgIndStatic),
+                 ("offset_StgIndStatic_indirectee", offset_StgIndStatic_indirectee),
+                 ("offset_StgInfoTable_layout", offset_StgInfoTable_layout),
+                 ("offset_StgInfoTable_type", offset_StgInfoTable_type),
+                 ("offset_StgInfoTable_srt", offset_StgInfoTable_srt),
+                 ("offset_StgLargeBitmap_size", offset_StgLargeBitmap_size),
+                 ("offset_StgLargeBitmap_bitmap", offset_StgLargeBitmap_bitmap),
+                 ("sizeof_StgMutArrPtrs", sizeof_StgMutArrPtrs),
+                 ("offset_StgMutArrPtrs_ptrs", offset_StgMutArrPtrs_ptrs),
+                 ("offset_StgMutArrPtrs_payload", offset_StgMutArrPtrs_payload),
+                 ("offset_StgMVar_head", offset_StgMVar_head),
+                 ("offset_StgMVar_tail", offset_StgMVar_tail),
+                 ("offset_StgMVar_value", offset_StgMVar_value),
+                 ("sizeof_StgPAP", sizeof_StgPAP),
+                 ("offset_StgPAP_arity", offset_StgPAP_arity),
+                 ("offset_StgPAP_n_args", offset_StgPAP_n_args),
+                 ("offset_StgPAP_fun", offset_StgPAP_fun),
+                 ("offset_StgPAP_payload", offset_StgPAP_payload),
+                 ("offset_StgRegTable_rR1", offset_StgRegTable_rR1),
+                 ( "offset_StgRegTable_rCurrentNursery",
+                   offset_StgRegTable_rCurrentNursery
+                 ),
+                 ("offset_StgRegTable_rHpAlloc", offset_StgRegTable_rHpAlloc),
+                 ("offset_StgRegTable_rRet", offset_StgRegTable_rRet),
+                 ("sizeof_StgRetFun", sizeof_StgRetFun),
+                 ("offset_StgRetFun_size", offset_StgRetFun_size),
+                 ("offset_StgRetFun_fun", offset_StgRetFun_fun),
+                 ("offset_StgRetFun_payload", offset_StgRetFun_payload),
+                 ("offset_StgRetInfoTable_i", offset_StgRetInfoTable_i),
+                 ("offset_StgRetInfoTable_srt", offset_StgRetInfoTable_srt),
+                 ("sizeof_StgSelector", sizeof_StgSelector),
+                 ("offset_StgSelector_selectee", offset_StgSelector_selectee),
+                 ("sizeof_StgSmallMutArrPtrs", sizeof_StgSmallMutArrPtrs),
+                 ("offset_StgSmallMutArrPtrs_ptrs", offset_StgSmallMutArrPtrs_ptrs),
+                 ( "offset_StgSmallMutArrPtrs_payload",
+                   offset_StgSmallMutArrPtrs_payload
+                 ),
+                 ("sizeof_StgThunk", sizeof_StgThunk),
+                 ("offset_StgThunk_payload", offset_StgThunk_payload),
+                 ("offset_StgThunkInfoTable_i", offset_StgThunkInfoTable_i),
+                 ("offset_StgThunkInfoTable_srt", offset_StgThunkInfoTable_srt),
+                 ("offset_StgTSO_id", offset_StgTSO_id),
+                 ("offset_StgTSO_stackobj", offset_StgTSO_stackobj),
+                 ("offset_StgTSO_what_next", offset_StgTSO_what_next),
+                 ("offset_StgTSO_why_blocked", offset_StgTSO_why_blocked),
+                 ("offset_StgTSO_block_info", offset_StgTSO_block_info),
+                 ("offset_StgTSO_ffi_func", offset_StgTSO_ffi_func),
+                 ("offset_StgTSO_ffi_return", offset_StgTSO_ffi_return),
+                 ("offset_StgTSO_saved_regs", offset_StgTSO_saved_regs),
+                 ("offset_StgStack_stack_size", offset_StgStack_stack_size),
+                 ("offset_StgStack_sp", offset_StgStack_sp),
+                 ("offset_StgStack_stack", offset_StgStack_stack),
+                 ("offset_StgUpdateFrame_updatee", offset_StgUpdateFrame_updatee),
+                 ("offset_StgWeak_cfinalizers", offset_StgWeak_cfinalizers),
+                 ("offset_StgWeak_key", offset_StgWeak_key),
+                 ("offset_StgWeak_value", offset_StgWeak_value),
+                 ("offset_StgWeak_finalizer", offset_StgWeak_finalizer),
+                 ("offset_StgWeak_link", offset_StgWeak_link),
+                 ("sizeof_StgStableName", sizeof_StgStableName),
+                 ("offset_StgStableName_header", offset_StgStableName_header),
+                 ("offset_StgStableName_sn", offset_StgStableName_sn)
+               ]
+         ]

--- a/asterius/src/Asterius/JSGen/Wasm.hs
+++ b/asterius/src/Asterius/JSGen/Wasm.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Asterius.JSGen.Wasm
-  ( genWasm
-  ) where
+  ( genWasm,
+  )
+where
 
 import Data.ByteString.Builder
 import System.FilePath
@@ -13,16 +14,17 @@ genWasm is_node base_name =
     [ case () of
         ()
           | is_node -> "import fs from \"fs\";\n"
-          | otherwise -> mempty
-    , "export default "
-    , case () of
+          | otherwise -> mempty,
+      "export default ",
+      case () of
         ()
           | is_node ->
-            "fs.promises.readFile(" <> out_wasm <>
-            ").then(bufferSource => WebAssembly.compile(bufferSource))"
+            "fs.promises.readFile("
+              <> out_wasm
+              <> ").then(bufferSource => WebAssembly.compile(bufferSource))"
           | otherwise ->
-            "WebAssembly.compileStreaming(fetch(" <> out_wasm <> "))"
-    , ";\n"
+            "WebAssembly.compileStreaming(fetch(" <> out_wasm <> "))",
+      ";\n"
     ]
   where
     out_wasm = string7 $ show $ base_name <.> "wasm"

--- a/asterius/src/Asterius/JSRun/Main.hs
+++ b/asterius/src/Asterius/JSRun/Main.hs
@@ -1,12 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Asterius.JSRun.Main
-  ( newAsteriusInstance
-  , hsInit
-  , hsMain
-  , hsStdOut
-  , hsStdErr
-  ) where
+  ( newAsteriusInstance,
+    hsInit,
+    hsMain,
+    hsStdOut,
+    hsStdErr,
+  )
+where
 
 import qualified Data.ByteString.Lazy as LBS
 import Language.JavaScript.Inline.Core

--- a/asterius/src/Asterius/JSRun/NonMain.hs
+++ b/asterius/src/Asterius/JSRun/NonMain.hs
@@ -46,38 +46,38 @@ linkNonMain store_m extra_syms = (m, link_report)
           }
         store_m
 
-distNonMain
-  :: FilePath -> [AsteriusEntitySymbol] -> (Module, LinkReport) -> IO ()
+distNonMain ::
+  FilePath -> [AsteriusEntitySymbol] -> (Module, LinkReport) -> IO ()
 distNonMain p extra_syms = ahcDistMain
-                             putStrLn
-                             Task
-                               { target = Node,
-                                 inputHS = p,
-                                 outputDirectory = takeDirectory p,
-                                 outputBaseName = takeBaseName p,
-                                 inputEntryMJS = Nothing,
-                                 tailCalls = False,
-                                 Asterius.Main.gcSections = True,
-                                 fullSymTable = True,
-                                 bundle = False,
-                                 Asterius.Main.binaryen = False,
-                                 Asterius.Main.debug = False,
-                                 outputLinkReport = False,
-                                 Asterius.Main.outputIR = False,
-                                 run = False,
-                                 Asterius.Main.verboseErr = True,
-                                 yolo = False,
-                                 extraGHCFlags = ["-no-hs-main"],
-                                 Asterius.Main.exportFunctions = [],
-                                 extraRootSymbols = extra_syms
-                               }
+  putStrLn
+  Task
+    { target = Node,
+      inputHS = p,
+      outputDirectory = takeDirectory p,
+      outputBaseName = takeBaseName p,
+      inputEntryMJS = Nothing,
+      tailCalls = False,
+      Asterius.Main.gcSections = True,
+      fullSymTable = True,
+      bundle = False,
+      Asterius.Main.binaryen = False,
+      Asterius.Main.debug = False,
+      outputLinkReport = False,
+      Asterius.Main.outputIR = False,
+      run = False,
+      Asterius.Main.verboseErr = True,
+      yolo = False,
+      extraGHCFlags = ["-no-hs-main"],
+      Asterius.Main.exportFunctions = [],
+      extraRootSymbols = extra_syms
+    }
 
-newAsteriusInstanceNonMain
-  :: JSSession
-  -> FilePath
-  -> [AsteriusEntitySymbol]
-  -> AsteriusModule
-  -> IO JSVal
+newAsteriusInstanceNonMain ::
+  JSSession ->
+  FilePath ->
+  [AsteriusEntitySymbol] ->
+  AsteriusModule ->
+  IO JSVal
 newAsteriusInstanceNonMain s p extra_syms m = do
   distNonMain p extra_syms $ linkNonMain m extra_syms
   let lib_path = p -<.> "lib.mjs"
@@ -85,8 +85,8 @@ newAsteriusInstanceNonMain s p extra_syms m = do
   lib_val <- importMJS s lib_path
   f_val <- eval s $ takeJSVal lib_val <> ".default"
   mod_val <-
-    eval s
-      $ "import('fs').then(fs => fs.promises.readFile("
+    eval s $
+      "import('fs').then(fs => fs.promises.readFile("
         <> fromString (show wasm_path)
         <> ")).then(buf => WebAssembly.compile(buf))"
   eval s $ takeJSVal f_val <> "(" <> takeJSVal mod_val <> ")"

--- a/asterius/src/Asterius/Ld.hs
+++ b/asterius/src/Asterius/Ld.hs
@@ -4,12 +4,13 @@
 {-# LANGUAGE StrictData #-}
 
 module Asterius.Ld
-  ( LinkTask(..)
-  , linkModules
-  , linkExeInMemory
-  , linkExe
-  , rtsUsedSymbols
-  ) where
+  ( LinkTask (..),
+    linkModules,
+    linkExeInMemory,
+    linkExe,
+    rtsUsedSymbols,
+  )
+where
 
 import Asterius.Ar
 import Asterius.Builtins
@@ -23,14 +24,16 @@ import Data.Set (Set)
 import Data.Traversable
 import Prelude hiding (IO)
 
-data LinkTask = LinkTask
-  { progName, linkOutput :: FilePath
-  , linkObjs, linkLibs :: [FilePath]
-  , linkModule :: AsteriusModule
-  , debug, gcSections, binaryen, verboseErr :: Bool
-  , outputIR :: Maybe FilePath
-  , rootSymbols, exportFunctions :: [AsteriusEntitySymbol]
-  } deriving (Show)
+data LinkTask
+  = LinkTask
+      { progName, linkOutput :: FilePath,
+        linkObjs, linkLibs :: [FilePath],
+        linkModule :: AsteriusModule,
+        debug, gcSections, binaryen, verboseErr :: Bool,
+        outputIR :: Maybe FilePath,
+        rootSymbols, exportFunctions :: [AsteriusEntitySymbol]
+      }
+  deriving (Show)
 
 loadTheWorld :: LinkTask -> IO AsteriusModule
 loadTheWorld LinkTask {..} = do
@@ -44,56 +47,58 @@ loadTheWorld LinkTask {..} = do
 rtsUsedSymbols :: Set AsteriusEntitySymbol
 rtsUsedSymbols =
   Set.fromList
-    [ "barf"
-    , "base_AsteriusziTopHandler_runMainIO_closure"
-    , "base_AsteriusziTypes_makeJSException_closure"
-    , "base_GHCziPtr_Ptr_con_info"
-    , "base_GHCziStable_StablePtr_con_info"
-    , "ghczmprim_GHCziTypes_Czh_con_info"
-    , "ghczmprim_GHCziTypes_Dzh_con_info"
-    , "ghczmprim_GHCziTypes_False_closure"
-    , "ghczmprim_GHCziTypes_Izh_con_info"
-    , "ghczmprim_GHCziTypes_True_closure"
-    , "ghczmprim_GHCziTypes_Wzh_con_info"
-    , "ghczmprim_GHCziTypes_ZC_con_info"
-    , "ghczmprim_GHCziTypes_ZMZN_closure"
-    , "integerzmwiredzmin_GHCziIntegerziType_Integer_con_info"
-    , "MainCapability"
-    , "Main_main_closure"
-    , "stg_ARR_WORDS_info"
-    , "stg_BLACKHOLE_info"
-    , "stg_DEAD_WEAK_info"
-    , "stg_marked_upd_frame_info"
-    , "stg_NO_FINALIZER_closure"
-    , "stg_raise_info"
-    , "stg_raisezh"
-    , "stg_returnToStackTop"
-    , "stg_STABLE_NAME_info"
-    , "stg_WEAK_info"
+    [ "barf",
+      "base_AsteriusziTopHandler_runMainIO_closure",
+      "base_AsteriusziTypes_makeJSException_closure",
+      "base_GHCziPtr_Ptr_con_info",
+      "base_GHCziStable_StablePtr_con_info",
+      "ghczmprim_GHCziTypes_Czh_con_info",
+      "ghczmprim_GHCziTypes_Dzh_con_info",
+      "ghczmprim_GHCziTypes_False_closure",
+      "ghczmprim_GHCziTypes_Izh_con_info",
+      "ghczmprim_GHCziTypes_True_closure",
+      "ghczmprim_GHCziTypes_Wzh_con_info",
+      "ghczmprim_GHCziTypes_ZC_con_info",
+      "ghczmprim_GHCziTypes_ZMZN_closure",
+      "integerzmwiredzmin_GHCziIntegerziType_Integer_con_info",
+      "MainCapability",
+      "Main_main_closure",
+      "stg_ARR_WORDS_info",
+      "stg_BLACKHOLE_info",
+      "stg_DEAD_WEAK_info",
+      "stg_marked_upd_frame_info",
+      "stg_NO_FINALIZER_closure",
+      "stg_raise_info",
+      "stg_raisezh",
+      "stg_returnToStackTop",
+      "stg_STABLE_NAME_info",
+      "stg_WEAK_info"
     ]
 
 linkModules ::
-     LinkTask -> AsteriusModule -> (AsteriusModule, Module, LinkReport)
+  LinkTask -> AsteriusModule -> (AsteriusModule, Module, LinkReport)
 linkModules LinkTask {..} m =
   linkStart
     debug
     gcSections
     binaryen
     verboseErr
-    (rtsAsteriusModule
-       defaultBuiltinsOptions
-         { Asterius.Builtins.progName = progName
-         , Asterius.Builtins.debug = debug
-         } <>
-     m)
-    (Set.unions
-       [ Set.fromList rootSymbols
-       , rtsUsedSymbols
-       , Set.fromList
-           [ AsteriusEntitySymbol {entityName = internalName}
-           | FunctionExport {..} <- rtsFunctionExports debug
-           ]
-       ])
+    ( rtsAsteriusModule
+        defaultBuiltinsOptions
+          { Asterius.Builtins.progName = progName,
+            Asterius.Builtins.debug = debug
+          }
+        <> m
+    )
+    ( Set.unions
+        [ Set.fromList rootSymbols,
+          rtsUsedSymbols,
+          Set.fromList
+            [ AsteriusEntitySymbol {entityName = internalName}
+              | FunctionExport {..} <- rtsFunctionExports debug
+            ]
+        ]
+    )
     exportFunctions
 
 linkExeInMemory :: LinkTask -> IO (AsteriusModule, Module, LinkReport)

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -4,12 +4,13 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Asterius.Main
-  ( Target(..)
-  , Task(..)
-  , getTask
-  , ahcDistMain
-  , ahcLinkMain
-  ) where
+  ( Target (..),
+    Task (..),
+    getTask,
+    ahcDistMain,
+    ahcLinkMain,
+  )
+where
 
 import qualified Asterius.Backends.Binaryen as Binaryen
 import qualified Asterius.Backends.WasmToolkit as WasmToolkit
@@ -23,10 +24,10 @@ import Asterius.JSGen.Wasm
 import Asterius.Ld (rtsUsedSymbols)
 import Asterius.Resolve
 import Asterius.Types
-  ( AsteriusEntitySymbol(..)
-  , FFIExportDecl(..)
-  , FFIMarshalState(..)
-  , Module
+  ( AsteriusEntitySymbol (..),
+    FFIExportDecl (..),
+    FFIMarshalState (..),
+    Module,
   )
 import Control.Monad
 import Control.Monad.Except
@@ -45,109 +46,110 @@ import Foreign
 import Language.WebAssembly.WireFormat
 import qualified Language.WebAssembly.WireFormat as Wasm
 import NPM.Parcel
-import Prelude hiding (IO)
 import System.Console.GetOpt
 import System.Directory
 import System.Environment.Blank
 import System.FilePath
 import System.IO hiding (IO)
 import System.Process
+import Prelude hiding (IO)
 
 data Target
   = Node
   | Browser
   deriving (Eq, Show)
 
-data Task = Task
-  { target :: Target
-  , inputHS :: FilePath
-  , inputEntryMJS :: Maybe FilePath
-  , outputDirectory :: FilePath
-  , outputBaseName :: String
-  , tailCalls, gcSections, fullSymTable, bundle, binaryen, debug, outputLinkReport, outputIR, run, verboseErr, yolo :: Bool
-  , extraGHCFlags :: [String]
-  , exportFunctions, extraRootSymbols :: [AsteriusEntitySymbol]
-  } deriving (Show)
+data Task
+  = Task
+      { target :: Target,
+        inputHS :: FilePath,
+        inputEntryMJS :: Maybe FilePath,
+        outputDirectory :: FilePath,
+        outputBaseName :: String,
+        tailCalls, gcSections, fullSymTable, bundle, binaryen, debug, outputLinkReport, outputIR, run, verboseErr, yolo :: Bool,
+        extraGHCFlags :: [String],
+        exportFunctions, extraRootSymbols :: [AsteriusEntitySymbol]
+      }
+  deriving (Show)
 
 parseTask :: [String] -> Task
-parseTask args =
-  case err_msgs of
-    [] -> task
-    _ -> error $ show err_msgs
+parseTask args = case err_msgs of
+  [] -> task
+  _ -> error $ show err_msgs
   where
     bool_opt s f = Option [] [s] (NoArg f) ""
     str_opt s f = Option [] [s] (ReqArg f "") ""
     (task_trans_list, _, err_msgs) =
       getOpt
         Permute
-        [ bool_opt "browser" $ \t -> t {target = Browser}
-        , str_opt "input-hs" $ \s t ->
+        [ bool_opt "browser" $ \t -> t {target = Browser},
+          str_opt "input-hs" $ \s t ->
             t
-              { inputHS = s
-              , outputDirectory = takeDirectory s
-              , outputBaseName = takeBaseName s
-              }
-        , str_opt "input-exe" $ \s t ->
+              { inputHS = s,
+                outputDirectory = takeDirectory s,
+                outputBaseName = takeBaseName s
+              },
+          str_opt "input-exe" $ \s t ->
             t
-              { inputHS = s
-              , outputDirectory = takeDirectory s
-              , outputBaseName = takeBaseName s
-              }
-        , str_opt "input-mjs" $ \s t -> t {inputEntryMJS = Just s}
-        , str_opt "output-directory" $ \s t -> t {outputDirectory = s}
-        , str_opt "output-prefix" $ \s t -> t {outputBaseName = s}
-        , bool_opt "tail-calls" $ \t -> t {tailCalls = True}
-        , bool_opt "no-gc-sections" $ \t -> t {gcSections = False}
-        , bool_opt "full-sym-table" $ \t -> t {fullSymTable = True}
-        , bool_opt "bundle" $ \t -> t {bundle = True}
-        , bool_opt "binaryen" $ \t -> t {binaryen = True}
-        , bool_opt "debug" $ \t ->
+              { inputHS = s,
+                outputDirectory = takeDirectory s,
+                outputBaseName = takeBaseName s
+              },
+          str_opt "input-mjs" $ \s t -> t {inputEntryMJS = Just s},
+          str_opt "output-directory" $ \s t -> t {outputDirectory = s},
+          str_opt "output-prefix" $ \s t -> t {outputBaseName = s},
+          bool_opt "tail-calls" $ \t -> t {tailCalls = True},
+          bool_opt "no-gc-sections" $ \t -> t {gcSections = False},
+          bool_opt "full-sym-table" $ \t -> t {fullSymTable = True},
+          bool_opt "bundle" $ \t -> t {bundle = True},
+          bool_opt "binaryen" $ \t -> t {binaryen = True},
+          bool_opt "debug" $ \t ->
             t
-              { fullSymTable = True
-              , binaryen = True
-              , debug = True
-              , outputLinkReport = True
-              , outputIR = True
-              , verboseErr = True
-              }
-        , bool_opt "output-link-report" $ \t -> t {outputLinkReport = True}
-        , bool_opt "output-ir" $ \t -> t {outputIR = True}
-        , bool_opt "run" $ \t -> t {run = True}
-        , bool_opt "verbose-err" $ \t -> t {verboseErr = True}
-        , bool_opt "yolo" $ \t -> t {yolo = True}
-        , str_opt "ghc-option" $ \s t ->
-            t {extraGHCFlags = extraGHCFlags t <> [s]}
-        , str_opt "export-function" $ \s t ->
-            t {exportFunctions = fromString s : exportFunctions t}
-        , str_opt "extra-root-symbol" $ \s t ->
-            t {extraRootSymbols = fromString s : extraRootSymbols t}
+              { fullSymTable = True,
+                binaryen = True,
+                debug = True,
+                outputLinkReport = True,
+                outputIR = True,
+                verboseErr = True
+              },
+          bool_opt "output-link-report" $ \t -> t {outputLinkReport = True},
+          bool_opt "output-ir" $ \t -> t {outputIR = True},
+          bool_opt "run" $ \t -> t {run = True},
+          bool_opt "verbose-err" $ \t -> t {verboseErr = True},
+          bool_opt "yolo" $ \t -> t {yolo = True},
+          str_opt "ghc-option" $
+            \s t -> t {extraGHCFlags = extraGHCFlags t <> [s]},
+          str_opt "export-function" $
+            \s t -> t {exportFunctions = fromString s : exportFunctions t},
+          str_opt "extra-root-symbol" $
+            \s t -> t {extraRootSymbols = fromString s : extraRootSymbols t}
         ]
         args
     task =
       foldl'
         (flip ($))
         Task
-          { target = Node
-          , inputHS = error "Asterius.Main.parseTask: missing inputHS"
-          , outputDirectory =
-              error "Asterius.Main.parseTask: missing outputDirectory"
-          , outputBaseName =
-              error "Asterius.Main.parseTask: missing outputBaseName"
-          , inputEntryMJS = Nothing
-          , tailCalls = False
-          , gcSections = True
-          , fullSymTable = False
-          , bundle = False
-          , binaryen = False
-          , debug = False
-          , outputLinkReport = False
-          , outputIR = False
-          , run = False
-          , verboseErr = False
-          , yolo = False
-          , extraGHCFlags = []
-          , exportFunctions = []
-          , extraRootSymbols = []
+          { target = Node,
+            inputHS = error "Asterius.Main.parseTask: missing inputHS",
+            outputDirectory =
+              error
+                "Asterius.Main.parseTask: missing outputDirectory",
+            outputBaseName = error "Asterius.Main.parseTask: missing outputBaseName",
+            inputEntryMJS = Nothing,
+            tailCalls = False,
+            gcSections = True,
+            fullSymTable = False,
+            bundle = False,
+            binaryen = False,
+            debug = False,
+            outputLinkReport = False,
+            outputIR = False,
+            run = False,
+            verboseErr = False,
+            yolo = False,
+            extraGHCFlags = [],
+            exportFunctions = [],
+            extraRootSymbols = []
           }
         task_trans_list
 
@@ -157,126 +159,119 @@ getTask = parseTask <$> getArgs
 genPackageJSON :: Task -> Builder
 genPackageJSON Task {..} =
   mconcat
-    [ "{\"name\": \""
-    , base_name
-    , "\",\n"
-    , "\"version\": \"0.0.1\",\n"
-    , "\"browserslist\": [\"last 1 Chrome version\"]\n"
-    , "}\n"
+    [ "{\"name\": \"",
+      base_name,
+      "\",\n",
+      "\"version\": \"0.0.1\",\n",
+      "\"browserslist\": [\"last 1 Chrome version\"]\n",
+      "}\n"
     ]
   where
     base_name = string7 outputBaseName
 
 genSymbolDict :: M.Map AsteriusEntitySymbol Int64 -> Builder
 genSymbolDict sym_map =
-  "Object.freeze({" <>
-  mconcat
-    (intersperse
-       ","
-       [ "\"" <> shortByteString (entityName sym) <> "\":" <>
-       intHex sym_idx
-       | (sym, sym_idx) <- M.toList sym_map
-       ]) <>
-  "})"
+  "Object.freeze({"
+    <> mconcat
+      ( intersperse
+          ","
+          [ "\"" <> shortByteString (entityName sym) <> "\":" <> intHex sym_idx
+            | (sym, sym_idx) <- M.toList sym_map
+          ]
+      )
+    <> "})"
 
 genInfoTables :: [Int64] -> Builder
 genInfoTables sym_set =
-  "new Set([" <> mconcat (intersperse "," (map intHex sym_set)) <>
-  "])"
+  "new Set([" <> mconcat (intersperse "," (map intHex sym_set)) <> "])"
 
-genExportStablePtrs
-  :: M.Map AsteriusEntitySymbol Int64
-  -> [AsteriusEntitySymbol]
-  -> FFIMarshalState
-  -> Builder
+genExportStablePtrs ::
+  M.Map AsteriusEntitySymbol Int64 ->
+  [AsteriusEntitySymbol] ->
+  FFIMarshalState ->
+  Builder
 genExportStablePtrs sym_map export_funcs FFIMarshalState {..} =
   "["
     <> mconcat
-         ( intersperse
-             ","
-             ( map (intHex . (sym_map !) . ffiExportClosure . (ffiExportDecls !))
-                 export_funcs
-             )
-         )
+      ( intersperse
+          ","
+          ( map
+              (intHex . (sym_map !) . ffiExportClosure . (ffiExportDecls !))
+              export_funcs
+          )
+      )
     <> "]"
 
 genLib :: Task -> LinkReport -> Builder
 genLib Task {..} LinkReport {..} =
   mconcat
-    [ "import * as rts from \"./rts.mjs\";\n"
-    , "export default module => \n"
-    , "rts.newAsteriusInstance({module: module, jsffiFactory: "
-    , generateFFIImportObjectFactory bundledFFIMarshalState
-    , ", exports: "
-    , generateFFIExportObject bundledFFIMarshalState
-    , ", symbolTable: "
-    , genSymbolDict symbol_table
-    , if debug
-        then
-          mconcat
-            [ ", infoTables: ",
-              genInfoTables infoTableSet
-            ]
-        else mempty
-    , ", exportStablePtrs: "
-    , genExportStablePtrs
-        staticsSymbolMap
-        exportFunctions
-        bundledFFIMarshalState
-    , ", tableSlots: "
-    , intDec tableSlots
-    , ", staticMBlocks: "
-    , intDec staticMBlocks
-    , ", yolo: "
-    , if yolo
-        then "true"
-        else "false"
-    , "})"
-    , ";\n"
+    [ "import * as rts from \"./rts.mjs\";\n",
+      "export default module => \n",
+      "rts.newAsteriusInstance({module: module, jsffiFactory: ",
+      generateFFIImportObjectFactory bundledFFIMarshalState,
+      ", exports: ",
+      generateFFIExportObject bundledFFIMarshalState,
+      ", symbolTable: ",
+      genSymbolDict symbol_table,
+      if debug
+        then mconcat [", infoTables: ", genInfoTables infoTableSet]
+        else mempty,
+      ", exportStablePtrs: ",
+      genExportStablePtrs staticsSymbolMap exportFunctions bundledFFIMarshalState,
+      ", tableSlots: ",
+      intDec tableSlots,
+      ", staticMBlocks: ",
+      intDec staticMBlocks,
+      ", yolo: ",
+      if yolo then "true" else "false",
+      "})",
+      ";\n"
     ]
   where
     raw_symbol_table = staticsSymbolMap <> functionSymbolMap
     symbol_table
-      | fullSymTable = raw_symbol_table
+      | fullSymTable =
+        raw_symbol_table
       | otherwise =
         M.restrictKeys raw_symbol_table $
-        S.fromList
-          [ ffiExportClosure
-          | FFIExportDecl {..} <-
-              M.elems $ ffiExportDecls bundledFFIMarshalState
-          ] <>
-        S.fromList extraRootSymbols <>
-        rtsUsedSymbols
+          S.fromList
+            [ ffiExportClosure
+              | FFIExportDecl {..} <-
+                  M.elems $
+                    ffiExportDecls bundledFFIMarshalState
+            ]
+            <> S.fromList extraRootSymbols
+            <> rtsUsedSymbols
 
 genDefEntry :: Task -> Builder
 genDefEntry Task {..} =
   mconcat
-    [ "import module from \"./"
-    , out_base
-    , ".wasm.mjs\";\n"
-    , "import "
-    , out_base
-    , " from \"./"
-    , out_base
-    , ".lib.mjs\";\n"
-    , case target of
+    [ "import module from \"./",
+      out_base,
+      ".wasm.mjs\";\n",
+      "import ",
+      out_base,
+      " from \"./",
+      out_base,
+      ".lib.mjs\";\n",
+      case target of
         Node -> "process.on(\"unhandledRejection\", err => { throw err; });\n"
-        Browser -> mempty
-    , mconcat
-        [ "module.then(m => "
-        , out_base
-        , "(m)).then(async i => {\n"
-        , "try {\n"
-        , "i.exports.hs_init();\n"
-        , "await i.exports.main();\n"
-        , "} catch (err) {\n"
-        , "console.log(i.stdio.stdout());\n"
-        , "console.log(i.stdio.stderr());\n"
-        , "throw err;\n"
-        , "}\n"
-        , "if (i.stdio.stdout().toString().length) console.log(i.stdio.stdout());\n"
-        , "if (i.stdio.stderr().toString().length) console.log(i.stdio.stderr());\n"
-        , "});\n"
+        Browser -> mempty,
+      mconcat
+        [ "module.then(m => ",
+          out_base,
+          "(m)).then(async i => {\n",
+          "try {\n",
+          "i.exports.hs_init();\n",
+          "await i.exports.main();\n",
+          "} catch (err) {\n",
+          "console.log(i.stdio.stdout());\n",
+          "console.log(i.stdio.stderr());\n",
+          "throw err;\n",
+          "}\n",
+          "if (i.stdio.stdout().toString().length) console.log(i.stdio.stdout());\n",
+          "if (i.stdio.stderr().toString().length) console.log(i.stdio.stderr());\n",
+          "});\n"
         ]
     ]
   where
@@ -285,20 +280,20 @@ genDefEntry Task {..} =
 genHTML :: Task -> Builder
 genHTML Task {..} =
   mconcat
-    [ "<!doctype html>\n"
-    , "<html lang=\"en\">\n"
-    , "<head>\n"
-    , "<title>"
-    , out_base
-    , "</title>\n"
-    , "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">\n"
-    , "</head>\n"
-    , "<body>\n"
-    , if bundle
+    [ "<!doctype html>\n",
+      "<html lang=\"en\">\n",
+      "<head>\n",
+      "<title>",
+      out_base,
+      "</title>\n",
+      "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">\n",
+      "</head>\n",
+      "<body>\n",
+      if bundle
         then "<script src=\"" <> out_js <> "\"></script>\n"
-        else "<script type=\"module\" src=\"" <> out_entry <> "\"></script>\n"
-    , "</body>\n"
-    , "</html>\n"
+        else "<script type=\"module\" src=\"" <> out_entry <> "\"></script>\n",
+      "</body>\n",
+      "</html>\n"
     ]
   where
     out_base = string7 outputBaseName
@@ -313,37 +308,38 @@ ahcLink Task {..} = do
   ld_output <- temp (takeBaseName inputHS)
   putStrLn $ "[INFO] Compiling " <> inputHS <> " to WebAssembly"
   callProcess ahc $
-    [ "--make"
-    , "-O"
-    , "-i" <> takeDirectory inputHS
-    , "-fexternal-interpreter"
-    , "-pgml" <> ahcLd
-    , "-clear-package-db"
-    , "-global-package-db"
-    ] <>
-    ["-optl--debug" | debug] <>
-    [ "-optl--extra-root-symbol=" <> c8SBS (entityName root_sym)
-    | root_sym <- extraRootSymbols
-    ] <>
-    [ "-optl--export-function=" <> c8SBS (entityName export_func)
-    | export_func <- exportFunctions
-    ] <>
-    ["-optl--no-gc-sections" | not gcSections] <>
-    ["-optl--binaryen" | binaryen] <>
-    ["-optl--verbose-err" | verboseErr] <>
-    extraGHCFlags <>
-    [ "-optl--output-ir=" <> outputDirectory </>
-    (outputBaseName <.> "unlinked.bin")
-    | outputIR
-    ] <>
-    ["-optl--prog-name=" <> takeBaseName inputHS] <>
-    ["-o", ld_output, inputHS]
+    [ "--make",
+      "-O",
+      "-i" <> takeDirectory inputHS,
+      "-fexternal-interpreter",
+      "-pgml" <> ahcLd,
+      "-clear-package-db",
+      "-global-package-db"
+    ]
+      <> ["-optl--debug" | debug]
+      <> [ "-optl--extra-root-symbol=" <> c8SBS (entityName root_sym)
+           | root_sym <- extraRootSymbols
+         ]
+      <> [ "-optl--export-function=" <> c8SBS (entityName export_func)
+           | export_func <- exportFunctions
+         ]
+      <> ["-optl--no-gc-sections" | not gcSections]
+      <> ["-optl--binaryen" | binaryen]
+      <> ["-optl--verbose-err" | verboseErr]
+      <> extraGHCFlags
+      <> [ "-optl--output-ir="
+             <> outputDirectory
+             </> (outputBaseName <.> "unlinked.bin")
+           | outputIR
+         ]
+      <> ["-optl--prog-name=" <> takeBaseName inputHS]
+      <> ["-o", ld_output, inputHS]
   r <- decodeFile ld_output
   removeFile ld_output
   pure r
 
 ahcDistMain ::
-     (String -> IO ()) -> Task -> (Asterius.Types.Module, LinkReport) -> IO ()
+  (String -> IO ()) -> Task -> (Asterius.Types.Module, LinkReport) -> IO ()
 ahcDistMain logger task@Task {..} (final_m, report) = do
   let out_package_json = outputDirectory </> "package.json"
       out_rts_constants = outputDirectory </> "rts.constants.mjs"
@@ -362,67 +358,73 @@ ahcDistMain logger task@Task {..} (final_m, report) = do
     logger $ "[INFO] Printing linked IR to " <> show p
     writeFile p $ show final_m
   if binaryen
-    then (do logger "[INFO] Converting linked IR to binaryen IR"
-             Binaryen.c_BinaryenSetDebugInfo 1
-             Binaryen.c_BinaryenSetOptimizeLevel 0
-             Binaryen.c_BinaryenSetShrinkLevel 0
-             m_ref <-
-               Binaryen.marshalModule
-                 (staticsSymbolMap report <> functionSymbolMap report)
-                 final_m
-             logger "[INFO] Validating binaryen IR"
-             pass_validation <- Binaryen.c_BinaryenModuleValidate m_ref
-             when (pass_validation /= 1) $
-               fail "[ERROR] binaryen validation failed"
-             m_bin <- Binaryen.serializeModule m_ref
-             logger $ "[INFO] Writing WebAssembly binary to " <> show out_wasm
-             BS.writeFile out_wasm m_bin
-             when outputIR $ do
-               let p = out_wasm -<.> "binaryen-show.txt"
-               logger $ "[info] writing re-parsed wasm-toolkit ir to " <> show p
-               case runGetOrFail Wasm.getModule (LBS.fromStrict m_bin) of
-                 Right (rest, _, r)
-                   | LBS.null rest -> writeFile p (show r)
-                   | otherwise -> fail "[ERROR] Re-parsing produced residule"
-                 _ -> fail "[ERROR] Re-parsing failed"
-               let out_wasm_binaryen_sexpr = out_wasm -<.> "binaryen-sexpr.txt"
-               logger $ "[info] writing re-parsed wasm-toolkit ir as s-expresions to " <> show out_wasm_binaryen_sexpr
-               -- disable colors when writing out the binaryen module
-               -- to a file, so that we don't get ANSI escape sequences
-               -- for colors. Reset the state after
-               cenabled <- Binaryen.isColorsEnabled
-               Binaryen.setColorsEnabled False
-               m_sexpr <- Binaryen.serializeModuleSExpr m_ref
-               Binaryen.setColorsEnabled cenabled
-
-               BS.writeFile out_wasm_binaryen_sexpr m_sexpr)
-    else (do logger "[INFO] Converting linked IR to wasm-toolkit IR"
-             let conv_result =
-                   runExcept $
-                   WasmToolkit.makeModule
-                     tailCalls
-                     (staticsSymbolMap report <> functionSymbolMap report)
-                     final_m
-             r <-
-               case conv_result of
-                 Left err ->
-                   fail $ "[ERROR] Conversion failed with " <> show err
-                 Right r -> pure r
-             when outputIR $ do
-               let p = out_wasm -<.> "wasm-toolkit.txt"
-               logger $ "[INFO] Writing wasm-toolkit IR to " <> show p
-               writeFile p $ show r
-             logger $ "[INFO] Writing WebAssembly binary to " <> show out_wasm
-             withBinaryFile out_wasm WriteMode $ \h ->
-               hPutBuilder h $ execPut $ putModule r)
+    then
+      ( do
+          logger "[INFO] Converting linked IR to binaryen IR"
+          Binaryen.c_BinaryenSetDebugInfo 1
+          Binaryen.c_BinaryenSetOptimizeLevel 0
+          Binaryen.c_BinaryenSetShrinkLevel 0
+          m_ref <-
+            Binaryen.marshalModule
+              (staticsSymbolMap report <> functionSymbolMap report)
+              final_m
+          logger "[INFO] Validating binaryen IR"
+          pass_validation <- Binaryen.c_BinaryenModuleValidate m_ref
+          when (pass_validation /= 1) $ fail "[ERROR] binaryen validation failed"
+          m_bin <- Binaryen.serializeModule m_ref
+          logger $ "[INFO] Writing WebAssembly binary to " <> show out_wasm
+          BS.writeFile out_wasm m_bin
+          when outputIR $ do
+            let p = out_wasm -<.> "binaryen-show.txt"
+            logger $ "[info] writing re-parsed wasm-toolkit ir to " <> show p
+            case runGetOrFail Wasm.getModule (LBS.fromStrict m_bin) of
+              Right (rest, _, r)
+                | LBS.null rest -> writeFile p (show r)
+                | otherwise -> fail "[ERROR] Re-parsing produced residule"
+              _ -> fail "[ERROR] Re-parsing failed"
+            let out_wasm_binaryen_sexpr = out_wasm -<.> "binaryen-sexpr.txt"
+            logger $
+              "[info] writing re-parsed wasm-toolkit ir as s-expresions to "
+                <> show out_wasm_binaryen_sexpr
+            -- disable colors when writing out the binaryen module
+            -- to a file, so that we don't get ANSI escape sequences
+            -- for colors. Reset the state after
+            cenabled <- Binaryen.isColorsEnabled
+            Binaryen.setColorsEnabled False
+            m_sexpr <- Binaryen.serializeModuleSExpr m_ref
+            Binaryen.setColorsEnabled cenabled
+            BS.writeFile out_wasm_binaryen_sexpr m_sexpr
+      )
+    else
+      ( do
+          logger "[INFO] Converting linked IR to wasm-toolkit IR"
+          let conv_result =
+                runExcept $
+                  WasmToolkit.makeModule
+                    tailCalls
+                    (staticsSymbolMap report <> functionSymbolMap report)
+                    final_m
+          r <- case conv_result of
+            Left err -> fail $ "[ERROR] Conversion failed with " <> show err
+            Right r -> pure r
+          when outputIR $ do
+            let p = out_wasm -<.> "wasm-toolkit.txt"
+            logger $ "[INFO] Writing wasm-toolkit IR to " <> show p
+            writeFile p $ show r
+          logger $ "[INFO] Writing WebAssembly binary to " <> show out_wasm
+          withBinaryFile out_wasm WriteMode $
+            \h -> hPutBuilder h $ execPut $ putModule r
+      )
   logger $
-    "[INFO] Writing JavaScript runtime constants to " <> show out_rts_constants
+    "[INFO] Writing JavaScript runtime constants to "
+      <> show out_rts_constants
   builderWriteFile out_rts_constants rtsConstants
   logger $
-    "[INFO] Writing JavaScript runtime modules to " <> show outputDirectory
+    "[INFO] Writing JavaScript runtime modules to "
+      <> show outputDirectory
   rts_files <- listDirectory $ dataDir </> "rts"
-  for_ rts_files $ \f ->
-    copyFile (dataDir </> "rts" </> f) (outputDirectory </> f)
+  for_ rts_files $
+    \f -> copyFile (dataDir </> "rts" </> f) (outputDirectory </> f)
   logger $ "[INFO] Writing JavaScript loader module to " <> show out_wasm_lib
   builderWriteFile out_wasm_lib $ genWasm (target == Node) outputBaseName
   logger $ "[INFO] Writing JavaScript lib module to " <> show out_lib
@@ -440,40 +442,40 @@ ahcDistMain logger task@Task {..} (final_m, report) = do
     withCurrentDirectory outputDirectory $
       callProcess
         "node"
-        [ parcel
-        , "build"
-        , "--out-dir"
-        , "."
-        , "--out-file"
-        , takeFileName out_js
-        , "--no-cache"
-        , "--no-source-maps"
-        , "--no-autoinstall"
-        , "--no-content-hash"
-        , "--target"
-        , case target of
+        [ parcel,
+          "build",
+          "--out-dir",
+          ".",
+          "--out-file",
+          takeFileName out_js,
+          "--no-cache",
+          "--no-source-maps",
+          "--no-autoinstall",
+          "--no-content-hash",
+          "--target",
+          case target of
             Node -> "node"
-            Browser -> "browser"
-        , takeFileName out_entry
+            Browser -> "browser",
+          takeFileName out_entry
         ]
   when (target == Browser) $ do
     logger $ "[INFO] Writing HTML to " <> show out_html
     builderWriteFile out_html $ genHTML task
-  when (target == Node && run) $
-    withCurrentDirectory (takeDirectory out_wasm) $
-    if bundle
+  when (target == Node && run)
+    $ withCurrentDirectory (takeDirectory out_wasm)
+    $ if bundle
       then do
         logger $ "[INFO] Running " <> out_js
         callProcess "node" $
-          ["--experimental-wasm-bigint" | debug] <>
-          ["--experimental-wasm-return-call" | tailCalls] <>
-          [takeFileName out_js]
+          ["--experimental-wasm-bigint" | debug]
+            <> ["--experimental-wasm-return-call" | tailCalls]
+            <> [takeFileName out_js]
       else do
         logger $ "[INFO] Running " <> out_entry
         callProcess "node" $
-          ["--experimental-wasm-bigint" | debug] <>
-          ["--experimental-wasm-return-call" | tailCalls] <>
-          ["--experimental-modules", takeFileName out_entry]
+          ["--experimental-wasm-bigint" | debug]
+            <> ["--experimental-wasm-return-call" | tailCalls]
+            <> ["--experimental-modules", takeFileName out_entry]
 
 ahcLinkMain :: Task -> IO ()
 ahcLinkMain task = do

--- a/asterius/src/Asterius/MemoryTrap.hs
+++ b/asterius/src/Asterius/MemoryTrap.hs
@@ -4,11 +4,15 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Asterius.MemoryTrap
-  ( addMemoryTrap
-  ) where
+  ( addMemoryTrap,
+  )
+where
 
 import Asterius.Types
-import Data.Data (Data, gmapT)
+import Data.Data
+  ( Data,
+    gmapT,
+  )
 import qualified Data.Map.Strict as M
 import Type.Reflection
 
@@ -21,39 +25,36 @@ addMemoryTrapDeep :: Data a => AsteriusEntitySymbol -> a -> a
 addMemoryTrapDeep sym = w
   where
     w :: Data a => a -> a
-    w t =
-      case eqTypeRep (typeOf t) (typeRep :: TypeRep Expression) of
-        Just HRefl ->
-          case t of
-            Load {ptr = Unary {unaryOp = WrapInt64, operand0 = i64_ptr}, ..} ->
-              let new_i64_ptr = w i64_ptr
-               in CallImport
-                    { target' =
-                        "__asterius_load_" <>
-                        load_fn_suffix valueType bytes signed
-                    , operands =
-                        [ Symbol {unresolvedSymbol = sym, symbolOffset = 0}
-                        , new_i64_ptr
-                        , ConstI32 $ fromIntegral offset
-                        ]
-                    , callImportReturnTypes = [valueType]
-                    }
-            Store {ptr = Unary {unaryOp = WrapInt64, operand0 = i64_ptr}, ..} ->
-              let new_i64_ptr = w i64_ptr
-                  new_value = w value
-               in CallImport
-                    { target' =
-                        "__asterius_store_" <> store_fn_suffix valueType bytes
-                    , operands =
-                        [ Symbol {unresolvedSymbol = sym, symbolOffset = 0}
-                        , new_i64_ptr
-                        , ConstI32 $ fromIntegral offset
-                        , new_value
-                        ]
-                    , callImportReturnTypes = []
-                    }
-            _ -> go
+    w t = case eqTypeRep (typeOf t) (typeRep :: TypeRep Expression) of
+      Just HRefl -> case t of
+        Load {ptr = Unary {unaryOp = WrapInt64, operand0 = i64_ptr}, ..} ->
+          let new_i64_ptr = w i64_ptr
+           in CallImport
+                { target' =
+                    "__asterius_load_"
+                      <> load_fn_suffix valueType bytes signed,
+                  operands =
+                    [ Symbol {unresolvedSymbol = sym, symbolOffset = 0},
+                      new_i64_ptr,
+                      ConstI32 $ fromIntegral offset
+                    ],
+                  callImportReturnTypes = [valueType]
+                }
+        Store {ptr = Unary {unaryOp = WrapInt64, operand0 = i64_ptr}, ..} ->
+          let new_i64_ptr = w i64_ptr
+              new_value = w value
+           in CallImport
+                { target' = "__asterius_store_" <> store_fn_suffix valueType bytes,
+                  operands =
+                    [ Symbol {unresolvedSymbol = sym, symbolOffset = 0},
+                      new_i64_ptr,
+                      ConstI32 $ fromIntegral offset,
+                      new_value
+                    ],
+                  callImportReturnTypes = []
+                }
         _ -> go
+      _ -> go
       where
         go = gmapT w t
     load_fn_suffix I32 1 False = "I32_U8"

--- a/asterius/src/Asterius/Passes/All.hs
+++ b/asterius/src/Asterius/Passes/All.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Asterius.Passes.All
-  ( adjustLocalRegs
-  ) where
+  ( adjustLocalRegs,
+  )
+where
 
 import Asterius.Internals.SYB
 import Asterius.Passes.Common
@@ -12,9 +13,11 @@ import Control.Monad.State.Strict
 
 {-# INLINEABLE adjustLocalRegs #-}
 adjustLocalRegs :: Function -> Function
-adjustLocalRegs Function {..} =
-  Function
-    {functionType = functionType, varTypes = localRegTable ps, body = result}
+adjustLocalRegs Function {..} = Function
+  { functionType = functionType,
+    varTypes = localRegTable ps,
+    body = result
+  }
   where
     (result, ps) = runState (pipeline body) defaultPassesState
     pipeline = everywhereM (resolveLocalRegs functionType)

--- a/asterius/src/Asterius/Passes/Barf.hs
+++ b/asterius/src/Asterius/Passes/Barf.hs
@@ -3,14 +3,18 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Asterius.Passes.Barf
-  ( processBarf
-  ) where
+  ( processBarf,
+  )
+where
 
 import Asterius.Types
 import Control.Monad.State.Strict
 import qualified Data.ByteString.Char8 as CBS
 import qualified Data.ByteString.Short as SBS
-import Data.Data (Data, gmapM)
+import Data.Data
+  ( Data,
+    gmapM,
+  )
 import qualified Data.Map.Strict as M
 import Data.String
 import Data.Word
@@ -18,47 +22,53 @@ import qualified Encoding as GHC
 import Type.Reflection
 
 processBarf :: AsteriusEntitySymbol -> Function -> AsteriusModule
-processBarf sym f = mempty {staticsMap = sm, functionMap = M.singleton sym f'}
+processBarf sym f =
+  mempty
+    { staticsMap = sm,
+      functionMap = M.singleton sym f'
+    }
   where
     (f', (_, sm)) = runState (w f) (0, M.empty)
-    w :: Data a
-      => a
-      -> State (Word64, M.Map AsteriusEntitySymbol AsteriusStatics) a
-    w t =
-      case eqTypeRep (typeOf t) (typeRep :: TypeRep Expression) of
-        Just HRefl ->
-          case t of
-            Barf {..} -> do
-              (i, sm_acc) <- get
-              let i_sym = fromString $ p <> GHC.toBase62 i
-                  ss =
-                    AsteriusStatics
-                      { staticsType = ConstBytes
-                      , asteriusStatics =
-                          [ Serialized $
-                            fromString $
-                            sym_str <> ": " <> unpack barfMessage <> "\0"
-                          ]
-                      }
-              put (succ i, M.insert i_sym ss sm_acc)
-              pure
-                Block
-                  { name = SBS.empty
-                  , bodys =
-                      [ Call
-                          { target = "barf"
-                          , operands =
-                              [ Symbol
-                                  {unresolvedSymbol = i_sym, symbolOffset = 0}
-                              ]
-                          , callReturnTypes = []
-                          }
-                      , Unreachable
-                      ]
-                  , blockReturnTypes = barfReturnTypes
-                  }
-            _ -> go
+    w ::
+      Data a =>
+      a ->
+      State (Word64, M.Map AsteriusEntitySymbol AsteriusStatics) a
+    w t = case eqTypeRep (typeOf t) (typeRep :: TypeRep Expression) of
+      Just HRefl -> case t of
+        Barf {..} -> do
+          (i, sm_acc) <- get
+          let i_sym = fromString $ p <> GHC.toBase62 i
+              ss = AsteriusStatics
+                { staticsType = ConstBytes,
+                  asteriusStatics =
+                    [ Serialized
+                        $ fromString
+                        $ sym_str
+                          <> ": "
+                          <> unpack barfMessage
+                          <> "\0"
+                    ]
+                }
+          put (succ i, M.insert i_sym ss sm_acc)
+          pure Block
+            { name = SBS.empty,
+              bodys =
+                [ Call
+                    { target = "barf",
+                      operands =
+                        [ Symbol
+                            { unresolvedSymbol = i_sym,
+                              symbolOffset = 0
+                            }
+                        ],
+                      callReturnTypes = []
+                    },
+                  Unreachable
+                ],
+              blockReturnTypes = barfReturnTypes
+            }
         _ -> go
+      _ -> go
       where
         go = gmapM w t
     sym_str = unpack (entityName sym)

--- a/asterius/src/Asterius/Passes/Common.hs
+++ b/asterius/src/Asterius/Passes/Common.hs
@@ -1,18 +1,21 @@
 {-# LANGUAGE StrictData #-}
 
 module Asterius.Passes.Common
-  ( PassesState(..)
-  , defaultPassesState
-  ) where
+  ( PassesState (..),
+    defaultPassesState,
+  )
+where
 
 import Asterius.Types
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 
-data PassesState = PassesState
-  { localRegMap :: Map UnresolvedLocalReg Int
-  , localRegStack :: [ValueType]
-  }
+data PassesState
+  = PassesState
+      { localRegMap :: Map UnresolvedLocalReg Int,
+        localRegStack :: [ValueType]
+      }
 
 defaultPassesState :: PassesState
-defaultPassesState = PassesState {localRegMap = Map.empty, localRegStack = []}
+defaultPassesState =
+  PassesState {localRegMap = Map.empty, localRegStack = []}

--- a/asterius/src/Asterius/Passes/DataSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/DataSymbolTable.hs
@@ -3,9 +3,10 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Asterius.Passes.DataSymbolTable
-  ( makeDataSymbolTable
-  , makeMemory
-  ) where
+  ( makeDataSymbolTable,
+    makeMemory,
+  )
+where
 
 import Asterius.Internals
 import Asterius.Internals.MagicNumber
@@ -22,69 +23,74 @@ import Language.Haskell.GHC.Toolkit.Constants
 
 sizeofStatics :: AsteriusStatics -> Int64
 sizeofStatics =
-  fromIntegral .
-  getSum .
-  foldMap
-    (Sum . \case
-       SymbolStatic {} -> 8
-       Uninitialized x -> x
-       Serialized buf -> SBS.length buf) .
-  asteriusStatics
+  fromIntegral
+    . getSum
+    . foldMap
+      ( Sum . \case
+          SymbolStatic {} -> 8
+          Uninitialized x -> x
+          Serialized buf -> SBS.length buf
+      )
+    . asteriusStatics
 
 unTag :: Int64 -> Int64
 unTag = (.&. 0xFFFFFFFF)
 
-{-# INLINABLE makeDataSymbolTable #-}
+{-# INLINEABLE makeDataSymbolTable #-}
 makeDataSymbolTable ::
-     AsteriusModule -> Int64 -> (Map AsteriusEntitySymbol Int64, Int64)
+  AsteriusModule -> Int64 -> (Map AsteriusEntitySymbol Int64, Int64)
 makeDataSymbolTable AsteriusModule {..} l =
   swap $
-  Map.mapAccum
-    (\a ss ->
-       (a + fromIntegral (fromIntegral (sizeofStatics ss) `roundup` 16), a))
-    l
-    staticsMap
+    Map.mapAccum
+      ( \a ss -> (a + fromIntegral (fromIntegral (sizeofStatics ss) `roundup` 16), a)
+      )
+      l
+      staticsMap
 
-{-# INLINABLE makeMemory #-}
+{-# INLINEABLE makeMemory #-}
 makeMemory ::
-     AsteriusModule
-  -> Map AsteriusEntitySymbol Int64
-  -> Int64
-  -> (BinaryenIndex, [DataSegment])
+  AsteriusModule ->
+  Map AsteriusEntitySymbol Int64 ->
+  Int64 ->
+  (BinaryenIndex, [DataSegment])
 makeMemory AsteriusModule {..} sym_map last_addr =
   ( fromIntegral $
-    (fromIntegral (unTag last_addr) `roundup` mblock_size) `quot` 65536
-  , Map.foldrWithKey'
-      (\statics_sym ss@AsteriusStatics {..} statics_segs ->
-         fst $
-         foldr'
-           (\static (static_segs, static_tail_addr) ->
-              let flush_static_segs buf =
-                    ( case static_segs of
-                        DataSegment {..}:static_segs'
-                          | offset == static_tail_addr ->
-                            DataSegment
-                              {content = buf <> content, offset = static_addr} :
-                            static_segs'
-                        _ ->
-                          DataSegment {content = buf, offset = static_addr} :
-                          static_segs
-                    , static_addr)
-                    where
-                      static_addr =
-                        static_tail_addr - fromIntegral (SBS.length buf)
-               in case static of
-                    SymbolStatic sym o ->
-                      flush_static_segs $
-                      encodeStorable $
-                      case Map.lookup sym sym_map of
-                        Just addr -> addr + fromIntegral o
-                        _ -> invalidAddress
-                    Uninitialized l ->
-                      (static_segs, static_tail_addr - fromIntegral l)
-                    Serialized buf -> flush_static_segs buf)
-           ( statics_segs
-           , fromIntegral $ unTag $ sym_map ! statics_sym + sizeofStatics ss)
-           asteriusStatics)
+      (fromIntegral (unTag last_addr) `roundup` mblock_size)
+        `quot` 65536,
+    Map.foldrWithKey'
+      ( \statics_sym ss@AsteriusStatics {..} statics_segs ->
+          fst $
+            foldr'
+              ( \static (static_segs, static_tail_addr) ->
+                  let flush_static_segs buf =
+                        ( case static_segs of
+                            DataSegment {..} : static_segs'
+                              | offset == static_tail_addr ->
+                                DataSegment {content = buf <> content, offset = static_addr}
+                                  : static_segs'
+                            _ ->
+                              DataSegment {content = buf, offset = static_addr}
+                                : static_segs,
+                          static_addr
+                        )
+                        where
+                          static_addr = static_tail_addr - fromIntegral (SBS.length buf)
+                   in case static of
+                        SymbolStatic sym o ->
+                          flush_static_segs
+                            $ encodeStorable
+                            $ case Map.lookup sym sym_map of
+                              Just addr -> addr + fromIntegral o
+                              _ -> invalidAddress
+                        Uninitialized l ->
+                          (static_segs, static_tail_addr - fromIntegral l)
+                        Serialized buf -> flush_static_segs buf
+              )
+              ( statics_segs,
+                fromIntegral $ unTag $ sym_map ! statics_sym + sizeofStatics ss
+              )
+              asteriusStatics
+      )
       []
-      staticsMap)
+      staticsMap
+  )

--- a/asterius/src/Asterius/Passes/FunctionSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/FunctionSymbolTable.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Asterius.Passes.FunctionSymbolTable
-  ( makeFunctionSymbolTable
-  , makeFunctionTable
-  ) where
+  ( makeFunctionSymbolTable,
+    makeFunctionTable,
+  )
+where
 
 import Asterius.Types
 import Data.Bits
@@ -13,16 +14,15 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Tuple
 
-{-# INLINABLE makeFunctionSymbolTable #-}
+{-# INLINEABLE makeFunctionSymbolTable #-}
 makeFunctionSymbolTable ::
-     AsteriusModule -> Int64 -> (Map AsteriusEntitySymbol Int64, Int64)
+  AsteriusModule -> Int64 -> (Map AsteriusEntitySymbol Int64, Int64)
 makeFunctionSymbolTable AsteriusModule {..} func_start_addr =
   swap $ Map.mapAccum (\a _ -> (succ a, a)) func_start_addr functionMap
 
-{-# INLINABLE makeFunctionTable #-}
+{-# INLINEABLE makeFunctionTable #-}
 makeFunctionTable :: Map AsteriusEntitySymbol Int64 -> Int64 -> FunctionTable
-makeFunctionTable func_sym_map func_start_addr =
-  FunctionTable
-    { tableFunctionNames = coerce $ Map.keys func_sym_map
-    , tableOffset = fromIntegral $ func_start_addr .&. 0xFFFFFFFF
-    }
+makeFunctionTable func_sym_map func_start_addr = FunctionTable
+  { tableFunctionNames = coerce $ Map.keys func_sym_map,
+    tableOffset = fromIntegral $ func_start_addr .&. 0xFFFFFFFF
+  }

--- a/asterius/src/Asterius/Passes/GlobalRegs.hs
+++ b/asterius/src/Asterius/Passes/GlobalRegs.hs
@@ -2,89 +2,84 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Asterius.Passes.GlobalRegs
-  ( unresolvedGetGlobal
-  , unresolvedSetGlobal
-  ) where
+  ( unresolvedGetGlobal,
+    unresolvedSetGlobal,
+  )
+where
 
 import Asterius.Types
 import Language.Haskell.GHC.Toolkit.Constants
 
 globalRegInfo :: UnresolvedGlobalReg -> (BinaryenIndex, Int, ValueType)
-globalRegInfo gr =
-  case gr of
-    VanillaReg 1 -> (8, offset_StgRegTable_rR1, I64)
-    VanillaReg 2 -> (8, offset_StgRegTable_rR2, I64)
-    VanillaReg 3 -> (8, offset_StgRegTable_rR3, I64)
-    VanillaReg 4 -> (8, offset_StgRegTable_rR4, I64)
-    VanillaReg 5 -> (8, offset_StgRegTable_rR5, I64)
-    VanillaReg 6 -> (8, offset_StgRegTable_rR6, I64)
-    VanillaReg 7 -> (8, offset_StgRegTable_rR7, I64)
-    VanillaReg 8 -> (8, offset_StgRegTable_rR8, I64)
-    VanillaReg 9 -> (8, offset_StgRegTable_rR9, I64)
-    VanillaReg 10 -> (8, offset_StgRegTable_rR10, I64)
-    FloatReg 1 -> (4, offset_StgRegTable_rF1, F32)
-    FloatReg 2 -> (4, offset_StgRegTable_rF2, F32)
-    FloatReg 3 -> (4, offset_StgRegTable_rF3, F32)
-    FloatReg 4 -> (4, offset_StgRegTable_rF4, F32)
-    FloatReg 5 -> (4, offset_StgRegTable_rF5, F32)
-    FloatReg 6 -> (4, offset_StgRegTable_rF6, F32)
-    DoubleReg 1 -> (8, offset_StgRegTable_rD1, F64)
-    DoubleReg 2 -> (8, offset_StgRegTable_rD2, F64)
-    DoubleReg 3 -> (8, offset_StgRegTable_rD3, F64)
-    DoubleReg 4 -> (8, offset_StgRegTable_rD4, F64)
-    DoubleReg 5 -> (8, offset_StgRegTable_rD5, F64)
-    DoubleReg 6 -> (8, offset_StgRegTable_rD6, F64)
-    LongReg 1 -> (8, offset_StgRegTable_rL1, I64)
-    Sp -> (8, offset_StgRegTable_rSp, I64)
-    SpLim -> (8, offset_StgRegTable_rSpLim, I64)
-    Hp -> (8, offset_StgRegTable_rHp, I64)
-    HpLim -> (8, offset_StgRegTable_rHpLim, I64)
-    CCCS -> (8, offset_StgRegTable_rCCCS, I64)
-    CurrentTSO -> (8, offset_StgRegTable_rCurrentTSO, I64)
-    CurrentNursery -> (8, offset_StgRegTable_rCurrentNursery, I64)
-    HpAlloc -> (8, offset_StgRegTable_rHpAlloc, I64)
-    EagerBlackholeInfo ->
-      (8, rf + offset_StgFunTable_stgEagerBlackholeInfo, I64)
-    GCEnter1 -> (8, rf + offset_StgFunTable_stgGCEnter1, I64)
-    GCFun -> (8, rf + offset_StgFunTable_stgGCFun, I64)
-    _ ->
-      error $
-      "Asterius.Passes.GlobalRegs.resolveGlobalRegs: Unsupported global reg " <>
-      show gr
+globalRegInfo gr = case gr of
+  VanillaReg 1 -> (8, offset_StgRegTable_rR1, I64)
+  VanillaReg 2 -> (8, offset_StgRegTable_rR2, I64)
+  VanillaReg 3 -> (8, offset_StgRegTable_rR3, I64)
+  VanillaReg 4 -> (8, offset_StgRegTable_rR4, I64)
+  VanillaReg 5 -> (8, offset_StgRegTable_rR5, I64)
+  VanillaReg 6 -> (8, offset_StgRegTable_rR6, I64)
+  VanillaReg 7 -> (8, offset_StgRegTable_rR7, I64)
+  VanillaReg 8 -> (8, offset_StgRegTable_rR8, I64)
+  VanillaReg 9 -> (8, offset_StgRegTable_rR9, I64)
+  VanillaReg 10 -> (8, offset_StgRegTable_rR10, I64)
+  FloatReg 1 -> (4, offset_StgRegTable_rF1, F32)
+  FloatReg 2 -> (4, offset_StgRegTable_rF2, F32)
+  FloatReg 3 -> (4, offset_StgRegTable_rF3, F32)
+  FloatReg 4 -> (4, offset_StgRegTable_rF4, F32)
+  FloatReg 5 -> (4, offset_StgRegTable_rF5, F32)
+  FloatReg 6 -> (4, offset_StgRegTable_rF6, F32)
+  DoubleReg 1 -> (8, offset_StgRegTable_rD1, F64)
+  DoubleReg 2 -> (8, offset_StgRegTable_rD2, F64)
+  DoubleReg 3 -> (8, offset_StgRegTable_rD3, F64)
+  DoubleReg 4 -> (8, offset_StgRegTable_rD4, F64)
+  DoubleReg 5 -> (8, offset_StgRegTable_rD5, F64)
+  DoubleReg 6 -> (8, offset_StgRegTable_rD6, F64)
+  LongReg 1 -> (8, offset_StgRegTable_rL1, I64)
+  Sp -> (8, offset_StgRegTable_rSp, I64)
+  SpLim -> (8, offset_StgRegTable_rSpLim, I64)
+  Hp -> (8, offset_StgRegTable_rHp, I64)
+  HpLim -> (8, offset_StgRegTable_rHpLim, I64)
+  CCCS -> (8, offset_StgRegTable_rCCCS, I64)
+  CurrentTSO -> (8, offset_StgRegTable_rCurrentTSO, I64)
+  CurrentNursery -> (8, offset_StgRegTable_rCurrentNursery, I64)
+  HpAlloc -> (8, offset_StgRegTable_rHpAlloc, I64)
+  EagerBlackholeInfo -> (8, rf + offset_StgFunTable_stgEagerBlackholeInfo, I64)
+  GCEnter1 -> (8, rf + offset_StgFunTable_stgGCEnter1, I64)
+  GCFun -> (8, rf + offset_StgFunTable_stgGCFun, I64)
+  _ ->
+    error $
+      "Asterius.Passes.GlobalRegs.resolveGlobalRegs: Unsupported global reg "
+        <> show gr
   where
     rf = offset_Capability_f - offset_Capability_r
 
 mainCap, mainCap32, baseReg :: Expression
 mainCap = Symbol {unresolvedSymbol = "MainCapability", symbolOffset = 0}
-
 mainCap32 = Unary {unaryOp = WrapInt64, operand0 = mainCap}
-
 baseReg = mainCap {symbolOffset = offset_Capability_r}
 
 unresolvedGetGlobal :: UnresolvedGlobalReg -> Expression
-unresolvedGetGlobal gr =
-  case gr of
-    BaseReg -> baseReg
-    _ ->
-      Load
-        { signed = False
-        , bytes = b
-        , offset = fromIntegral $ offset_Capability_r + o
-        , valueType = vt
-        , ptr = mainCap32
-        }
-      where (b, o, vt) = globalRegInfo gr
+unresolvedGetGlobal gr = case gr of
+  BaseReg -> baseReg
+  _ -> Load
+    { signed = False,
+      bytes = b,
+      offset = fromIntegral $ offset_Capability_r + o,
+      valueType = vt,
+      ptr = mainCap32
+    }
+    where
+      (b, o, vt) = globalRegInfo gr
 
 unresolvedSetGlobal :: UnresolvedGlobalReg -> Expression -> Expression
-unresolvedSetGlobal gr v =
-  case gr of
-    BaseReg -> Nop
-    _ ->
-      Store
-        { bytes = b
-        , offset = fromIntegral $ offset_Capability_r + o
-        , ptr = mainCap32
-        , value = v
-        , valueType = vt
-        }
-      where (b, o, vt) = globalRegInfo gr
+unresolvedSetGlobal gr v = case gr of
+  BaseReg -> Nop
+  _ -> Store
+    { bytes = b,
+      offset = fromIntegral $ offset_Capability_r + o,
+      ptr = mainCap32,
+      value = v,
+      valueType = vt
+    }
+    where
+      (b, o, vt) = globalRegInfo gr

--- a/asterius/src/Asterius/Passes/LocalRegs.hs
+++ b/asterius/src/Asterius/Passes/LocalRegs.hs
@@ -5,9 +5,10 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Asterius.Passes.LocalRegs
-  ( resolveLocalRegs
-  , localRegTable
-  ) where
+  ( resolveLocalRegs,
+    localRegTable,
+  )
+where
 
 import Asterius.Internals.SYB
 import Asterius.Passes.Common
@@ -17,50 +18,45 @@ import qualified Data.Map.Strict as Map
 import Type.Reflection
 
 unresolvedLocalRegValueType :: UnresolvedLocalReg -> ValueType
-unresolvedLocalRegValueType reg =
-  case reg of
-    UniqueLocalReg _ vt -> vt
-    QuotRemI32X -> I32
-    QuotRemI32Y -> I32
-    QuotRemI64X -> I64
-    QuotRemI64Y -> I64
+unresolvedLocalRegValueType reg = case reg of
+  UniqueLocalReg _ vt -> vt
+  QuotRemI32X -> I32
+  QuotRemI32Y -> I32
+  QuotRemI64X -> I64
+  QuotRemI64Y -> I64
 
-{-# INLINABLE resolveLocalRegs #-}
+{-# INLINEABLE resolveLocalRegs #-}
 resolveLocalRegs ::
-     forall m. MonadState PassesState m
-  => FunctionType
-  -> GenericM m
+  forall m. MonadState PassesState m => FunctionType -> GenericM m
 resolveLocalRegs FunctionType {..} t =
   case eqTypeRep (typeOf t) (typeRep :: TypeRep Expression) of
-    Just HRefl ->
-      case t of
-        UnresolvedGetLocal {..} ->
-          (\i ->
-             GetLocal
-               { index = i
-               , valueType = unresolvedLocalRegValueType unresolvedLocalReg
-               }) <$>
-          idx unresolvedLocalReg
-        UnresolvedSetLocal {..} ->
-          (\i -> SetLocal {index = i, value = value}) <$> idx unresolvedLocalReg
-        _ -> pure t
+    Just HRefl -> case t of
+      UnresolvedGetLocal {..} ->
+        ( \i -> GetLocal
+            { index = i,
+              valueType = unresolvedLocalRegValueType unresolvedLocalReg
+            }
+        )
+          <$> idx unresolvedLocalReg
+      UnresolvedSetLocal {..} ->
+        (\i -> SetLocal {index = i, value = value}) <$> idx unresolvedLocalReg
+      _ -> pure t
     _ -> pure t
   where
     base_idx = 3 + length paramTypes
     idx :: UnresolvedLocalReg -> m BinaryenIndex
-    idx reg =
-      state $ \ps@PassesState {..} ->
-        case Map.lookup reg localRegMap of
-          Just i -> (fromIntegral i, ps)
-          _ ->
-            ( fromIntegral i
-            , ps
-                { localRegMap = Map.insert reg i localRegMap
-                , localRegStack =
-                    unresolvedLocalRegValueType reg : localRegStack
-                })
-            where i = base_idx + Map.size localRegMap
+    idx reg = state $ \ps@PassesState {..} -> case Map.lookup reg localRegMap of
+      Just i -> (fromIntegral i, ps)
+      _ ->
+        ( fromIntegral i,
+          ps
+            { localRegMap = Map.insert reg i localRegMap,
+              localRegStack = unresolvedLocalRegValueType reg : localRegStack
+            }
+        )
+        where
+          i = base_idx + Map.size localRegMap
 
-{-# INLINABLE localRegTable #-}
+{-# INLINEABLE localRegTable #-}
 localRegTable :: PassesState -> [ValueType]
 localRegTable PassesState {..} = I32 : I32 : I32 : reverse localRegStack

--- a/asterius/src/Asterius/Passes/MergeSymbolOffset.hs
+++ b/asterius/src/Asterius/Passes/MergeSymbolOffset.hs
@@ -2,8 +2,9 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Asterius.Passes.MergeSymbolOffset
-  ( mergeSymbolOffset
-  ) where
+  ( mergeSymbolOffset,
+  )
+where
 
 import Asterius.Internals.SYB
 import Asterius.Types
@@ -12,39 +13,41 @@ import Type.Reflection
 
 noNeg :: Expression -> Int -> Word32
 noNeg e n
-  | n >= 0 = fromIntegral n
+  | n >= 0 =
+    fromIntegral n
   | otherwise =
     error $
-    "Asterius.Passes.MergeSymbolOffset.noNeg: negative index " <> show n <>
-    " when merging " <>
-    show e
+      "Asterius.Passes.MergeSymbolOffset.noNeg: negative index "
+        <> show n
+        <> " when merging "
+        <> show e
 
 {-# INLINEABLE mergeSymbolOffset #-}
 mergeSymbolOffset :: Monad m => GenericM m
 mergeSymbolOffset t =
-  pure $
-  case eqTypeRep (typeOf t) (typeRep :: TypeRep Expression) of
-    Just HRefl ->
-      case t of
-        Load {ptr = Unary {unaryOp = WrapInt64, operand0 = sym@Symbol {..}}, ..} ->
-          Load
-            { signed = signed
-            , bytes = bytes
-            , offset = noNeg t $ symbolOffset + fromIntegral offset
-            , valueType = valueType
-            , ptr =
-                Unary {unaryOp = WrapInt64, operand0 = sym {symbolOffset = 0}}
-            }
-        Store { ptr = Unary {unaryOp = WrapInt64, operand0 = sym@Symbol {..}}
-              , ..
-              } ->
-          Store
-            { bytes = bytes
-            , offset = noNeg t $ symbolOffset + fromIntegral offset
-            , ptr =
-                Unary {unaryOp = WrapInt64, operand0 = sym {symbolOffset = 0}}
-            , value = value
-            , valueType = valueType
-            }
-        _ -> t
+  pure $ case eqTypeRep (typeOf t) (typeRep :: TypeRep Expression) of
+    Just HRefl -> case t of
+      Load {ptr = Unary {unaryOp = WrapInt64, operand0 = sym@Symbol {..}}, ..} ->
+        Load
+          { signed = signed,
+            bytes = bytes,
+            offset = noNeg t $ symbolOffset + fromIntegral offset,
+            valueType = valueType,
+            ptr = Unary
+              { unaryOp = WrapInt64,
+                operand0 = sym {symbolOffset = 0}
+              }
+          }
+      Store {ptr = Unary {unaryOp = WrapInt64, operand0 = sym@Symbol {..}}, ..} ->
+        Store
+          { bytes = bytes,
+            offset = noNeg t $ symbolOffset + fromIntegral offset,
+            ptr = Unary
+              { unaryOp = WrapInt64,
+                operand0 = sym {symbolOffset = 0}
+              },
+            value = value,
+            valueType = valueType
+          }
+      _ -> t
     _ -> t

--- a/asterius/src/Asterius/Passes/Relooper.hs
+++ b/asterius/src/Asterius/Passes/Relooper.hs
@@ -3,8 +3,9 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Asterius.Passes.Relooper
-  ( relooper
-  ) where
+  ( relooper,
+  )
+where
 
 import Asterius.Internals
 import Asterius.Types
@@ -19,81 +20,85 @@ relooper RelooperRun {..} = result_expr
     lbl_map = M.fromList $ zip lbls [0 ..]
     lbl_to_idx = (lbl_map !)
     set_block_lbl lbl = SetLocal {index = 0, value = ConstI32 $ lbl_to_idx lbl}
-    initial_expr =
-      Switch
-        { names = lbls
-        , defaultName = "__asterius_unreachable"
-        , condition = GetLocal {index = 0, valueType = I32}
-        }
+    initial_expr = Switch
+      { names = lbls,
+        defaultName = "__asterius_unreachable",
+        condition = GetLocal {index = 0, valueType = I32}
+      }
     loop_lbl = "__asterius_loop"
     exit_lbl = "__asterius_exit"
     (blocks_expr, last_block_residule_exprs) =
       M.foldlWithKey'
-        (\(tot_expr, residule_exprs) lbl RelooperBlock {..} ->
-           ( Block
-               { name = lbl
-               , bodys = tot_expr : residule_exprs
-               , blockReturnTypes = []
-               }
-           , case addBlock of
-               AddBlock {..} ->
-                 code :
-                 (case addBranches of
-                    [] -> [Break {name = exit_lbl, breakCondition = Nothing}]
-                    branches ->
-                      foldr'
-                        (\AddBranch {addBranchCondition = Just cond, to} e ->
-                           If
-                             { condition = cond
-                             , ifTrue = set_block_lbl to
-                             , ifFalse = Just e
-                             })
-                        (set_block_lbl $ to def_branch)
-                        (init branches) :
-                      [Break {name = loop_lbl, breakCondition = Nothing}]
-                      where def_branch@AddBranch {addBranchCondition = Nothing} =
-                              last branches)
-               AddBlockWithSwitch {..} ->
-                 [code, SetLocal {index = 1, value = condition}] <>
-                 (foldr'
-                    (\AddBranchForSwitch {to, indexes} e ->
-                       If
-                         { condition =
-                             foldl1'
-                               (Binary OrInt32)
-                               [ Binary
-                                 { binaryOp = EqInt32
-                                 , operand0 =
-                                     GetLocal {index = 1, valueType = I32}
-                                 , operand1 = ConstI32 $ fromIntegral tag
-                                 }
-                               | tag <- indexes
-                               ]
-                         , ifTrue = set_block_lbl to
-                         , ifFalse = Just e
-                         })
-                    (set_block_lbl $ to def_branch)
-                    (init branches) :
-                  [Break {name = loop_lbl, breakCondition = Nothing}])
-                 where branches = addBranches
-                       def_branch@AddBranch {addBranchCondition = Nothing} =
-                         last branches))
+        ( \(tot_expr, residule_exprs) lbl RelooperBlock {..} ->
+            ( Block
+                { name = lbl,
+                  bodys = tot_expr : residule_exprs,
+                  blockReturnTypes = []
+                },
+              case addBlock of
+                AddBlock {..} ->
+                  code
+                    : ( case addBranches of
+                          [] -> [Break {name = exit_lbl, breakCondition = Nothing}]
+                          branches ->
+                            foldr'
+                              ( \AddBranch {addBranchCondition = Just cond, to} e -> If
+                                  { condition = cond,
+                                    ifTrue = set_block_lbl to,
+                                    ifFalse = Just e
+                                  }
+                              )
+                              (set_block_lbl $ to def_branch)
+                              (init branches)
+                              : [Break {name = loop_lbl, breakCondition = Nothing}]
+                            where
+                              def_branch@AddBranch {addBranchCondition = Nothing} =
+                                last branches
+                      )
+                AddBlockWithSwitch {..} ->
+                  [code, SetLocal {index = 1, value = condition}]
+                    <> ( foldr'
+                           ( \AddBranchForSwitch {to, indexes} e -> If
+                               { condition =
+                                   foldl1'
+                                     (Binary OrInt32)
+                                     [ Binary
+                                         { binaryOp = EqInt32,
+                                           operand0 = GetLocal
+                                             { index = 1,
+                                               valueType = I32
+                                             },
+                                           operand1 = ConstI32 $ fromIntegral tag
+                                         }
+                                       | tag <- indexes
+                                     ],
+                                 ifTrue = set_block_lbl to,
+                                 ifFalse = Just e
+                               }
+                           )
+                           (set_block_lbl $ to def_branch)
+                           (init branches)
+                           : [Break {name = loop_lbl, breakCondition = Nothing}]
+                       )
+                  where
+                    branches = addBranches
+                    def_branch@AddBranch {addBranchCondition = Nothing} = last branches
+            )
+        )
         (initial_expr, [])
         blockMap
-    result_expr =
-      Block
-        { name = exit_lbl
-        , bodys =
-            [ set_block_lbl entry
-            , Loop
-                { name = loop_lbl
-                , body =
-                    Block
-                      { name = ""
-                      , bodys = blocks_expr : last_block_residule_exprs
-                      , blockReturnTypes = []
-                      }
-                }
-            ]
-        , blockReturnTypes = []
-        }
+    result_expr = Block
+      { name = exit_lbl,
+        bodys =
+          [ set_block_lbl entry,
+            Loop
+              { name = loop_lbl,
+                body = Block
+                  { name = "",
+                    bodys = blocks_expr : last_block_residule_exprs,
+                    blockReturnTypes = []
+                  }
+              }
+          ],
+        blockReturnTypes = []
+      }

--- a/asterius/src/Asterius/Passes/Tracing.hs
+++ b/asterius/src/Asterius/Passes/Tracing.hs
@@ -4,152 +4,156 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Asterius.Passes.Tracing
-  ( addTracingModule
-  ) where
+  ( addTracingModule,
+  )
+where
 
-import Asterius.EDSL (convertSInt64ToFloat64, convertUInt64ToFloat64)
+import Asterius.EDSL
+  ( convertSInt64ToFloat64,
+    convertUInt64ToFloat64,
+  )
 import Asterius.Internals
 import Asterius.TypeInfer
 import Asterius.Types
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Short as SBS
 import Data.Char
-import Data.Data (Data, gmapM)
+import Data.Data
+  ( Data,
+    gmapM,
+  )
 import qualified Data.Map.Strict as M
 import Data.Traversable
 import Foreign
 import Type.Reflection
 
-{-# INLINABLE addTracingModule #-}
+{-# INLINEABLE addTracingModule #-}
 addTracingModule ::
-     Monad m
-  => M.Map AsteriusEntitySymbol Int64
-  -> AsteriusEntitySymbol
-  -> Function
-  -> m Function
+  Monad m =>
+  M.Map AsteriusEntitySymbol Int64 ->
+  AsteriusEntitySymbol ->
+  Function ->
+  m Function
 addTracingModule func_sym_map func_sym func@Function {functionType = func_type}
-  | "__asterius" `BS.isPrefixOf` SBS.fromShort (entityName func_sym) = pure func
-  | otherwise = f func
+  | "__asterius" `BS.isPrefixOf` SBS.fromShort (entityName func_sym) =
+    pure func
+  | otherwise =
+    f func
   where
     f :: (Monad m, Data a) => a -> m a
-    f x =
-      case eqTypeRep (typeOf x) (typeRep :: TypeRep Function) of
-        Just HRefl ->
-          case x of
-            Function {..} -> do
-              new_body <- f body
-              pure
-                Function
-                  { functionType = functionType
-                  , varTypes = varTypes
-                  , body =
-                      Block
-                        { name = ""
-                        , bodys =
-                            [ CallImport
-                                { target' = "__asterius_traceCmm"
-                                , operands = [func_idx]
-                                , callImportReturnTypes = []
-                                }
-                            , new_body
-                            ]
-                        , blockReturnTypes = infer new_body
-                        }
-                  }
-        _ ->
-          case eqTypeRep (typeOf x) (typeRep :: TypeRep Expression) of
-            Just HRefl ->
-              case x of
-                CFG {graph = g@RelooperRun {..}} -> do
-                  new_block_map <-
-                    fmap M.fromList $
-                    for (M.toList blockMap) $ \(lbl, blk@RelooperBlock {..}) ->
-                      case addBlock of
-                        AddBlock {..} -> do
-                          new_code <- f code
-                          pure
-                            ( lbl
-                            , blk
-                                { addBlock =
-                                    AddBlock
-                                      { code =
-                                          Block
-                                            { name = ""
-                                            , bodys =
-                                                [ CallImport
-                                                    { target' =
-                                                        "__asterius_traceCmmBlock"
-                                                    , operands =
-                                                        [ func_idx
-                                                        , lbl_to_idx lbl
-                                                        ]
-                                                    , callImportReturnTypes = []
-                                                    }
-                                                , new_code
-                                                ]
-                                            , blockReturnTypes = infer new_code
-                                            }
-                                      }
-                                })
-                        AddBlockWithSwitch {..} -> do
-                          new_code <- f code
-                          pure
-                            ( lbl
-                            , blk
-                                { addBlock =
-                                    AddBlockWithSwitch
-                                      { code =
-                                          Block
-                                            { name = ""
-                                            , bodys =
-                                                [ CallImport
-                                                    { target' =
-                                                        "__asterius_traceCmmBlock"
-                                                    , operands =
-                                                        [ func_idx
-                                                        , lbl_to_idx lbl
-                                                        ]
-                                                    , callImportReturnTypes = []
-                                                    }
-                                                , new_code
-                                                ]
-                                            , blockReturnTypes = infer new_code
-                                            }
-                                      , condition = condition
-                                      }
-                                })
-                  pure CFG {graph = g {blockMap = new_block_map}}
-                  where lbl_to_idx =
-                          ConstI32 .
-                          read . map (chr . fromIntegral) . SBS.unpack
-                SetLocal {..}
-                  | ((index_int < param_num) && (params !! index_int == I64)) ||
-                      ((index_int >= param_num) &&
-                       varTypes func !! (index_int - param_num) == I64) ->
+    f x = case eqTypeRep (typeOf x) (typeRep :: TypeRep Function) of
+      Just HRefl -> case x of
+        Function {..} -> do
+          new_body <- f body
+          pure Function
+            { functionType = functionType,
+              varTypes = varTypes,
+              body = Block
+                { name = "",
+                  bodys =
+                    [ CallImport
+                        { target' = "__asterius_traceCmm",
+                          operands = [func_idx],
+                          callImportReturnTypes = []
+                        },
+                      new_body
+                    ],
+                  blockReturnTypes = infer new_body
+                }
+            }
+      _ -> case eqTypeRep (typeOf x) (typeRep :: TypeRep Expression) of
+        Just HRefl -> case x of
+          CFG {graph = g@RelooperRun {..}} -> do
+            new_block_map <-
+              fmap M.fromList
+                $ for (M.toList blockMap)
+                $ \(lbl, blk@RelooperBlock {..}) -> case addBlock of
+                  AddBlock {..} -> do
+                    new_code <- f code
                     pure
-                      Block
-                        { name = ""
-                        , bodys =
-                            [ SetLocal {index = index, value = value}
-                            , CallImport
-                                { target' = "__asterius_traceCmmSetLocal"
-                                , operands =
-                                    [ func_idx
-                                    , ConstI32 $ fromIntegral index
-                                    , convertSInt64ToFloat64
-                                        GetLocal
-                                          {index = index, valueType = I64}
-                                    ]
-                                , callImportReturnTypes = []
+                      ( lbl,
+                        blk
+                          { addBlock = AddBlock
+                              { code = Block
+                                  { name = "",
+                                    bodys =
+                                      [ CallImport
+                                          { target' =
+                                              "__asterius_traceCmmBlock",
+                                            operands =
+                                              [ func_idx,
+                                                lbl_to_idx lbl
+                                              ],
+                                            callImportReturnTypes = []
+                                          },
+                                        new_code
+                                      ],
+                                    blockReturnTypes = infer new_code
+                                  }
+                              }
+                          }
+                      )
+                  AddBlockWithSwitch {..} -> do
+                    new_code <- f code
+                    pure
+                      ( lbl,
+                        blk
+                          { addBlock = AddBlockWithSwitch
+                              { code = Block
+                                  { name = "",
+                                    bodys =
+                                      [ CallImport
+                                          { target' =
+                                              "__asterius_traceCmmBlock",
+                                            operands =
+                                              [ func_idx,
+                                                lbl_to_idx lbl
+                                              ],
+                                            callImportReturnTypes = []
+                                          },
+                                        new_code
+                                      ],
+                                    blockReturnTypes = infer new_code
+                                  },
+                                condition = condition
+                              }
+                          }
+                      )
+            pure CFG {graph = g {blockMap = new_block_map}}
+            where
+              lbl_to_idx = ConstI32 . read . map (chr . fromIntegral) . SBS.unpack
+          SetLocal {..}
+            | ((index_int < param_num) && (params !! index_int == I64))
+                || ( (index_int >= param_num)
+                       && varTypes func
+                       !! (index_int - param_num)
+                       == I64
+                   ) ->
+              pure Block
+                { name = "",
+                  bodys =
+                    [ SetLocal {index = index, value = value},
+                      CallImport
+                        { target' = "__asterius_traceCmmSetLocal",
+                          operands =
+                            [ func_idx,
+                              ConstI32 $ fromIntegral index,
+                              convertSInt64ToFloat64 GetLocal
+                                { index = index,
+                                  valueType = I64
                                 }
-                            ]
-                        , blockReturnTypes = []
+                            ],
+                          callImportReturnTypes = []
                         }
-                  where params = paramTypes func_type
-                        param_num = length params
-                        index_int = fromIntegral index
-                _ -> go
-            _ -> go
+                    ],
+                  blockReturnTypes = []
+                }
+            where
+              params = paramTypes func_type
+              param_num = length params
+              index_int = fromIntegral index
+          _ -> go
+        _ -> go
       where
         go = gmapM f x
         func_idx = convertUInt64ToFloat64 $ ConstI64 $ func_sym_map ! func_sym

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -9,8 +9,8 @@
 module Asterius.Resolve
   ( unresolvedGlobalRegType,
     LinkReport (..),
-    linkStart
-    )
+    linkStart,
+  )
 where
 
 import Asterius.Builtins
@@ -25,8 +25,8 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Short as SBS
 import Data.Data
   ( Data,
-    gmapQl
-    )
+    gmapQl,
+  )
 import qualified Data.Map.Lazy as LM
 import qualified Data.Set as S
 import Data.String
@@ -38,8 +38,8 @@ import Type.Reflection
     TypeRep,
     eqTypeRep,
     typeOf,
-    typeRep
-    )
+    typeRep,
+  )
 import Unsafe.Coerce
 import Prelude hiding (IO)
 
@@ -49,8 +49,8 @@ unresolvedGlobalRegType gr = case gr of
   DoubleReg _ -> F64
   _ -> I64
 
-collectAsteriusEntitySymbols
-  :: Data a => a -> S.Set AsteriusEntitySymbol -> S.Set AsteriusEntitySymbol
+collectAsteriusEntitySymbols ::
+  Data a => a -> S.Set AsteriusEntitySymbol -> S.Set AsteriusEntitySymbol
 collectAsteriusEntitySymbols t acc =
   case eqTypeRep (typeOf t) (typeRep :: TypeRep AsteriusEntitySymbol) of
     Just HRefl -> S.insert t acc
@@ -62,25 +62,24 @@ data LinkReport
         infoTableSet :: [Int64],
         tableSlots, staticMBlocks :: Int,
         bundledFFIMarshalState :: FFIMarshalState
-        }
+      }
   deriving (Generic, Show)
 
 instance Binary LinkReport
 
 instance Semigroup LinkReport where
-
   r0 <> r1 = LinkReport
     { staticsSymbolMap = staticsSymbolMap r0 <> staticsSymbolMap r1,
       functionSymbolMap = functionSymbolMap r0 <> functionSymbolMap r1,
       infoTableSet = infoTableSet r0 <> infoTableSet r1,
       tableSlots = 0,
       staticMBlocks = 0,
-      bundledFFIMarshalState = bundledFFIMarshalState r0
-        <> bundledFFIMarshalState r1
-      }
+      bundledFFIMarshalState =
+        bundledFFIMarshalState r0
+          <> bundledFFIMarshalState r1
+    }
 
 instance Monoid LinkReport where
-
   mempty = LinkReport
     { staticsSymbolMap = mempty,
       functionSymbolMap = mempty,
@@ -88,16 +87,16 @@ instance Monoid LinkReport where
       tableSlots = 0,
       staticMBlocks = 0,
       bundledFFIMarshalState = mempty
-      }
+    }
 
-mergeSymbols
-  :: Bool
-  -> Bool
-  -> Bool
-  -> AsteriusModule
-  -> S.Set AsteriusEntitySymbol
-  -> [AsteriusEntitySymbol]
-  -> (AsteriusModule, LinkReport)
+mergeSymbols ::
+  Bool ->
+  Bool ->
+  Bool ->
+  AsteriusModule ->
+  S.Set AsteriusEntitySymbol ->
+  [AsteriusEntitySymbol] ->
+  (AsteriusModule, LinkReport)
 mergeSymbols _ gc_sections verbose_err store_mod root_syms export_funcs
   | not gc_sections = (store_mod, mempty {bundledFFIMarshalState = ffi_all})
   | otherwise = (final_m, mempty {bundledFFIMarshalState = ffi_this})
@@ -108,7 +107,7 @@ mergeSymbols _ gc_sections verbose_err store_mod root_syms export_funcs
         { ffiImportDecls = flip LM.filterWithKey (ffiImportDecls ffi_all) $ \k _ ->
             (k <> "_wrapper") `LM.member` functionMap final_m,
           ffiExportDecls = ffi_exports
-          }
+        }
     ffi_exports
       | not gc_sections = ffiExportDecls (ffiMarshalState store_mod)
       | otherwise =
@@ -132,66 +131,71 @@ mergeSymbols _ gc_sections verbose_err store_mod root_syms export_funcs
                     ( collectAsteriusEntitySymbols ss i_child_syms_acc,
                       o_m_acc
                         { staticsMap = LM.insert i_staging_sym ss (staticsMap o_m_acc)
-                          }
-                      )
+                        }
+                    )
                   _ -> case LM.lookup i_staging_sym (functionMap store_mod) of
                     Just func ->
                       ( collectAsteriusEntitySymbols func i_child_syms_acc,
                         o_m_acc
-                          { functionMap = LM.insert i_staging_sym
-                                            func
-                                            (functionMap o_m_acc)
-                            }
-                        )
+                          { functionMap =
+                              LM.insert
+                                i_staging_sym
+                                func
+                                (functionMap o_m_acc)
+                          }
+                      )
                     _
                       | verbose_err ->
                         ( i_child_syms_acc,
                           o_m_acc
-                            { staticsMap = LM.insert
-                                             ("__asterius_barf_" <> i_staging_sym)
-                                             AsteriusStatics
-                                               { staticsType = ConstBytes,
-                                                 asteriusStatics = [ Serialized
-                                                                       $ entityName i_staging_sym
-                                                                       <> ( case LM.lookup i_staging_sym
-                                                                                   (staticsErrorMap store_mod) of
-                                                                              Just err -> fromString (": " <> show err)
-                                                                              _ -> mempty
-                                                                            )
-                                                                       <> "\0"
-                                                                     ]
-                                                 }
-                                             (staticsMap o_m_acc)
-                              }
-                          )
+                            { staticsMap =
+                                LM.insert
+                                  ("__asterius_barf_" <> i_staging_sym)
+                                  AsteriusStatics
+                                    { staticsType = ConstBytes,
+                                      asteriusStatics =
+                                        [ Serialized $
+                                            entityName i_staging_sym
+                                              <> ( case LM.lookup
+                                                     i_staging_sym
+                                                     (staticsErrorMap store_mod) of
+                                                     Just err -> fromString (": " <> show err)
+                                                     _ -> mempty
+                                                 )
+                                              <> "\0"
+                                        ]
+                                    }
+                                  (staticsMap o_m_acc)
+                            }
+                        )
                       | otherwise ->
                         (i_child_syms_acc, o_m_acc)
-              )
+            )
             (S.empty, i_m)
             i_staging_syms
         o_staging_syms = i_child_syms `S.difference` o_acc_syms
 
-makeInfoTableSet
-  :: AsteriusModule -> LM.Map AsteriusEntitySymbol Int64 -> [Int64]
+makeInfoTableSet ::
+  AsteriusModule -> LM.Map AsteriusEntitySymbol Int64 -> [Int64]
 makeInfoTableSet AsteriusModule {..} sym_map =
-  LM.elems $ LM.restrictKeys sym_map $ LM.keysSet
-    $ LM.filter
-        ((== InfoTable) . staticsType)
-        staticsMap
+  LM.elems $ LM.restrictKeys sym_map $ LM.keysSet $
+    LM.filter
+      ((== InfoTable) . staticsType)
+      staticsMap
 
-resolveAsteriusModule
-  :: Bool
-  -> Bool
-  -> FFIMarshalState
-  -> AsteriusModule
-  -> Int64
-  -> Int64
-  -> ( Module,
-       LM.Map AsteriusEntitySymbol Int64,
-       LM.Map AsteriusEntitySymbol Int64,
-       Int,
-       Int
-       )
+resolveAsteriusModule ::
+  Bool ->
+  Bool ->
+  FFIMarshalState ->
+  AsteriusModule ->
+  Int64 ->
+  Int64 ->
+  ( Module,
+    LM.Map AsteriusEntitySymbol Int64,
+    LM.Map AsteriusEntitySymbol Int64,
+    Int,
+    Int
+  )
 resolveAsteriusModule debug _ bundled_ffi_state m_globals_resolved func_start_addr data_start_addr =
   (new_mod, ss_sym_map, func_sym_map, table_slots, initial_mblocks)
   where
@@ -217,27 +221,27 @@ resolveAsteriusModule debug _ bundled_ffi_state m_globals_resolved func_start_ad
         tableImport = TableImport
           { externalModuleName = "WasmTable",
             externalBaseName = "table"
-            },
+          },
         tableExport = TableExport {externalName = "table"},
         tableSlots = table_slots,
         memorySegments = segs,
         memoryImport = MemoryImport
           { externalModuleName = "WasmMemory",
             externalBaseName = "memory"
-            },
+          },
         memoryExport = MemoryExport {externalName = "memory"},
         memoryMBlocks = initial_mblocks
-        }
+      }
 
-linkStart
-  :: Bool
-  -> Bool
-  -> Bool
-  -> Bool
-  -> AsteriusModule
-  -> S.Set AsteriusEntitySymbol
-  -> [AsteriusEntitySymbol]
-  -> (AsteriusModule, Module, LinkReport)
+linkStart ::
+  Bool ->
+  Bool ->
+  Bool ->
+  Bool ->
+  AsteriusModule ->
+  S.Set AsteriusEntitySymbol ->
+  [AsteriusEntitySymbol] ->
+  (AsteriusModule, Module, LinkReport)
 linkStart debug gc_sections binaryen verbose_err store root_syms export_funcs =
   ( merged_m,
     result_m,
@@ -247,8 +251,8 @@ linkStart debug gc_sections binaryen verbose_err store root_syms export_funcs =
         infoTableSet = makeInfoTableSet merged_m ss_sym_map,
         Asterius.Resolve.tableSlots = tbl_slots,
         staticMBlocks = static_mbs
-        }
-    )
+      }
+  )
   where
     (merged_m0, !report) =
       mergeSymbols debug gc_sections verbose_err store root_syms export_funcs
@@ -259,17 +263,19 @@ linkStart debug gc_sections binaryen verbose_err store root_syms export_funcs =
       | verbose_err = merged_m1
       | otherwise =
         merged_m1
-          { staticsMap = LM.filterWithKey
-                           ( \sym _ ->
-                               not
-                                 ( "__asterius_barf_"
-                                     `BS.isPrefixOf` SBS.fromShort (entityName sym)
-                                   )
-                             )
-              $ staticsMap merged_m1
-            }
+          { staticsMap =
+              LM.filterWithKey
+                ( \sym _ ->
+                    not
+                      ( "__asterius_barf_"
+                          `BS.isPrefixOf` SBS.fromShort (entityName sym)
+                      )
+                )
+                $ staticsMap merged_m1
+          }
     (!result_m, !ss_sym_map, !func_sym_map, !tbl_slots, !static_mbs) =
-      resolveAsteriusModule debug
+      resolveAsteriusModule
+        debug
         binaryen
         (bundledFFIMarshalState report)
         merged_m

--- a/asterius/src/Asterius/TypeInfer.hs
+++ b/asterius/src/Asterius/TypeInfer.hs
@@ -1,47 +1,46 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Asterius.TypeInfer
-  ( infer
-  ) where
+  ( infer,
+  )
+where
 
 import Asterius.Types
 
 infer :: Expression -> [ValueType]
-infer expr =
-  case expr of
-    Block {..} -> blockReturnTypes
-    If {..} -> infer ifTrue
-    Loop {} -> []
-    Break {} -> []
-    Switch {} -> []
-    Call {..} -> callReturnTypes
-    CallImport {..} -> callImportReturnTypes
-    CallIndirect {} -> [I64]
-    GetLocal {..} -> [valueType]
-    SetLocal {} -> []
-    Load {..} -> [valueType]
-    Store {} -> []
-    ConstI32 {} -> [I32]
-    ConstI64 {} -> [I64]
-    ConstF32 {} -> [F32]
-    ConstF64 {} -> [F64]
-    Unary {unaryOp = WrapInt64} -> [I32]
-    Unary {unaryOp = ExtendUInt32} -> [I64]
-    Unary {unaryOp = ConvertUInt64ToFloat64} -> [F64]
-    Unary {unaryOp = ConvertSInt64ToFloat64} -> [F64]
-    Unary {unaryOp = TruncUFloat64ToInt64} -> [I64]
-    Unary {unaryOp = TruncSFloat64ToInt64} -> [I64]
-    Host {} -> [I32]
-    Nop -> []
-    Unreachable -> []
-    CFG {} -> []
-    Symbol {} -> [I64]
-    UnresolvedGetLocal {..} ->
-      case unresolvedLocalReg of
-        UniqueLocalReg _ vt -> [vt]
-        QuotRemI32X -> [I32]
-        QuotRemI32Y -> [I32]
-        QuotRemI64X -> [I64]
-        QuotRemI64Y -> [I64]
-    UnresolvedSetLocal {} -> []
-    _ -> error $ "Asterius.TypeInfer.infer: " <> show expr
+infer expr = case expr of
+  Block {..} -> blockReturnTypes
+  If {..} -> infer ifTrue
+  Loop {} -> []
+  Break {} -> []
+  Switch {} -> []
+  Call {..} -> callReturnTypes
+  CallImport {..} -> callImportReturnTypes
+  CallIndirect {} -> [I64]
+  GetLocal {..} -> [valueType]
+  SetLocal {} -> []
+  Load {..} -> [valueType]
+  Store {} -> []
+  ConstI32 {} -> [I32]
+  ConstI64 {} -> [I64]
+  ConstF32 {} -> [F32]
+  ConstF64 {} -> [F64]
+  Unary {unaryOp = WrapInt64} -> [I32]
+  Unary {unaryOp = ExtendUInt32} -> [I64]
+  Unary {unaryOp = ConvertUInt64ToFloat64} -> [F64]
+  Unary {unaryOp = ConvertSInt64ToFloat64} -> [F64]
+  Unary {unaryOp = TruncUFloat64ToInt64} -> [I64]
+  Unary {unaryOp = TruncSFloat64ToInt64} -> [I64]
+  Host {} -> [I32]
+  Nop -> []
+  Unreachable -> []
+  CFG {} -> []
+  Symbol {} -> [I64]
+  UnresolvedGetLocal {..} -> case unresolvedLocalReg of
+    UniqueLocalReg _ vt -> [vt]
+    QuotRemI32X -> [I32]
+    QuotRemI32Y -> [I32]
+    QuotRemI64X -> [I64]
+    QuotRemI64Y -> [I64]
+  UnresolvedSetLocal {} -> []
+  _ -> error $ "Asterius.TypeInfer.infer: " <> show expr

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -4,48 +4,49 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE StrictData #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE StrictData #-}
 
 module Asterius.Types
-  ( BinaryenIndex
-  , AsteriusCodeGenError(..)
-  , AsteriusStatic(..)
-  , AsteriusStaticsType(..)
-  , AsteriusStatics(..)
-  , AsteriusModule(..)
-  , AsteriusModuleSymbol(..)
-  , AsteriusEntitySymbol(..)
-  , UnresolvedLocalReg(..)
-  , UnresolvedGlobalReg(..)
-  , ValueType(..)
-  , FunctionType(..)
-  , UnaryOp(..)
-  , BinaryOp(..)
-  , HostOp(..)
-  , Expression(..)
-  , Function(..)
-  , FunctionImport(..)
-  , TableImport(..)
-  , MemoryImport(..)
-  , FunctionExport(..)
-  , TableExport(..)
-  , MemoryExport(..)
-  , FunctionTable(..)
-  , DataSegment(..)
-  , Module(..)
-  , RelooperAddBlock(..)
-  , RelooperAddBranch(..)
-  , RelooperBlock(..)
-  , RelooperRun(..)
-  , Chunk(..)
-  , FFIValueType(..)
-  , FFIFunctionType(..)
-  , FFISafety(..)
-  , FFIImportDecl(..)
-  , FFIExportDecl(..)
-  , FFIMarshalState(..)
-  ) where
+  ( BinaryenIndex,
+    AsteriusCodeGenError (..),
+    AsteriusStatic (..),
+    AsteriusStaticsType (..),
+    AsteriusStatics (..),
+    AsteriusModule (..),
+    AsteriusModuleSymbol (..),
+    AsteriusEntitySymbol (..),
+    UnresolvedLocalReg (..),
+    UnresolvedGlobalReg (..),
+    ValueType (..),
+    FunctionType (..),
+    UnaryOp (..),
+    BinaryOp (..),
+    HostOp (..),
+    Expression (..),
+    Function (..),
+    FunctionImport (..),
+    TableImport (..),
+    MemoryImport (..),
+    FunctionExport (..),
+    TableExport (..),
+    MemoryExport (..),
+    FunctionTable (..),
+    DataSegment (..),
+    Module (..),
+    RelooperAddBlock (..),
+    RelooperAddBranch (..),
+    RelooperBlock (..),
+    RelooperRun (..),
+    Chunk (..),
+    FFIValueType (..),
+    FFIFunctionType (..),
+    FFISafety (..),
+    FFIImportDecl (..),
+    FFIExportDecl (..),
+    FFIMarshalState (..),
+  )
+where
 
 import Asterius.Internals.Binary
 import Control.Exception
@@ -68,9 +69,7 @@ data AsteriusCodeGenError
   | UnsupportedCmmGlobalReg SBS.ShortByteString
   | UnsupportedCmmExpr SBS.ShortByteString
   | UnsupportedCmmSectionType SBS.ShortByteString
-  | UnsupportedImplicitCasting Expression
-                               ValueType
-                               ValueType
+  | UnsupportedImplicitCasting Expression ValueType ValueType
   | AssignToImmutableGlobalReg UnresolvedGlobalReg
   deriving (Eq, Show, Generic, Data)
 
@@ -79,8 +78,7 @@ instance Binary AsteriusCodeGenError
 instance Exception AsteriusCodeGenError
 
 data AsteriusStatic
-  = SymbolStatic AsteriusEntitySymbol
-                 Int
+  = SymbolStatic AsteriusEntitySymbol Int
   | Uninitialized Int
   | Serialized SBS.ShortByteString
   deriving (Eq, Ord, Show, Generic, Data)
@@ -96,25 +94,32 @@ data AsteriusStaticsType
 
 instance Binary AsteriusStaticsType
 
-data AsteriusStatics = AsteriusStatics
-  { staticsType :: AsteriusStaticsType
-  , asteriusStatics :: [AsteriusStatic]
-  } deriving (Eq, Ord, Show, Generic, Data)
+data AsteriusStatics
+  = AsteriusStatics
+      { staticsType :: AsteriusStaticsType,
+        asteriusStatics :: [AsteriusStatic]
+      }
+  deriving (Eq, Ord, Show, Generic, Data)
 
 instance Binary AsteriusStatics
 
-data AsteriusModule = AsteriusModule
-  { staticsMap :: LM.Map AsteriusEntitySymbol AsteriusStatics
-  , staticsErrorMap :: LM.Map AsteriusEntitySymbol AsteriusCodeGenError
-  , functionMap :: LM.Map AsteriusEntitySymbol Function
-  , ffiMarshalState :: FFIMarshalState
-  } deriving (Eq, Show, Generic, Data)
+data AsteriusModule
+  = AsteriusModule
+      { staticsMap :: LM.Map AsteriusEntitySymbol AsteriusStatics,
+        staticsErrorMap :: LM.Map AsteriusEntitySymbol AsteriusCodeGenError,
+        functionMap :: LM.Map AsteriusEntitySymbol Function,
+        ffiMarshalState :: FFIMarshalState
+      }
+  deriving (Eq, Show, Generic, Data)
 
 instance Binary AsteriusModule where
+
   put AsteriusModule {..} =
-    lazyMapPut staticsMap *> lazyMapPut staticsErrorMap *>
-    lazyMapPut functionMap *>
-    put ffiMarshalState
+    lazyMapPut staticsMap
+      *> lazyMapPut staticsErrorMap
+      *> lazyMapPut functionMap
+      *> put ffiMarshalState
+
   get = AsteriusModule <$> lazyMapGet <*> lazyMapGet <*> lazyMapGet <*> get
 
 instance Semigroup AsteriusModule where
@@ -128,24 +133,27 @@ instance Semigroup AsteriusModule where
 instance Monoid AsteriusModule where
   mempty = AsteriusModule mempty mempty mempty mempty
 
-data AsteriusModuleSymbol = AsteriusModuleSymbol
-  { unitId :: SBS.ShortByteString
-  , moduleName :: [SBS.ShortByteString]
-  } deriving (Eq, Ord, Show, Generic, Data)
+data AsteriusModuleSymbol
+  = AsteriusModuleSymbol
+      { unitId :: SBS.ShortByteString,
+        moduleName :: [SBS.ShortByteString]
+      }
+  deriving (Eq, Ord, Show, Generic, Data)
 
 instance Binary AsteriusModuleSymbol
 
-newtype AsteriusEntitySymbol = AsteriusEntitySymbol
-  { entityName :: SBS.ShortByteString
-  } deriving (Eq, Ord, IsString, Binary, Semigroup)
+newtype AsteriusEntitySymbol
+  = AsteriusEntitySymbol
+      { entityName :: SBS.ShortByteString
+      }
+  deriving (Eq, Ord, IsString, Binary, Semigroup)
 
 deriving newtype instance Show AsteriusEntitySymbol
 
 deriving instance Data AsteriusEntitySymbol
 
 data UnresolvedLocalReg
-  = UniqueLocalReg Int
-                   ValueType
+  = UniqueLocalReg Int ValueType
   | QuotRemI32X
   | QuotRemI32Y
   | QuotRemI64X
@@ -184,9 +192,11 @@ data ValueType
 
 instance Binary ValueType
 
-data FunctionType = FunctionType
-  { paramTypes, returnTypes :: [ValueType]
-  } deriving (Eq, Ord, Show, Generic, Data)
+data FunctionType
+  = FunctionType
+      { paramTypes, returnTypes :: [ValueType]
+      }
+  deriving (Eq, Ord, Show, Generic, Data)
 
 instance Binary FunctionType
 
@@ -331,167 +341,243 @@ data HostOp
 instance Binary HostOp
 
 data Expression
-  = Block { name :: SBS.ShortByteString
-          , bodys :: [Expression]
-          , blockReturnTypes :: [ValueType] }
-  | If { condition, ifTrue :: Expression
-       , ifFalse :: Maybe Expression }
-  | Loop { name :: SBS.ShortByteString
-         , body :: Expression }
-  | Break { name :: SBS.ShortByteString
-          , breakCondition :: Maybe Expression }
-  | Switch { names :: [SBS.ShortByteString]
-           , defaultName :: SBS.ShortByteString
-           , condition :: Expression }
-  | Call { target :: AsteriusEntitySymbol
-         , operands :: [Expression]
-         , callReturnTypes :: [ValueType] }
-  | CallImport { target' :: SBS.ShortByteString
-               , operands :: [Expression]
-               , callImportReturnTypes :: [ValueType] }
-  | CallIndirect { indirectTarget :: Expression
-                 , operands :: [Expression]
-                 , functionType :: FunctionType }
-  | GetLocal { index :: BinaryenIndex
-             , valueType :: ValueType }
-  | SetLocal { index :: BinaryenIndex
-             , value :: Expression }
-  | Load { signed :: Bool
-         , bytes, offset :: BinaryenIndex
-         , valueType :: ValueType
-         , ptr :: Expression }
-  | Store { bytes, offset :: BinaryenIndex
-          , ptr, value :: Expression
-          , valueType :: ValueType }
+  = Block
+      { name :: SBS.ShortByteString,
+        bodys :: [Expression],
+        blockReturnTypes :: [ValueType]
+      }
+  | If
+      { condition, ifTrue :: Expression,
+        ifFalse :: Maybe Expression
+      }
+  | Loop
+      { name :: SBS.ShortByteString,
+        body :: Expression
+      }
+  | Break
+      { name :: SBS.ShortByteString,
+        breakCondition :: Maybe Expression
+      }
+  | Switch
+      { names :: [SBS.ShortByteString],
+        defaultName :: SBS.ShortByteString,
+        condition :: Expression
+      }
+  | Call
+      { target :: AsteriusEntitySymbol,
+        operands :: [Expression],
+        callReturnTypes :: [ValueType]
+      }
+  | CallImport
+      { target' :: SBS.ShortByteString,
+        operands :: [Expression],
+        callImportReturnTypes :: [ValueType]
+      }
+  | CallIndirect
+      { indirectTarget :: Expression,
+        operands :: [Expression],
+        functionType :: FunctionType
+      }
+  | GetLocal
+      { index :: BinaryenIndex,
+        valueType :: ValueType
+      }
+  | SetLocal
+      { index :: BinaryenIndex,
+        value :: Expression
+      }
+  | Load
+      { signed :: Bool,
+        bytes, offset :: BinaryenIndex,
+        valueType :: ValueType,
+        ptr :: Expression
+      }
+  | Store
+      { bytes, offset :: BinaryenIndex,
+        ptr, value :: Expression,
+        valueType :: ValueType
+      }
   | ConstI32 Int32
   | ConstI64 Int64
   | ConstF32 Float
   | ConstF64 Double
-  | Unary { unaryOp :: UnaryOp
-          , operand0 :: Expression }
-  | Binary { binaryOp :: BinaryOp
-           , operand0, operand1 :: Expression }
-  | ReturnCall { returnCallTarget64 :: AsteriusEntitySymbol }
-  | ReturnCallIndirect { returnCallIndirectTarget64 :: Expression }
-  | Host { hostOp :: HostOp
-         , operands :: [Expression] }
+  | Unary
+      { unaryOp :: UnaryOp,
+        operand0 :: Expression
+      }
+  | Binary
+      { binaryOp :: BinaryOp,
+        operand0, operand1 :: Expression
+      }
+  | ReturnCall
+      { returnCallTarget64 :: AsteriusEntitySymbol
+      }
+  | ReturnCallIndirect
+      { returnCallIndirectTarget64 :: Expression
+      }
+  | Host
+      { hostOp :: HostOp,
+        operands :: [Expression]
+      }
   | Nop
   | Unreachable
-  | CFG { graph :: RelooperRun }
-  | Symbol { unresolvedSymbol :: AsteriusEntitySymbol
-           , symbolOffset :: Int }
-  | UnresolvedGetLocal { unresolvedLocalReg :: UnresolvedLocalReg }
-  | UnresolvedSetLocal { unresolvedLocalReg :: UnresolvedLocalReg
-                       , value :: Expression }
-  | Barf { barfMessage :: SBS.ShortByteString
-         , barfReturnTypes :: [ValueType] }
+  | CFG
+      { graph :: RelooperRun
+      }
+  | Symbol
+      { unresolvedSymbol :: AsteriusEntitySymbol,
+        symbolOffset :: Int
+      }
+  | UnresolvedGetLocal
+      { unresolvedLocalReg :: UnresolvedLocalReg
+      }
+  | UnresolvedSetLocal
+      { unresolvedLocalReg :: UnresolvedLocalReg,
+        value :: Expression
+      }
+  | Barf
+      { barfMessage :: SBS.ShortByteString,
+        barfReturnTypes :: [ValueType]
+      }
   deriving (Eq, Show, Generic, Data)
 
 instance Binary Expression
 
-data Function = Function
-  { functionType :: FunctionType
-  , varTypes :: [ValueType]
-  , body :: Expression
-  } deriving (Eq, Show, Generic, Data)
+data Function
+  = Function
+      { functionType :: FunctionType,
+        varTypes :: [ValueType],
+        body :: Expression
+      }
+  deriving (Eq, Show, Generic, Data)
 
 instance Binary Function
 
-data FunctionImport = FunctionImport
-  { internalName, externalModuleName, externalBaseName :: SBS.ShortByteString
-  , functionType :: FunctionType
-  } deriving (Eq, Show, Data, Generic)
+data FunctionImport
+  = FunctionImport
+      { internalName, externalModuleName, externalBaseName :: SBS.ShortByteString,
+        functionType :: FunctionType
+      }
+  deriving (Eq, Show, Data, Generic)
 
 instance Binary FunctionImport
 
-data TableImport = TableImport
-  { externalModuleName, externalBaseName :: SBS.ShortByteString
-  } deriving (Eq, Show, Data, Generic)
+data TableImport
+  = TableImport
+      { externalModuleName, externalBaseName :: SBS.ShortByteString
+      }
+  deriving (Eq, Show, Data, Generic)
 
 instance Binary TableImport
 
-data MemoryImport = MemoryImport
-  { externalModuleName, externalBaseName :: SBS.ShortByteString
-  } deriving (Eq, Show, Data, Generic)
+data MemoryImport
+  = MemoryImport
+      { externalModuleName, externalBaseName :: SBS.ShortByteString
+      }
+  deriving (Eq, Show, Data, Generic)
 
 instance Binary MemoryImport
 
-data FunctionExport = FunctionExport
-  { internalName, externalName :: SBS.ShortByteString
-  } deriving (Eq, Show, Data, Generic)
+data FunctionExport
+  = FunctionExport
+      { internalName, externalName :: SBS.ShortByteString
+      }
+  deriving (Eq, Show, Data, Generic)
 
 instance Binary FunctionExport
 
-newtype TableExport = TableExport
-  { externalName :: SBS.ShortByteString
-  } deriving (Eq, Show, Data, Generic)
+newtype TableExport
+  = TableExport
+      { externalName :: SBS.ShortByteString
+      }
+  deriving (Eq, Show, Data, Generic)
 
 instance Binary TableExport
 
-newtype MemoryExport = MemoryExport
-  { externalName :: SBS.ShortByteString
-  } deriving (Eq, Show, Data, Generic)
+newtype MemoryExport
+  = MemoryExport
+      { externalName :: SBS.ShortByteString
+      }
+  deriving (Eq, Show, Data, Generic)
 
 instance Binary MemoryExport
 
-data FunctionTable = FunctionTable
-  { tableFunctionNames :: [SBS.ShortByteString]
-  , tableOffset :: BinaryenIndex
-  } deriving (Eq, Show, Data, Generic)
+data FunctionTable
+  = FunctionTable
+      { tableFunctionNames :: [SBS.ShortByteString],
+        tableOffset :: BinaryenIndex
+      }
+  deriving (Eq, Show, Data, Generic)
 
 instance Binary FunctionTable
 
-data DataSegment = DataSegment
-  { content :: SBS.ShortByteString
-  , offset :: Int32
-  } deriving (Eq, Show, Data, Generic)
+data DataSegment
+  = DataSegment
+      { content :: SBS.ShortByteString,
+        offset :: Int32
+      }
+  deriving (Eq, Show, Data, Generic)
 
 instance Binary DataSegment
 
-data Module = Module
-  { functionMap' :: LM.Map SBS.ShortByteString Function
-  , functionImports :: [FunctionImport]
-  , functionExports :: [FunctionExport]
-  , functionTable :: FunctionTable
-  , tableImport :: TableImport
-  , tableExport :: TableExport
-  , tableSlots :: Int
-  , memorySegments :: [DataSegment]
-  , memoryImport :: MemoryImport
-  , memoryExport :: MemoryExport
-  , memoryMBlocks :: Int
-  } deriving (Eq, Show, Data, Generic)
+data Module
+  = Module
+      { functionMap' :: LM.Map SBS.ShortByteString Function,
+        functionImports :: [FunctionImport],
+        functionExports :: [FunctionExport],
+        functionTable :: FunctionTable,
+        tableImport :: TableImport,
+        tableExport :: TableExport,
+        tableSlots :: Int,
+        memorySegments :: [DataSegment],
+        memoryImport :: MemoryImport,
+        memoryExport :: MemoryExport,
+        memoryMBlocks :: Int
+      }
+  deriving (Eq, Show, Data, Generic)
 
 instance Binary Module
 
 data RelooperAddBlock
-  = AddBlock { code :: Expression }
-  | AddBlockWithSwitch { code, condition :: Expression }
+  = AddBlock
+      { code :: Expression
+      }
+  | AddBlockWithSwitch
+      { code, condition :: Expression
+      }
   deriving (Eq, Show, Generic, Data)
 
 instance Binary RelooperAddBlock
 
 data RelooperAddBranch
-  = AddBranch { to :: SBS.ShortByteString
-              , addBranchCondition :: Maybe Expression }
-  | AddBranchForSwitch { to :: SBS.ShortByteString
-                       , indexes :: [BinaryenIndex] }
+  = AddBranch
+      { to :: SBS.ShortByteString,
+        addBranchCondition :: Maybe Expression
+      }
+  | AddBranchForSwitch
+      { to :: SBS.ShortByteString,
+        indexes :: [BinaryenIndex]
+      }
   deriving (Eq, Show, Generic, Data)
 
 instance Binary RelooperAddBranch
 
-data RelooperBlock = RelooperBlock
-  { addBlock :: RelooperAddBlock
-  , addBranches :: [RelooperAddBranch]
-  } deriving (Eq, Show, Generic, Data)
+data RelooperBlock
+  = RelooperBlock
+      { addBlock :: RelooperAddBlock,
+        addBranches :: [RelooperAddBranch]
+      }
+  deriving (Eq, Show, Generic, Data)
 
 instance Binary RelooperBlock
 
-data RelooperRun = RelooperRun
-  { entry :: SBS.ShortByteString
-  , blockMap :: LM.Map SBS.ShortByteString RelooperBlock
-  , labelHelper :: BinaryenIndex
-  } deriving (Eq, Show, Generic, Data)
+data RelooperRun
+  = RelooperRun
+      { entry :: SBS.ShortByteString,
+        blockMap :: LM.Map SBS.ShortByteString RelooperBlock,
+        labelHelper :: BinaryenIndex
+      }
+  deriving (Eq, Show, Generic, Data)
 
 instance Binary RelooperRun
 
@@ -503,18 +589,22 @@ data Chunk a
 instance Binary a => Binary (Chunk a)
 
 data FFIValueType
-  = FFI_VAL { ffiWasmValueType, ffiJSValueType :: ValueType
-            , hsTyCon :: SBS.ShortByteString
-            , signed :: Bool }
+  = FFI_VAL
+      { ffiWasmValueType, ffiJSValueType :: ValueType,
+        hsTyCon :: SBS.ShortByteString,
+        signed :: Bool
+      }
   | FFI_JSVAL
   deriving (Eq, Show, Generic, Data)
 
 instance Binary FFIValueType
 
-data FFIFunctionType = FFIFunctionType
-  { ffiParamTypes, ffiResultTypes :: [FFIValueType]
-  , ffiInIO :: Bool
-  } deriving (Eq, Show, Generic, Data)
+data FFIFunctionType
+  = FFIFunctionType
+      { ffiParamTypes, ffiResultTypes :: [FFIValueType],
+        ffiInIO :: Bool
+      }
+  deriving (Eq, Show, Generic, Data)
 
 instance Binary FFIFunctionType
 
@@ -526,37 +616,44 @@ data FFISafety
 
 instance Binary FFISafety
 
-data FFIImportDecl = FFIImportDecl
-  { ffiFunctionType :: FFIFunctionType
-  , ffiSafety :: FFISafety
-  , ffiSourceChunks :: [Chunk Int]
-  } deriving (Eq, Show, Generic, Data)
+data FFIImportDecl
+  = FFIImportDecl
+      { ffiFunctionType :: FFIFunctionType,
+        ffiSafety :: FFISafety,
+        ffiSourceChunks :: [Chunk Int]
+      }
+  deriving (Eq, Show, Generic, Data)
 
 instance Binary FFIImportDecl
 
-data FFIExportDecl = FFIExportDecl
-  { ffiFunctionType :: FFIFunctionType
-  , ffiExportClosure :: AsteriusEntitySymbol
-  } deriving (Eq, Show, Generic, Data)
+data FFIExportDecl
+  = FFIExportDecl
+      { ffiFunctionType :: FFIFunctionType,
+        ffiExportClosure :: AsteriusEntitySymbol
+      }
+  deriving (Eq, Show, Generic, Data)
 
 instance Binary FFIExportDecl
 
-data FFIMarshalState = FFIMarshalState
-  { ffiImportDecls :: LM.Map AsteriusEntitySymbol FFIImportDecl
-  , ffiExportDecls :: LM.Map AsteriusEntitySymbol FFIExportDecl
-  } deriving (Eq, Show, Data)
+data FFIMarshalState
+  = FFIMarshalState
+      { ffiImportDecls :: LM.Map AsteriusEntitySymbol FFIImportDecl,
+        ffiExportDecls :: LM.Map AsteriusEntitySymbol FFIExportDecl
+      }
+  deriving (Eq, Show, Data)
 
 instance Semigroup FFIMarshalState where
-  s0 <> s1 =
-    FFIMarshalState
-      { ffiImportDecls = ffiImportDecls s0 <> ffiImportDecls s1
-      , ffiExportDecls = ffiExportDecls s0 <> ffiExportDecls s1
-      }
+  s0 <> s1 = FFIMarshalState
+    { ffiImportDecls = ffiImportDecls s0 <> ffiImportDecls s1,
+      ffiExportDecls = ffiExportDecls s0 <> ffiExportDecls s1
+    }
 
 instance Monoid FFIMarshalState where
   mempty = FFIMarshalState {ffiImportDecls = mempty, ffiExportDecls = mempty}
 
 instance Binary FFIMarshalState where
+
   put FFIMarshalState {..} =
     lazyMapPut ffiImportDecls *> lazyMapPut ffiExportDecls
+
   get = FFIMarshalState <$> lazyMapGet <*> lazyMapGet

--- a/asterius/src/Asterius/TypesConv.hs
+++ b/asterius/src/Asterius/TypesConv.hs
@@ -3,12 +3,13 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Asterius.TypesConv
-  ( marshalToModuleSymbol
-  , zEncodeModuleSymbol
-  , generateWasmFunctionTypeSet
-  , asmPpr
-  , asmPrint
-  ) where
+  ( marshalToModuleSymbol,
+    zEncodeModuleSymbol,
+    generateWasmFunctionTypeSet,
+    asmPpr,
+    asmPrint,
+  )
+where
 
 import Asterius.Internals
 import Asterius.Types
@@ -18,34 +19,36 @@ import Data.List
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified GhcPlugins as GHC
-import Prelude hiding (IO)
 import qualified Pretty as GHC
-import System.IO (IOMode(WriteMode), withFile)
+import System.IO
+  ( IOMode (WriteMode),
+    withFile,
+  )
+import Prelude hiding (IO)
 
 {-# INLINE marshalToModuleSymbol #-}
 marshalToModuleSymbol :: GHC.Module -> AsteriusModuleSymbol
-marshalToModuleSymbol (GHC.Module u m) =
-  AsteriusModuleSymbol
-    { unitId = SBS.toShort $ GHC.fs_bs $ GHC.unitIdFS u
-    , moduleName =
-        map SBS.toShort $
-        CBS.splitWith (== '.') $ GHC.fs_bs $ GHC.moduleNameFS m
-    }
+marshalToModuleSymbol (GHC.Module u m) = AsteriusModuleSymbol
+  { unitId = SBS.toShort $ GHC.fs_bs $ GHC.unitIdFS u,
+    moduleName =
+      map SBS.toShort $ CBS.splitWith (== '.') $ GHC.fs_bs $ GHC.moduleNameFS m
+  }
 
 {-# INLINE zEncodeModuleSymbol #-}
 zEncodeModuleSymbol :: AsteriusModuleSymbol -> String
 zEncodeModuleSymbol AsteriusModuleSymbol {..} =
-  GHC.zString $
-  GHC.zEncodeFS $
-  GHC.mkFastStringByteString $
-  SBS.fromShort unitId <> "_" <>
-  CBS.intercalate "." [SBS.fromShort mod_chunk | mod_chunk <- moduleName]
+  GHC.zString
+    $ GHC.zEncodeFS
+    $ GHC.mkFastStringByteString
+    $ SBS.fromShort unitId
+      <> "_"
+      <> CBS.intercalate "." [SBS.fromShort mod_chunk | mod_chunk <- moduleName]
 
 {-# INLINE generateWasmFunctionTypeSet #-}
 generateWasmFunctionTypeSet :: Module -> Set.Set FunctionType
 generateWasmFunctionTypeSet Module {..} =
-  Set.fromList [functionType | FunctionImport {..} <- functionImports] <>
-  Set.fromList [functionType | Function {..} <- Map.elems functionMap']
+  Set.fromList [functionType | FunctionImport {..} <- functionImports]
+    <> Set.fromList [functionType | Function {..} <- Map.elems functionMap']
 
 {-# INLINE asmPpr #-}
 asmPpr :: GHC.Outputable a => GHC.DynFlags -> a -> String
@@ -53,11 +56,10 @@ asmPpr dflags = GHC.showSDoc dflags . GHC.pprCode GHC.AsmStyle . GHC.ppr
 
 {-# INLINE asmPrint #-}
 asmPrint :: GHC.Outputable a => GHC.DynFlags -> FilePath -> a -> IO ()
-asmPrint dflags p a =
-  withFile p WriteMode $ \h ->
-    GHC.printSDocLn
-      GHC.PageMode
-      dflags
-      h
-      (GHC.mkCodeStyle GHC.AsmStyle)
-      (GHC.ppr a)
+asmPrint dflags p a = withFile p WriteMode $ \h ->
+  GHC.printSDocLn
+    GHC.PageMode
+    dflags
+    h
+    (GHC.mkCodeStyle GHC.AsmStyle)
+    (GHC.ppr a)

--- a/asterius/test/array.hs
+++ b/asterius/test/array.hs
@@ -5,4 +5,5 @@ main :: IO ()
 main = do
   args <- getArgs
   callProcess "ahc-link" $
-    ["--input-hs", "test/array/array.hs", "--run"] <> args
+    ["--input-hs", "test/array/array.hs", "--run"]
+      <> args

--- a/asterius/test/bigint.hs
+++ b/asterius/test/bigint.hs
@@ -5,4 +5,5 @@ main :: IO ()
 main = do
   args <- getArgs
   callProcess "ahc-link" $
-    ["--input-hs", "test/bigint/bigint.hs", "--run"] <> args
+    ["--input-hs", "test/bigint/bigint.hs", "--run"]
+      <> args

--- a/asterius/test/bytearray.hs
+++ b/asterius/test/bytearray.hs
@@ -5,4 +5,5 @@ main :: IO ()
 main = do
   args <- getArgs
   callProcess "ahc-link" $
-    ["--input-hs", "test/bytearray/bytearray.hs", "--run"] <> args
+    ["--input-hs", "test/bytearray/bytearray.hs", "--run"]
+      <> args

--- a/asterius/test/bytearraymini.hs
+++ b/asterius/test/bytearraymini.hs
@@ -5,4 +5,5 @@ main :: IO ()
 main = do
   args <- getArgs
   callProcess "ahc-link" $
-    ["--input-hs", "test/bytearraymini/bytearraymini.hs", "--run"] <> args
+    ["--input-hs", "test/bytearraymini/bytearraymini.hs", "--run"]
+      <> args

--- a/asterius/test/bytearraymini/bytearraymini.hs
+++ b/asterius/test/bytearraymini/bytearraymini.hs
@@ -16,58 +16,41 @@ Expected output:
 -1
 65535
 -}
-
 mainInt8 :: IO ()
 mainInt8 = do
-  r <-
-    IO $ \s0 ->
-      case newByteArray# 8# s0 of
-        (# s1, mba #) ->
-          case writeInt8Array# mba 0# 255# s1 of
-            s2 ->
-              case unsafeFreezeByteArray# mba s2 of
-                (# s10, ba #) -> (# s10, I# (indexInt8Array# ba 0#) #)
+  r <- IO $ \s0 -> case newByteArray# 8# s0 of
+    (# s1, mba #) -> case writeInt8Array# mba 0# 255# s1 of
+      s2 -> case unsafeFreezeByteArray# mba s2 of
+        (# s10, ba #) -> (# s10, I# (indexInt8Array# ba 0#) #)
   print r
 
 mainInt16 :: IO ()
 mainInt16 = do
-  r <-
-    IO $ \s0 ->
-      case newByteArray# 16# s0 of
-        (# s1, mba #) ->
-          case writeInt16Array# mba 0# 65535# s1 of
-            s2 ->
-              case unsafeFreezeByteArray# mba s2 of
-                (# s10, ba #) -> (# s10, I# (indexInt16Array# ba 0#) #)
+  r <- IO $ \s0 -> case newByteArray# 16# s0 of
+    (# s1, mba #) -> case writeInt16Array# mba 0# 65535# s1 of
+      s2 -> case unsafeFreezeByteArray# mba s2 of
+        (# s10, ba #) -> (# s10, I# (indexInt16Array# ba 0#) #)
   print r
 
 mainWord8 :: IO ()
 mainWord8 = do
-  r <-
-    IO $ \s0 ->
-      case newByteArray# 8# s0 of
-        (# s1, mba #) ->
-          case writeWord8Array# mba 0# 255## s1 of
-            s2 ->
-              case unsafeFreezeByteArray# mba s2 of
-                (# s10, ba #) -> (# s10, W# (indexWord8Array# ba 0#) #)
+  r <- IO $ \s0 -> case newByteArray# 8# s0 of
+    (# s1, mba #) -> case writeWord8Array# mba 0# 255## s1 of
+      s2 -> case unsafeFreezeByteArray# mba s2 of
+        (# s10, ba #) -> (# s10, W# (indexWord8Array# ba 0#) #)
   print r
 
 mainWord16 :: IO ()
 mainWord16 = do
-  r <-
-    IO $ \s0 ->
-      case newByteArray# 16# s0 of
-        (# s1, mba #) ->
-          case writeWord16Array# mba 0# 65535## s1 of
-            s2 ->
-              case unsafeFreezeByteArray# mba s2 of
-                (# s10, ba #) -> (# s10, W# (indexWord16Array# ba 0#) #)
+  r <- IO $ \s0 -> case newByteArray# 16# s0 of
+    (# s1, mba #) -> case writeWord16Array# mba 0# 65535## s1 of
+      s2 -> case unsafeFreezeByteArray# mba s2 of
+        (# s10, ba #) -> (# s10, W# (indexWord16Array# ba 0#) #)
   print r
 
 main :: IO ()
 main = do
-    mainInt8
-    mainWord8
-    mainInt16
-    mainWord16
+  mainInt8
+  mainWord8
+  mainInt16
+  mainWord16

--- a/asterius/test/cloudflare.hs
+++ b/asterius/test/cloudflare.hs
@@ -6,11 +6,11 @@ main :: IO ()
 main = do
   args <- getArgs
   callProcess "ahc-link" $
-    [ "--bundle"
-    , "--browser"
-    , "--input-hs"
-    , "test/cloudflare/cloudflare.hs"
-    , "--input-mjs"
-    , "test/cloudflare/cloudflare.mjs"
-    ] <>
-    args
+    [ "--bundle",
+      "--browser",
+      "--input-hs",
+      "test/cloudflare/cloudflare.hs",
+      "--input-mjs",
+      "test/cloudflare/cloudflare.mjs"
+    ]
+      <> args

--- a/asterius/test/cloudflare/cloudflare.hs
+++ b/asterius/test/cloudflare/cloudflare.hs
@@ -6,22 +6,21 @@ handleFetch :: (JSObject -> IO ()) -> IO ()
 handleFetch = coerce makeHaskellCallback1 >=> js_handle_fetch
 
 main :: IO ()
-main =
-  handleFetch $ \ev -> do
-    req <- indexJSObject ev "request"
-    let req_str = jsonStringify req
-        resp = js_new_response $ toJSString $ "From Haskell: " <> req_str
-        resp_promise = js_promise_resolve resp
-    js_respond_with ev resp_promise
+main = handleFetch $ \ev -> do
+  req <- indexJSObject ev "request"
+  let req_str = jsonStringify req
+      resp = js_new_response $ toJSString $ "From Haskell: " <> req_str
+      resp_promise = js_promise_resolve resp
+  js_respond_with ev resp_promise
 
-foreign import javascript "addEventListener('fetch', ${1})" js_handle_fetch
-  :: JSFunction -> IO ()
+foreign import javascript "addEventListener('fetch', ${1})"
+  js_handle_fetch :: JSFunction -> IO ()
 
-foreign import javascript "new Response(${1})" js_new_response
-  :: JSString -> JSObject
+foreign import javascript "new Response(${1})"
+  js_new_response :: JSString -> JSObject
 
-foreign import javascript "Promise.resolve(${1})" js_promise_resolve
-  :: JSObject -> JSObject
+foreign import javascript "Promise.resolve(${1})"
+  js_promise_resolve :: JSObject -> JSObject
 
-foreign import javascript "${1}.respondWith(${2})" js_respond_with
-  :: JSObject -> JSObject -> IO ()
+foreign import javascript "${1}.respondWith(${2})"
+  js_respond_with :: JSObject -> JSObject -> IO ()

--- a/asterius/test/exception.hs
+++ b/asterius/test/exception.hs
@@ -5,4 +5,5 @@ main :: IO ()
 main = do
   args <- getArgs
   callProcess "ahc-link" $
-    ["--input-hs", "test/exception/exception.hs", "--run"] <> args
+    ["--input-hs", "test/exception/exception.hs", "--run"]
+      <> args

--- a/asterius/test/fib/fib.hs
+++ b/asterius/test/fib/fib.hs
@@ -5,9 +5,9 @@
 import Control.DeepSeq
 import Control.Monad.State.Strict
 import qualified Data.IntMap.Strict as IM
+import Debug.Trace (trace)
 import GHC.Generics
 import System.Mem
-import Debug.Trace (trace)
 
 fib :: Int -> Int
 fib n = go 0 1 0
@@ -27,83 +27,64 @@ factMap :: Int -> IM.IntMap Int
 factMap n = IM.fromList $ take n $ zip [0 ..] facts
 
 sumFacts :: Int -> Int
-sumFacts n =
-  fst $
-  flip execState (0, 0) $
-  fix $ \w -> do
-    (tot, i) <- get
-    put (tot + facts !! i, i + 1)
-    when (i < n) w
+sumFacts n = fst $ flip execState (0, 0) $ fix $ \w -> do
+  (tot, i) <- get
+  put (tot + facts !! i, i + 1)
+  when (i < n) w
 
 data BinTree
   = Tip
-  | Branch !BinTree
-           !BinTree
+  | Branch !BinTree !BinTree
   deriving (Eq, Ord, Generic)
 
 instance NFData BinTree
 
 genBinTree :: Int -> BinTree
 genBinTree 0 = Tip
-genBinTree n = Branch t t
-  where
-    t = genBinTree (n - 1)
+genBinTree n = Branch t t where t = genBinTree (n - 1)
 
 sizeofBinTree :: BinTree -> Int
 sizeofBinTree Tip = 1
 sizeofBinTree (Branch x y) = 1 + sizeofBinTree x + sizeofBinTree y
 
 foreign import ccall safe "print_i64" print_i64 :: Int -> IO ()
+
 foreign import ccall unsafe "assert_eq_i64" assert_eq_i64 :: Int -> Int -> IO ()
 
 foreign import ccall unsafe "print_f64" print_f64 :: Double -> IO ()
 
 readDouble :: IO ()
-readDouble = let r = read "1.2"
-  in if (r :: Double) == 1.2
-       then pure ()
-       else fail $ "read value: " <> show r
+readDouble =
+  let r = read "1.2"
+   in if (r :: Double) == 1.2 then pure () else fail $ "read value: " <> show r
 
 main :: IO ()
 main = do
-
   performGC
-
   putStrLn $ trace "trace message" ""
-
   readDouble
-
   -- Test that assert_eq works
   assert_eq_i64 10 10
-
   print_i64 $ fib 10
   assert_eq_i64 (fib 10) 55
-
   print_i64 $ fact 5
   assert_eq_i64 (fact 5) 120
-
   print_f64 $ cos 0.5
   print_f64 $ 2 ** 3
-
   let sizeof3Tree = sizeofBinTree $ force $ genBinTree 3
   print_i64 $ sizeof3Tree
   -- 2^4 - 1
   assert_eq_i64 sizeof3Tree 15
-
   let sizeof5Tree = sizeofBinTree $ force $ genBinTree 5
   print_i64 $ sizeof5Tree
   -- 2^6 - 1
   assert_eq_i64 sizeof5Tree 63
-
   print_i64 $ facts !! 5
   assert_eq_i64 (facts !! 5) 120
-
   let factmapAt5 = factMap 10 IM.! 5
   print_i64 $ factmapAt5
   assert_eq_i64 factmapAt5 120
-
   -- 0! + 1! + 2! + 3! + 4! + 5!
   print_i64 $ sumFacts 5
   assert_eq_i64 (sumFacts 5) (154)
-
   performGC

--- a/asterius/test/ghc-testsuite.hs
+++ b/asterius/test/ghc-testsuite.hs
@@ -10,7 +10,10 @@ import Control.Exception
 import qualified Data.ByteString.Lazy as LBS
 import Data.Csv
 import Data.IORef
-import Data.List (sort, sortOn)
+import Data.List
+  ( sort,
+    sortOn,
+  )
 import Data.Maybe
 import Data.Ord
 import Data.Traversable
@@ -24,25 +27,27 @@ import System.Process
 import Test.Tasty
 import Test.Tasty.HUnit
 
-data TestCase = TestCase
-  { casePath :: FilePath
-  , caseStdIn, caseStdOut, caseStdErr :: LBS.ByteString
-  } deriving (Show)
+data TestCase
+  = TestCase
+      { casePath :: FilePath,
+        caseStdIn, caseStdOut, caseStdErr :: LBS.ByteString
+      }
+  deriving (Show)
 
--- | Convert a Char to a Word8
+-- Convert a Char to a Word8
 charToWord8 :: Char -> Word8
 charToWord8 = toEnum . fromEnum
 
--- | Try to read a file. if file does not exist, then return empty string.
+-- Try to read a file. if file does not exist, then return empty string.
 readFileNullable :: FilePath -> IO LBS.ByteString
 readFileNullable p = do
   exist <- doesFileExist p
   if exist
     then do
       bs <- LBS.readFile p
-       -- | Add trailing whitespace if it does not exist.
-       -- | The GHC testsuite also performs normalization:
-       -- | testsuite/driver/testlib.py
+      -- Add trailing whitespace if it does not exist.
+      -- The GHC testsuite also performs normalization:
+      -- testsuite/driver/testlib.py
       if LBS.last bs /= charToWord8 '\n'
         then return $ LBS.snoc bs (charToWord8 '\n')
         else return bs
@@ -52,34 +57,24 @@ getTestCases :: IO [TestCase]
 getTestCases = do
   let root = "test" </> "ghc-testsuite"
   subdirs <- sort <$> listDirectory root
-  fmap concat $
-    for subdirs $ \subdir -> do
-      let subroot = root </> subdir
-      files <- sort <$> listDirectory subroot
-      let cases = map (subroot </>) $ filter ((== ".hs") . takeExtension) files
-      for cases $ \c
-        -- | GHC has some tests that differ for 32 and 64 bit architectures. So,
-        -- we first check if the 64 bit test exists. If it does, we always
-        -- use it. If it does not, we use the default test (which should
-        -- be the same for both architectures).
-       -> do
+  fmap concat $ for subdirs $ \subdir -> do
+    let subroot = root </> subdir
+    files <- sort <$> listDirectory subroot
+    let cases = map (subroot </>) $ filter ((== ".hs") . takeExtension) files
+    for cases $ \c ->
+      -- GHC has some tests that differ for 32 and 64 bit architectures. So,
+      -- we first check if the 64 bit test exists. If it does, we always
+      -- use it. If it does not, we use the default test (which should
+      -- be the same for both architectures).
+      do
         ws64exists <- doesFileExist (c -<.> "stdout-ws-64")
-        let stdoutp =
-              c -<.>
-              ("stdout" <>
-               if ws64exists
-                 then "-ws-64"
-                 else "")
+        let stdoutp = c -<.> ("stdout" <> if ws64exists then "-ws-64" else "")
         ws64exists <- doesFileExist (c -<.> "stderr-ws-64")
-        let stderrp =
-              c -<.>
-              ("stderr" <>
-               if ws64exists
-                 then "-ws-64"
-                 else "")
-        TestCase c <$> readFileNullable (c -<.> "stdin") <*>
-          readFileNullable stdoutp <*>
-          readFileNullable stderrp
+        let stderrp = c -<.> ("stderr" <> if ws64exists then "-ws-64" else "")
+        TestCase c
+          <$> readFileNullable (c -<.> "stdin")
+          <*> readFileNullable stdoutp
+          <*> readFileNullable stderrp
 
 data TestOutcome
   = TestSuccess
@@ -89,11 +84,15 @@ data TestOutcome
 instance ToField TestOutcome where
   toField = toField . show
 
-data TestRecord = TestRecord
-  { trOutcome :: TestOutcome
-  , trPath :: FilePath -- ^ Path of the test case
-  , trErrorMessage :: String -- ^ If the test failed, then the error message associated to the failure.
-  } deriving (Generic)
+data TestRecord
+  = TestRecord
+      { trOutcome :: TestOutcome,
+        -- | Path of the test case
+        trPath :: FilePath,
+        -- | If the test failed, then the error message associated to the failure.
+        trErrorMessage :: String
+      }
+  deriving (Generic)
 
 instance ToRecord TestRecord
 
@@ -107,12 +106,13 @@ runTestCase l_opts tlref TestCase {..} = catch m h
     h (e :: SomeException) = do
       atomicModifyIORef' tlref $ \trs ->
         ( TestRecord
-            { trOutcome = TestFailure
-            , trPath = casePath
-            , trErrorMessage = show e
-            } :
-          trs
-        , ())
+            { trOutcome = TestFailure,
+              trPath = casePath,
+              trErrorMessage = show e
+            }
+            : trs,
+          ()
+        )
       throwIO e
     m = do
       withTempDir "" $ \tmp_dir -> do
@@ -120,42 +120,50 @@ runTestCase l_opts tlref TestCase {..} = catch m h
         copyFile casePath tmp_case_path
         _ <-
           readCreateProcess
-            (proc "ahc-link" $
-             [ "--input-hs"
-             , takeFileName tmp_case_path
-             , "--binaryen"
-             , "--verbose-err"
-             ] <>
-             l_opts)
-              {cwd = Just tmp_dir, std_err = CreatePipe}
+            ( proc "ahc-link" $
+                [ "--input-hs",
+                  takeFileName tmp_case_path,
+                  "--binaryen",
+                  "--verbose-err"
+                ]
+                  <> l_opts
+            )
+              { cwd = Just tmp_dir,
+                std_err = CreatePipe
+              }
             ""
         mod_buf <- LBS.readFile $ tmp_case_path -<.> "wasm"
         withJSSession
           defJSSessionOpts
             { nodeExtraArgs =
-                ["--experimental-wasm-bigint" | "--debug" `elem` l_opts] <>
-                [ "--experimental-wasm-return-call"
-                | "--tail-calls" `elem` l_opts
-                ]
-            } $ \s -> do
-          i <- newAsteriusInstance s (tmp_case_path -<.> "lib.mjs") mod_buf
-          hsInit s i
-          hsMain s i
-          hs_stdout <- hsStdOut s i
-          hs_stderr <- hsStdErr s i
-          hs_stdout @?= caseStdOut
-          hs_stderr @?= caseStdErr
+                ["--experimental-wasm-bigint" | "--debug" `elem` l_opts]
+                  <> [ "--experimental-wasm-return-call"
+                       | "--tail-calls" `elem` l_opts
+                     ]
+            }
+          $ \s -> do
+            i <- newAsteriusInstance s (tmp_case_path -<.> "lib.mjs") mod_buf
+            hsInit s i
+            hsMain s i
+            hs_stdout <- hsStdOut s i
+            hs_stderr <- hsStdErr s i
+            hs_stdout @?= caseStdOut
+            hs_stderr @?= caseStdErr
       atomicModifyIORef' tlref $ \trs ->
         ( TestRecord
-            {trOutcome = TestSuccess, trPath = casePath, trErrorMessage = ""} :
-          trs
-        , ())
+            { trOutcome = TestSuccess,
+              trPath = casePath,
+              trErrorMessage = ""
+            }
+            : trs,
+          ()
+        )
 
 makeTestTree :: [String] -> IORef [TestRecord] -> TestCase -> TestTree
 makeTestTree l_opts tlref c@TestCase {..} =
   testCase casePath $ runTestCase l_opts tlref c
 
--- | save the test log to disk as a CSV file
+-- save the test log to disk as a CSV file
 saveTestLogToCSV :: IORef [TestRecord] -> FilePath -> IO ()
 saveTestLogToCSV tlref out_basepath = do
   let out_csvpath = out_basepath <.> "csv"
@@ -173,7 +181,7 @@ main = do
   trees <- map (makeTestTree l_opts tlref) <$> getTestCases
   cwd <- getCurrentDirectory
   let out_basepath = cwd </> "test-report"
-    -- | Tasty throws an exception if stuff fails, so re-throw the exception
-    -- | in case this happens.
-  defaultMain (testGroup "asterius ghc-testsuite" trees) `finally`
-    saveTestLogToCSV tlref out_basepath
+  -- Tasty throws an exception if stuff fails, so re-throw the exception
+  -- in case this happens.
+  defaultMain (testGroup "asterius ghc-testsuite" trees)
+    `finally` saveTestLogToCSV tlref out_basepath

--- a/asterius/test/jsffi.hs
+++ b/asterius/test/jsffi.hs
@@ -5,13 +5,13 @@ main :: IO ()
 main = do
   args <- getArgs
   callProcess "ahc-link" $
-    [ "--input-hs"
-    , "test/jsffi/jsffi.hs"
-    , "--input-mjs"
-    , "test/jsffi/jsffi.mjs"
-    , "--export-function=mult_hs_int"
-    , "--export-function=mult_hs_double"
-    , "--export-function=putchar"
-    , "--run"
-    ] <>
-    args
+    [ "--input-hs",
+      "test/jsffi/jsffi.hs",
+      "--input-mjs",
+      "test/jsffi/jsffi.mjs",
+      "--export-function=mult_hs_int",
+      "--export-function=mult_hs_double",
+      "--export-function=putchar",
+      "--run"
+    ]
+      <> args

--- a/asterius/test/jsffi/AsteriusPrim.hs
+++ b/asterius/test/jsffi/AsteriusPrim.hs
@@ -1,24 +1,25 @@
 {-# OPTIONS_GHC -Wall -ddump-to-file -ddump-rn -ddump-foreign -ddump-stg -ddump-cmm-raw -ddump-asm #-}
 
 module AsteriusPrim
-  ( emptyJSString
-  , concatJSString
-  , indexJSString
-  , toJSString
-  , fromJSString
-  , emptyJSArray
-  , concatJSArray
-  , indexJSArray
-  , toJSArray
-  , fromJSArray
-  , emptyJSObject
-  , indexJSObject
-  , callJSObjectMethod
-  , json
-  , callJSFunction
-  ) where
+  ( emptyJSString,
+    concatJSString,
+    indexJSString,
+    toJSString,
+    fromJSString,
+    emptyJSArray,
+    concatJSArray,
+    indexJSArray,
+    toJSArray,
+    fromJSArray,
+    emptyJSObject,
+    indexJSObject,
+    callJSObjectMethod,
+    json,
+    callJSFunction,
+  )
+where
 
-import Asterius.Types (JSVal(..))
+import Asterius.Types (JSVal (..))
 import Data.List
 
 {-# INLINEABLE emptyJSString #-}
@@ -35,7 +36,8 @@ indexJSString = js_string_tochar
 
 {-# INLINEABLE toJSString #-}
 toJSString :: String -> JSVal
-toJSString = foldl' (\s c -> js_concat s (js_string_fromchar c)) js_string_empty
+toJSString =
+  foldl' (\s c -> js_concat s (js_string_fromchar c)) js_string_empty
 
 {-# INLINEABLE fromJSString #-}
 fromJSString :: JSVal -> String
@@ -84,16 +86,16 @@ callJSFunction f args = js_function_apply f js_object_empty (toJSArray args)
 
 foreign import javascript "\"\"" js_string_empty :: JSVal
 
-foreign import javascript "${1}.concat(${2})" js_concat
-  :: JSVal -> JSVal -> JSVal
+foreign import javascript "${1}.concat(${2})"
+  js_concat :: JSVal -> JSVal -> JSVal
 
 foreign import javascript "${1}.length" js_length :: JSVal -> Int
 
-foreign import javascript "String.fromCodePoint(${1})" js_string_fromchar
-  :: Char -> JSVal
+foreign import javascript "String.fromCodePoint(${1})"
+  js_string_fromchar :: Char -> JSVal
 
-foreign import javascript "${1}.codePointAt(${2})" js_string_tochar
-  :: JSVal -> Int -> Char
+foreign import javascript "${1}.codePointAt(${2})"
+  js_string_tochar :: JSVal -> Int -> Char
 
 foreign import javascript "[]" js_array_empty :: JSVal
 
@@ -101,10 +103,10 @@ foreign import javascript "${1}[${2}]" js_index_by_int :: JSVal -> Int -> JSVal
 
 foreign import javascript "{}" js_object_empty :: JSVal
 
-foreign import javascript "${1}[${2}]" js_index_by_jsref
-  :: JSVal -> JSVal -> JSVal
+foreign import javascript "${1}[${2}]"
+  js_index_by_jsref :: JSVal -> JSVal -> JSVal
 
 foreign import javascript "JSON" js_json :: JSVal
 
-foreign import javascript "${1}.apply(${2}, ${3})" js_function_apply
-  :: JSVal -> JSVal -> JSVal -> JSVal
+foreign import javascript "${1}.apply(${2}, ${3})"
+  js_function_apply :: JSVal -> JSVal -> JSVal -> JSVal

--- a/asterius/test/jsffi/jsffi.hs
+++ b/asterius/test/jsffi/jsffi.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_GHC -Wall -ddump-to-file -ddump-rn -ddump-foreign -ddump-stg -ddump-cmm-raw -ddump-asm #-}
 
-import Asterius.Types (JSVal(..))
+import Asterius.Types (JSVal (..))
 import AsteriusPrim
 import Foreign.StablePtr
 
@@ -8,15 +8,15 @@ foreign import javascript "new Date()" current_time :: IO JSVal
 
 foreign import javascript "console.log(${1})" js_print :: JSVal -> IO ()
 
-foreign import javascript "console.log(String.fromCodePoint(${1}))" js_putchar
-  :: Char -> IO ()
+foreign import javascript "console.log(String.fromCodePoint(${1}))"
+  js_putchar :: Char -> IO ()
 
 foreign import javascript "${1} * ${2}" js_mult :: Int -> Int -> Int
 
 foreign import javascript "console.log(${1})" print_int :: Int -> IO ()
 
-foreign import javascript "${1}" js_stableptr_id
-  :: StablePtr Int -> IO (StablePtr Int)
+foreign import javascript "${1}"
+  js_stableptr_id :: StablePtr Int -> IO (StablePtr Int)
 
 foreign import javascript "false" js_false :: Bool
 
@@ -41,9 +41,9 @@ main = do
   print_int x
   x' <- newStablePtr 233 >>= js_stableptr_id >>= deRefStablePtr
   print_int x'
-  js_print $
-    toJSString $
-    fromJSString $ toJSString "I AM A STRING THAT LEAPS BETWEEN HEAPS"
+  js_print $ toJSString $ fromJSString $
+    toJSString
+      "I AM A STRING THAT LEAPS BETWEEN HEAPS"
   js_print $ toJSArray $ fromJSArray $ toJSArray [t, t, t]
   js_print $ callJSObjectMethod json "parse" [toJSString "{}"]
   print_int $ fromEnum js_false

--- a/asterius/test/largenum.hs
+++ b/asterius/test/largenum.hs
@@ -4,4 +4,6 @@ import System.Process
 main :: IO ()
 main = do
   args <- getArgs
-  callProcess "ahc-link" $ ["--input-hs", "test/largenum/largenum.hs", "--run"] <> args
+  callProcess "ahc-link" $
+    ["--input-hs", "test/largenum/largenum.hs", "--run"]
+      <> args

--- a/asterius/test/largenum/largenum.hs
+++ b/asterius/test/largenum/largenum.hs
@@ -3,21 +3,18 @@
 {-# OPTIONS_GHC -fforce-recomp -Wall -ddump-to-file -ddump-stg -ddump-cmm-raw -ddump-asm #-}
 
 import Control.DeepSeq
+import Control.Exception (throwIO)
 import Control.Monad.State.Strict
 import qualified Data.IntMap.Strict as IM
+import Debug.Trace (trace)
 import GHC.Generics
 import System.Mem
-import Control.Exception (throwIO)
-import Debug.Trace (trace)
 
 main :: IO ()
 main = do
-    let w = (18446744073709551614 :: Word)
-    print $ w
-    print $ (fromIntegral w :: Integer)
-
-    if show (fromIntegral w) /=  show w
+  let w = (18446744073709551614 :: Word)
+  print $ w
+  print $ (fromIntegral w :: Integer)
+  if show (fromIntegral w) /= show w
     then throwIO . userError $ "cannot create Integer from large Word"
     else pure ()
-
-

--- a/asterius/test/nir-test.hs
+++ b/asterius/test/nir-test.hs
@@ -14,23 +14,21 @@ main :: IO ()
 main = do
   c_BinaryenSetOptimizeLevel 0
   c_BinaryenSetShrinkLevel 0
-  m <-
-    withPool $ \pool ->
-      marshalModule pool $
-      Module
-        { functionMap' =
-            [ ( "func"
-              , Function (FunctionType [] [I32]) [I32, I64, I64, I32] $
-                Block
-                  mempty
-                  [Block mempty [Block mempty [GetLocal 3 I32] [I32]] [I32]]
-                  [I32])
-            ]
-        , functionImports = []
-        , functionExports = []
-        , functionTable = FunctionTable [] ""
-        , memory = Memory 1 mempty mempty
-        }
+  m <- withPool $ \pool -> marshalModule pool $ Module
+    { functionMap' =
+        [ ( "func",
+            Function (FunctionType [] [I32]) [I32, I64, I64, I32] $
+              Block
+                mempty
+                [Block mempty [Block mempty [GetLocal 3 I32] [I32]] [I32]]
+                [I32]
+          )
+        ],
+      functionImports = [],
+      functionExports = [],
+      functionTable = FunctionTable [] "",
+      memory = Memory 1 mempty mempty
+    }
   c_BinaryenModuleValidate m >>= print
   buf <- LBS.fromStrict <$> serializeModule m
   let r = runGet Wasm.getModule buf

--- a/asterius/test/node-compile.hs
+++ b/asterius/test/node-compile.hs
@@ -16,8 +16,6 @@ import qualified Data.Map.Strict as Map
 import Foreign
 import GHC.Exts
 import qualified Language.WebAssembly.WireFormat as Wasm
-import qualified Prelude
-import Prelude hiding (IO)
 import System.Directory
 import System.Exit
 import System.FilePath
@@ -25,135 +23,139 @@ import System.IO hiding (IO)
 import System.Process
 import Test.QuickCheck
 import Test.QuickCheck.Monadic
+import Prelude hiding (IO)
+import qualified Prelude
 
 type Shrink a = a -> FList.FList a
 
 preserve :: a -> Shrink a -> Shrink a
-preserve def f a = FList.snoc r def
-  where
-    r = f a
+preserve def f a = FList.snoc r def where r = f a
 
 shrinkExpression :: Shrink Expression
-shrinkExpression =
-  preserve Unreachable $ \expr ->
-    case expr of
-      Block {..} -> do
-        _new_bodys <- traverse shrinkExpression bodys
-        pure expr {bodys = _new_bodys}
-      If {..} -> do
-        _new_ifTrue <- shrinkExpression ifTrue
-        _new_ifFalse <- shrinkMaybeExpression ifFalse
-        pure expr {ifTrue = _new_ifTrue, ifFalse = _new_ifFalse}
-      Loop {..} -> do
-        _new_body <- shrinkExpression body
-        pure Loop {name = name, body = _new_body}
-      Break {..} -> do
-        _new_condition <- shrinkMaybeExpression breakCondition
-        pure Break {name = name, breakCondition = _new_condition}
-      Switch {..} -> do
-        _new_condition <- shrinkExpression condition
-        pure
-          Switch
-            { names = names
-            , defaultName = defaultName
-            , condition = _new_condition
-            }
-      Call {..} -> do
-        _new_operands <- traverse shrinkExpression operands
-        pure expr {operands = _new_operands}
-      CallImport {..} -> do
-        _new_operands <- traverse shrinkExpression operands
-        pure expr {operands = _new_operands}
-      CallIndirect {..} -> do
-        _new_indirect_target <- shrinkExpression indirectTarget
-        _new_operands <- traverse shrinkExpression operands
-        pure
-          expr {indirectTarget = _new_indirect_target, operands = _new_operands}
-      SetLocal {..} -> do
-        _new_value <- shrinkExpression value
-        pure expr {value = _new_value}
-      Load {..} -> do
-        _new_ptr <- shrinkExpression ptr
-        pure expr {ptr = _new_ptr}
-      Store {..} -> do
-        _new_ptr <- shrinkExpression ptr
-        _new_value <- shrinkExpression value
-        pure expr {ptr = _new_ptr, value = _new_value}
-      Unary {..} -> do
-        _new_operand0 <- shrinkExpression operand0
-        pure expr {operand0 = _new_operand0}
-      Binary {..} -> do
-        _new_operand0 <- shrinkExpression operand0
-        _new_operand1 <- shrinkExpression operand1
-        pure expr {operand0 = _new_operand0, operand1 = _new_operand1}
-      Host {..} -> do
-        _new_operands <- traverse shrinkExpression operands
-        pure expr {operands = _new_operands}
-      _ -> mempty
+shrinkExpression = preserve Unreachable $ \expr -> case expr of
+  Block {..} -> do
+    _new_bodys <- traverse shrinkExpression bodys
+    pure expr {bodys = _new_bodys}
+  If {..} -> do
+    _new_ifTrue <- shrinkExpression ifTrue
+    _new_ifFalse <- shrinkMaybeExpression ifFalse
+    pure expr {ifTrue = _new_ifTrue, ifFalse = _new_ifFalse}
+  Loop {..} -> do
+    _new_body <- shrinkExpression body
+    pure Loop {name = name, body = _new_body}
+  Break {..} -> do
+    _new_condition <- shrinkMaybeExpression breakCondition
+    pure Break {name = name, breakCondition = _new_condition}
+  Switch {..} -> do
+    _new_condition <- shrinkExpression condition
+    pure Switch
+      { names = names,
+        defaultName = defaultName,
+        condition = _new_condition
+      }
+  Call {..} -> do
+    _new_operands <- traverse shrinkExpression operands
+    pure expr {operands = _new_operands}
+  CallImport {..} -> do
+    _new_operands <- traverse shrinkExpression operands
+    pure expr {operands = _new_operands}
+  CallIndirect {..} -> do
+    _new_indirect_target <- shrinkExpression indirectTarget
+    _new_operands <- traverse shrinkExpression operands
+    pure
+      expr
+        { indirectTarget = _new_indirect_target,
+          operands = _new_operands
+        }
+  SetLocal {..} -> do
+    _new_value <- shrinkExpression value
+    pure expr {value = _new_value}
+  Load {..} -> do
+    _new_ptr <- shrinkExpression ptr
+    pure expr {ptr = _new_ptr}
+  Store {..} -> do
+    _new_ptr <- shrinkExpression ptr
+    _new_value <- shrinkExpression value
+    pure expr {ptr = _new_ptr, value = _new_value}
+  Unary {..} -> do
+    _new_operand0 <- shrinkExpression operand0
+    pure expr {operand0 = _new_operand0}
+  Binary {..} -> do
+    _new_operand0 <- shrinkExpression operand0
+    _new_operand1 <- shrinkExpression operand1
+    pure expr {operand0 = _new_operand0, operand1 = _new_operand1}
+  Host {..} -> do
+    _new_operands <- traverse shrinkExpression operands
+    pure expr {operands = _new_operands}
+  _ -> mempty
 
 shrinkMaybeExpression :: Shrink (Maybe Expression)
-shrinkMaybeExpression =
-  preserve Nothing $ \case
-    Just expr -> Just <$> shrinkExpression expr
-    _ -> mempty
+shrinkMaybeExpression = preserve Nothing $ \case
+  Just expr -> Just <$> shrinkExpression expr
+  _ -> mempty
 
 shrinkModule' :: Shrink Module
 shrinkModule' m@Module {..} = _shrink_funcs {-_shrink_memory <> _shrink_exports <>-}
   where
     _shrink_memory, _shrink_exports, _shrink_funcs :: FList.FList Module
-    _shrink_memory =
-      case memory of
-        Memory {..}
-          | not (SBS.null memoryExportName) || not (null dataSegments) ->
-            pure
-              m
-                { memory =
-                    memory {memoryExportName = mempty, dataSegments = mempty}
-                }
-          | otherwise -> mempty
+    _shrink_memory = case memory of
+      Memory {..}
+        | not (SBS.null memoryExportName) || not (null dataSegments) ->
+          pure
+            m
+              { memory = memory {memoryExportName = mempty, dataSegments = mempty}
+              }
+        | otherwise -> mempty
     _shrink_exports
       | not (null functionExports) = pure m {functionExports = []}
       | otherwise = mempty
     _shrink_funcs = do
       let (_function_map_no_shrink, _function_map_to_shrink) =
             Map.partition
-              (\Function {..} ->
-                 case body of
-                   Unreachable -> True
-                   _ -> False)
+              ( \Function {..} -> case body of
+                  Unreachable -> True
+                  _ -> False
+              )
               functionMap'
-      (do (_func_to_shrink_key, Function {..}) <-
-            fromList $ toList _function_map_to_shrink
+      ( do
+          (_func_to_shrink_key, Function {..}) <-
+            fromList $
+              toList _function_map_to_shrink
           pure
             m
               { functionMap' =
-                  _function_map_no_shrink <>
-                  Map.insert
-                    _func_to_shrink_key
-                    Function
-                      { functionType = functionType
-                      , varTypes = varTypes
-                      , body = Unreachable
-                      }
-                    _function_map_to_shrink
-              }) <>
-        (do (_func_to_shrink_key, Function {..}) <-
-              fromList $ toList _function_map_to_shrink
-            _shrink_expr <-
-              fromList $ filter (/= body) (toList (shrinkExpression body))
-            pure
-              m
-                { functionMap' =
-                    _function_map_no_shrink <>
-                    Map.insert
+                  _function_map_no_shrink
+                    <> Map.insert
                       _func_to_shrink_key
                       Function
-                        { functionType = functionType
-                        , varTypes = varTypes
-                        , body = _shrink_expr
+                        { functionType = functionType,
+                          varTypes = varTypes,
+                          body = Unreachable
                         }
                       _function_map_to_shrink
-                })
+              }
+        )
+        <> ( do
+               (_func_to_shrink_key, Function {..}) <-
+                 fromList $
+                   toList _function_map_to_shrink
+               _shrink_expr <-
+                 fromList $
+                   filter (/= body) (toList (shrinkExpression body))
+               pure
+                 m
+                   { functionMap' =
+                       _function_map_no_shrink
+                         <> Map.insert
+                           _func_to_shrink_key
+                           Function
+                             { functionType = functionType,
+                               varTypes = varTypes,
+                               body = _shrink_expr
+                             }
+                           _function_map_to_shrink
+                   }
+           )
 
 shrinkModule :: Module -> [Module]
 shrinkModule = toList . shrinkModule'
@@ -162,67 +164,66 @@ type Backend = (String, Module -> Prelude.IO LBS.ByteString)
 
 binaryenBackend, wasmToolkitBackend :: Backend
 binaryenBackend =
-  ( "binaryen"
-  , \m ->
-      withPool $ \pool ->
-        fmap LBS.fromStrict $
-        OldMarshal.marshalModule pool m >>= OldMarshal.serializeModule)
-
+  ( "binaryen",
+    \m -> withPool $ \pool ->
+      fmap LBS.fromStrict $
+        OldMarshal.marshalModule pool m
+          >>= OldMarshal.serializeModule
+  )
 wasmToolkitBackend =
-  ( "wasm-toolkit"
-  , \m ->
-      case runExcept (NewMarshal.makeModule m) of
-        Left err -> throwIO err
-        Right r -> pure $ runPut $ Wasm.putModule r)
+  ( "wasm-toolkit",
+    \m -> case runExcept (NewMarshal.makeModule m) of
+      Left err -> throwIO err
+      Right r -> pure $ runPut $ Wasm.putModule r
+  )
 
 testNodeCompile :: Backend -> Module -> Property
-testNodeCompile (backend_tag, backend) m =
-  monadicIO $ do
-    _result <-
-      run $ do
-        tmpdir <- getTemporaryDirectory
-        bracket
-          (openBinaryTempFile tmpdir "wasm-toolkit-test.wasm")
-          (\(p, _) -> removeFile p)
-          (\(p, h) -> do
-             buf <- backend m
-             LBS.hPut h buf
-             hClose h
-             (_exit_code, _stdout, _stderr) <-
-               readProcessWithExitCode
-                 "node"
-                 ["test" </> "node-compile" </> "node-compile.js", p]
-                 ""
-             case _exit_code of
-               ExitSuccess -> pure Nothing
-               _ -> do
-                 (p_err, h_err) <-
-                   openTempFile tmpdir "wasm-toolkit-test-dump.bin"
-                 LBS.hPut h_err $ encode m
-                 hClose h_err
-                 pure $ Just (_exit_code, _stdout, _stderr, p_err))
-    case _result of
-      Just (_exit_code, _stdout, _stderr, p_err) ->
-        fail $
-        "Compiling serialized module via " <> backend_tag <>
-        " backend failed.\nExit code: " <>
-        show _exit_code <>
-        "\nStdout: " <>
-        _stdout <>
-        "\nStderr: " <>
-        _stderr <>
-        "\nModule binary dump path: " <>
-        p_err
-      _ -> pure ()
+testNodeCompile (backend_tag, backend) m = monadicIO $ do
+  _result <- run $ do
+    tmpdir <- getTemporaryDirectory
+    bracket
+      (openBinaryTempFile tmpdir "wasm-toolkit-test.wasm")
+      (\(p, _) -> removeFile p)
+      ( \(p, h) -> do
+          buf <- backend m
+          LBS.hPut h buf
+          hClose h
+          (_exit_code, _stdout, _stderr) <-
+            readProcessWithExitCode
+              "node"
+              ["test" </> "node-compile" </> "node-compile.js", p]
+              ""
+          case _exit_code of
+            ExitSuccess -> pure Nothing
+            _ -> do
+              (p_err, h_err) <- openTempFile tmpdir "wasm-toolkit-test-dump.bin"
+              LBS.hPut h_err $ encode m
+              hClose h_err
+              pure $ Just (_exit_code, _stdout, _stderr, p_err)
+      )
+  case _result of
+    Just (_exit_code, _stdout, _stderr, p_err) ->
+      fail $
+        "Compiling serialized module via "
+          <> backend_tag
+          <> " backend failed.\nExit code: "
+          <> show _exit_code
+          <> "\nStdout: "
+          <> _stdout
+          <> "\nStderr: "
+          <> _stderr
+          <> "\nModule binary dump path: "
+          <> p_err
+    _ -> pure ()
 
 testNodeCompileWithShrink ::
-     Backend -> (Module -> [Module]) -> Module -> Property
+  Backend -> (Module -> [Module]) -> Module -> Property
 testNodeCompileWithShrink backend s m = shrinking s m $ testNodeCompile backend
 
 testNodeCompileBoth :: (Module -> [Module]) -> Module -> Property
 testNodeCompileBoth s m =
-  testNodeCompileWithShrink binaryenBackend s m .&&.
-  testNodeCompileWithShrink wasmToolkitBackend s m
+  testNodeCompileWithShrink binaryenBackend s m
+    .&&. testNodeCompileWithShrink wasmToolkitBackend s m
 
 main :: IO ()
 main = do

--- a/asterius/test/nodeio.hs
+++ b/asterius/test/nodeio.hs
@@ -23,7 +23,7 @@ main = do
         { pipeRead = host_read_handle,
           pipeWrite = host_write_handle,
           pipeLeftovers = lo_ref
-          }
+        }
   setEnv "ASTERIUS_NODE_READ_FD" (show node_read_fd) True
   setEnv "ASTERIUS_NODE_WRITE_FD" (show node_write_fd) True
   args <- getArgs
@@ -36,7 +36,7 @@ main = do
           "--binaryen",
           "--verbose-err",
           "--run"
-          ]
+        ]
         <> args
   (r :: CBS.ByteString) <- readPipe p get
   print r

--- a/asterius/test/nodeio/nodeio.hs
+++ b/asterius/test/nodeio/nodeio.hs
@@ -13,14 +13,16 @@ import System.IO
 main :: IO ()
 main = do
   read_handle <-
-    fdToHandle' (fromIntegral read_fd)
+    fdToHandle'
+      (fromIntegral read_fd)
       (Just Stream)
       False
       ""
       ReadMode
       True
   write_handle <-
-    fdToHandle' (fromIntegral write_fd)
+    fdToHandle'
+      (fromIntegral write_fd)
       (Just Stream)
       False
       ""
@@ -33,11 +35,13 @@ main = do
         { pipeRead = read_handle,
           pipeWrite = write_handle,
           pipeLeftovers = lo_ref
-          }
+        }
   (r :: CBS.ByteString) <- readPipe p get
   print r
   writePipe p (put (CBS.pack "ELINA"))
 
-foreign import javascript "Number(process.env.ASTERIUS_NODE_READ_FD)" read_fd :: Int
+foreign import javascript "Number(process.env.ASTERIUS_NODE_READ_FD)"
+  read_fd :: Int
 
-foreign import javascript "Number(process.env.ASTERIUS_NODE_WRITE_FD)" write_fd :: Int
+foreign import javascript "Number(process.env.ASTERIUS_NODE_WRITE_FD)"
+  write_fd :: Int

--- a/asterius/test/nomain.hs
+++ b/asterius/test/nomain.hs
@@ -11,20 +11,21 @@ import System.Process
 main :: IO ()
 main = do
   args <- getArgs
-  callProcess "ahc-link"
-    $ [ "--input-hs",
-        "test/nomain/NoMain.hs",
-        "--output-ir",
-        "--full-sym-table",
-        "--ghc-option=-no-hs-main",
-        "--extra-root-symbol=NoMain_x_closure",
-        "--no-gc-sections"
-      ]
+  callProcess "ahc-link" $
+    [ "--input-hs",
+      "test/nomain/NoMain.hs",
+      "--output-ir",
+      "--full-sym-table",
+      "--ghc-option=-no-hs-main",
+      "--extra-root-symbol=NoMain_x_closure",
+      "--no-gc-sections"
+    ]
       <> args
   m <- decodeFile "test/nomain/NoMain.unlinked.bin"
   withJSSession defJSSessionOpts {nodeStdErrInherit = True} $ \s -> do
     i <-
-      newAsteriusInstanceNonMain s
+      newAsteriusInstanceNonMain
+        s
         "test/nomain/NoMain"
         ["NoMain_x_closure"]
         m

--- a/asterius/test/parsec.hs
+++ b/asterius/test/parsec.hs
@@ -5,4 +5,5 @@ main :: IO ()
 main = do
   args <- getArgs
   callProcess "ahc-link" $
-    ["--input-hs", "test/parsec/parsec.hs", "--run"] <> args
+    ["--input-hs", "test/parsec/parsec.hs", "--run"]
+      <> args

--- a/asterius/test/parsec/parsec.hs
+++ b/asterius/test/parsec/parsec.hs
@@ -1,44 +1,32 @@
-import Text.Parsec
-import Text.Parsec.Combinator
-import Text.Parsec.Token
-import Text.Parsec.Prim
 import Asterius.Types
 import Data.Coerce
 import Numeric
+import Text.Parsec
+import Text.Parsec.Combinator
+import Text.Parsec.Prim
+import Text.Parsec.Token
 
 foreign import javascript "console.log(${1})" js_print :: JSVal -> IO ()
 
 main :: IO ()
 main = do
-   let
-      js_print_string :: String -> IO ()
+  let js_print_string :: String -> IO ()
       js_print_string s = js_print (coerce (toJSString s))
-
       parenSet = char '(' >> many parenSet >> char ')' :: Parsec String () Char
       parens = (many parenSet >> eof) <|> eof
-
-   js_print_string $ show $ parse parens "" "()"
-
-   -- example adapted from http://book.realworldhaskell.org/read/using-parsec.html (by-nc 3.0)
-   let
-      p_query = p_pair `sepBy` char '&'
-
+  js_print_string $ show $ parse parens "" "()"
+  -- example adapted from http://book.realworldhaskell.org/read/using-parsec.html (by-nc 3.0)
+  let p_query = p_pair `sepBy` char '&'
       p_pair = do
-         name <- many1 p_char
-         value <- optionMaybe (char '=' >> many p_char)
-         return (name, value)
-
-      p_char = oneOf urlBaseChars
-           <|> (char '+' >> return ' ')
-           <|> p_hex
-
-      urlBaseChars = ['a'..'z']++['A'..'Z']++['0'..'9']++"$-_.!*'(),"
-
+        name <- many1 p_char
+        value <- optionMaybe (char '=' >> many p_char)
+        return (name, value)
+      p_char = oneOf urlBaseChars <|> (char '+' >> return ' ') <|> p_hex
+      urlBaseChars = ['a' .. 'z'] ++ ['A' .. 'Z'] ++ ['0' .. '9'] ++ "$-_.!*'(),"
       p_hex = do
-         char '%'
-         a <- hexDigit
-         b <- hexDigit
-         let ((d, _):_) = readHex [a,b]
-         return . toEnum $ d
-
-   js_print_string $ show $ parse p_query "" "foo=bar&a%21=b+c"
+        char '%'
+        a <- hexDigit
+        b <- hexDigit
+        let ((d, _) : _) = readHex [a, b]
+        return . toEnum $ d
+  js_print_string $ show $ parse p_query "" "foo=bar&a%21=b+c"

--- a/asterius/test/regression60.hs
+++ b/asterius/test/regression60.hs
@@ -5,4 +5,5 @@ main :: IO ()
 main = do
   args <- getArgs
   callProcess "ahc-link" $
-    ["--input-hs", "test/regression60/regression60.hs", "--run"] <> args
+    ["--input-hs", "test/regression60/regression60.hs", "--run"]
+      <> args

--- a/asterius/test/regression60/regression60.hs
+++ b/asterius/test/regression60/regression60.hs
@@ -1,12 +1,14 @@
 {-# OPTIONS_GHC -fforce-recomp #-}
 
 module Main where
+
+import Control.Exception
+  ( assert,
+    throwIO,
+  )
+import Control.Monad (forM_)
 import Data.Char
-import Control.Exception (assert, throwIO)
 import GHC.Char (chr)
-import Control.Monad(forM_)
-
-
 
 assert_ :: String -> Bool -> IO ()
 assert_ s True = return ()
@@ -14,17 +16,15 @@ assert_ s False = throwIO $ userError s
 
 main :: IO ()
 main = do
-   -- Once we get top-level exceptions working, this will print a good
-   -- correct error message!
-   assert_ "read 21" $ (read "21" :: Int) == 21
-   assert_ "generalCategory of 2" $ generalCategory '2' == DecimalNumber
-   assert_ "generalCategory of a" $ generalCategory 'a' == LowercaseLetter
-   assert_ "generalCategory of A" $ generalCategory 'A' == UppercaseLetter
-
-   assert_ "tolower of A" $ toLower 'A' == 'a'
-   assert_ "tolower of a" $ toLower 'a' == 'a'
-   assert_ "tolower of 1" $ toLower '1' == '1'
-
-   assert_ "toupper of A" $ toUpper 'A' == 'A'
-   assert_ "toupper of a" $ toUpper 'a' == 'A'
-   assert_ "toupper of 1" $ toUpper '1' == '1'
+  assert_ "read 21" $ (read "21" :: Int) == 21
+  assert_ "generalCategory of 2" $ generalCategory '2' == DecimalNumber
+  assert_ "generalCategory of a" $ generalCategory 'a' == LowercaseLetter
+  assert_ "generalCategory of A" $ generalCategory 'A' == UppercaseLetter
+  assert_ "tolower of A" $ toLower 'A' == 'a'
+  assert_ "tolower of a" $ toLower 'a' == 'a'
+  assert_ "tolower of 1" $ toLower '1' == '1'
+  assert_ "toupper of A" $ toUpper 'A' == 'A'
+  assert_ "toupper of a" $ toUpper 'a' == 'A'
+  assert_ "toupper of 1" $ toUpper '1' == '1'
+-- Once we get top-level exceptions working, this will print a good
+-- correct error message!

--- a/asterius/test/rts.hs
+++ b/asterius/test/rts.hs
@@ -4,11 +4,9 @@ import System.Process
 main :: IO ()
 main = do
   args <- getArgs
+  callProcess "ahc-link" $ ["--input-hs", "test/rts/MVar.hs", "--run"] <> args
+  callProcess "ahc-link" $ ["--input-hs", "test/rts/FFI.hs", "--run"] <> args
   callProcess "ahc-link" $
-    ["--input-hs", "test/rts/MVar.hs", "--run"] <> args
-  callProcess "ahc-link" $
-    ["--input-hs", "test/rts/FFI.hs", "--run"] <> args
-  callProcess "ahc-link" $
-    ["--input-hs", "test/rts/ThreadDelay.hs", "--run"] <> args
-  callProcess "ahc-link" $
-    ["--input-hs", "test/rts/ForkIO.hs", "--run"] <> args
+    ["--input-hs", "test/rts/ThreadDelay.hs", "--run"]
+      <> args
+  callProcess "ahc-link" $ ["--input-hs", "test/rts/ForkIO.hs", "--run"] <> args

--- a/asterius/test/rts/FFI.hs
+++ b/asterius/test/rts/FFI.hs
@@ -1,12 +1,13 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 import Asterius.Types
-import Data.Coerce
 import Control.Concurrent
-import Control.Monad
 import Control.Exception
+import Control.Monad
+import Data.Coerce
 
 foreign import javascript "console.log(${1})" js_print :: JSVal -> IO ()
+
 foreign import javascript safe "(() => {throw 'FAILED'})()" js_failed :: IO ()
 
 printString :: String -> IO ()
@@ -14,5 +15,5 @@ printString s = js_print (coerce (toJSString s))
 
 main :: IO ()
 main = do
-   js_failed `catch` \(e :: JSException) -> do
-      printString ("Exception caught in safe FFI: " ++ show e)
+  js_failed `catch` \(e :: JSException) -> do
+    printString ("Exception caught in safe FFI: " ++ show e)

--- a/asterius/test/rts/ForkIO.hs
+++ b/asterius/test/rts/ForkIO.hs
@@ -1,7 +1,7 @@
 import Asterius.Types
-import Data.Coerce
 import Control.Concurrent
 import Control.Monad
+import Data.Coerce
 
 foreign import javascript "console.log(${1})" js_print :: JSVal -> IO ()
 
@@ -10,20 +10,15 @@ printString s = js_print (coerce (toJSString s))
 
 main :: IO ()
 main = do
-   let ps s = do
-         tid <- myThreadId
-         printString (show tid <> ": " <> s)
-
-   ps "Hello"
-
-   forkIO $ do
-      threadDelay 2000000
-      ps "world"
-      threadDelay 3000000
-      ps "Don't forget me!"
-      
-   threadDelay 4000000
-   ps "of (forked) delays!"
-
-   replicateM_ 10 $ forkIO $ ps "Hi!"
-
+  let ps s = do
+        tid <- myThreadId
+        printString (show tid <> ": " <> s)
+  ps "Hello"
+  forkIO $ do
+    threadDelay 2000000
+    ps "world"
+    threadDelay 3000000
+    ps "Don't forget me!"
+  threadDelay 4000000
+  ps "of (forked) delays!"
+  replicateM_ 10 $ forkIO $ ps "Hi!"

--- a/asterius/test/rts/MVar.hs
+++ b/asterius/test/rts/MVar.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE LambdaCase #-}
 
 import Asterius.Types
-import Data.Coerce
 import Control.Concurrent
 import Control.Concurrent.MVar
 import Control.Monad
+import Data.Coerce
 import System.Mem
 
 foreign import javascript "console.log(${1})" js_print :: JSVal -> IO ()
@@ -14,38 +14,29 @@ printString s = js_print (coerce (toJSString s))
 
 main :: IO ()
 main = do
-   let ps s = do
-         tid <- myThreadId
-         printString (show tid <> ": " <> s)
-
-   mvar <- newEmptyMVar
-
-   ps "Creating workers"
-
-   forkIO $ do
-      ps "Working..."
-      threadDelay 4000000
-      ps "Writing result"
-      tid <- myThreadId
-      putMVar mvar tid
-
-   forkIO $ do
-      ps "Working..."
-      threadDelay 3000000
-      ps "Writing result"
-      tid <- myThreadId
-      putMVar mvar tid
-
-   ps "Waiting for results"
-      
-   v1 <- takeMVar mvar
-   ps ("First result: " <> show v1)
-
-   v2 <- takeMVar mvar
-   ps ("Second result: " <> show v2)
-
-   forkIO $ do
-      v3 <- takeMVar mvar
-      ps ("WAT? " ++ show v3)
-
-   performGC
+  let ps s = do
+        tid <- myThreadId
+        printString (show tid <> ": " <> s)
+  mvar <- newEmptyMVar
+  ps "Creating workers"
+  forkIO $ do
+    ps "Working..."
+    threadDelay 4000000
+    ps "Writing result"
+    tid <- myThreadId
+    putMVar mvar tid
+  forkIO $ do
+    ps "Working..."
+    threadDelay 3000000
+    ps "Writing result"
+    tid <- myThreadId
+    putMVar mvar tid
+  ps "Waiting for results"
+  v1 <- takeMVar mvar
+  ps ("First result: " <> show v1)
+  v2 <- takeMVar mvar
+  ps ("Second result: " <> show v2)
+  forkIO $ do
+    v3 <- takeMVar mvar
+    ps ("WAT? " ++ show v3)
+  performGC

--- a/asterius/test/rts/ThreadDelay.hs
+++ b/asterius/test/rts/ThreadDelay.hs
@@ -1,6 +1,6 @@
 import Asterius.Types
-import Data.Coerce
 import Control.Concurrent
+import Data.Coerce
 
 foreign import javascript "console.log(${1})" js_print :: JSVal -> IO ()
 
@@ -9,9 +9,8 @@ printString s = js_print (coerce (toJSString s))
 
 main :: IO ()
 main = do
-   printString "Hello"
-   threadDelay 2000000
-   printString "world"
-   threadDelay 2000000
-   printString "of delays!"
-
+  printString "Hello"
+  threadDelay 2000000
+  printString "world"
+  threadDelay 2000000
+  printString "of delays!"

--- a/asterius/test/rtsapi.hs
+++ b/asterius/test/rtsapi.hs
@@ -5,14 +5,14 @@ main :: IO ()
 main = do
   args <- getArgs
   callProcess "ahc-link" $
-    [ "--input-hs"
-    , "test/rtsapi/rtsapi.hs"
-    , "--input-mjs"
-    , "test/rtsapi/rtsapi.mjs"
-    , "--run"
-    , "--extra-root-symbol=Main_printInt_closure"
-    , "--extra-root-symbol=Main_fact_closure"
-    , "--extra-root-symbol=base_GHCziBase_id_closure"
-    , "--full-sym-table"
-    ] <>
-    args
+    [ "--input-hs",
+      "test/rtsapi/rtsapi.hs",
+      "--input-mjs",
+      "test/rtsapi/rtsapi.mjs",
+      "--run",
+      "--extra-root-symbol=Main_printInt_closure",
+      "--extra-root-symbol=Main_fact_closure",
+      "--extra-root-symbol=base_GHCziBase_id_closure",
+      "--full-sym-table"
+    ]
+      <> args

--- a/asterius/test/rtsapi/rtsapi.hs
+++ b/asterius/test/rtsapi/rtsapi.hs
@@ -1,10 +1,11 @@
 {-# OPTIONS_GHC -Wall -ddump-to-file -ddump-stg -ddump-cmm-raw -ddump-asm #-}
 
 module Main
-  ( printInt
-  , fact
-  , main
-  ) where
+  ( printInt,
+    fact,
+    main,
+  )
+where
 
 foreign import javascript "console.log(${1})" js_print_int :: Int -> IO ()
 

--- a/asterius/test/sizeof_md5context.hs
+++ b/asterius/test/sizeof_md5context.hs
@@ -4,4 +4,6 @@ import System.Process
 main :: IO ()
 main = do
   args <- getArgs
-  callProcess "ahc-link" $ ["--input-hs", "test/sizeof_md5context/sizeof_md5context.hs", "--run"] <> args
+  callProcess "ahc-link" $
+    ["--input-hs", "test/sizeof_md5context/sizeof_md5context.hs", "--run"]
+      <> args

--- a/asterius/test/sizeof_md5context/sizeof_md5context.hs
+++ b/asterius/test/sizeof_md5context/sizeof_md5context.hs
@@ -1,30 +1,31 @@
 {-# LANGUAGE CPP #-}
 
 #include "HsBaseConfig.h"
+
 import Control.Exception (assert)
+import Control.Monad
+import Foreign
+import Foreign.C
+import Foreign.Marshal.Alloc
 import GHC.Fingerprint
 import GHC.Num
-import Foreign.C
-import Foreign
-import Control.Monad
-import Foreign.Marshal.Alloc
 
 data MD5Context
 
-foreign import ccall unsafe "__hsbase_MD5Init"
-   c_MD5Init   :: Ptr MD5Context -> IO ()
-foreign import ccall unsafe "__hsbase_MD5Update"
-   c_MD5Update :: Ptr MD5Context -> Ptr Word8 -> CInt -> IO ()
-foreign import ccall unsafe "__hsbase_MD5Final"
-   c_MD5Final  :: Ptr Word8 -> Ptr MD5Context -> IO ()
+foreign import ccall unsafe "__hsbase_MD5Init" c_MD5Init
+  :: Ptr MD5Context -> IO ()
 
-dataPart1:: [Word8]
+foreign import ccall unsafe "__hsbase_MD5Update" c_MD5Update
+  :: Ptr MD5Context -> Ptr Word8 -> CInt -> IO ()
+
+foreign import ccall unsafe "__hsbase_MD5Final" c_MD5Final
+  :: Ptr Word8 -> Ptr MD5Context -> IO ()
+
+dataPart1 :: [Word8]
 dataPart1 = [fromIntegral 1]
 
-
-dataPart2:: [Word8]
+dataPart2 :: [Word8]
 dataPart2 = [fromIntegral 3]
-
 
 -- | Use single call to c_MD5Update`
 singleShot :: IO Fingerprint
@@ -50,22 +51,15 @@ twoShot = do
       c_MD5Final pdigest pctxt
       peek (castPtr pdigest :: Ptr Fingerprint)
 
-
 main :: IO ()
 main = do
-  assert (SIZEOF_STRUCT_MD5CONTEXT  == (88 :: Int)) (pure ())
-  forM_ [1..10] $ \i -> print $ fingerprintString (replicate i ' ')
-
+  assert (SIZEOF_STRUCT_MD5CONTEXT == (88 :: Int)) (pure ())
+  forM_ [1 .. 10] $ \i -> print $ fingerprintString (replicate i ' ')
   -- | Ensure that calling c_MD5Update actually saves the state in the context.
   -- | So, have one invocation of calling it once, and another invocation of
   -- | calling it in two sequential invocations. Check that the result is the
   -- | same
-
   fingerprint1 <- singleShot
   fingerprint2 <- twoShot
-
   print (fingerprint1, fingerprint2)
   assert (fingerprint1 == fingerprint2) (pure ())
-
-
-

--- a/asterius/test/stableptr.hs
+++ b/asterius/test/stableptr.hs
@@ -5,4 +5,5 @@ main :: IO ()
 main = do
   args <- getArgs
   callProcess "ahc-link" $
-    ["--input-hs", "test/stableptr/stableptr.hs", "--run"] <> args
+    ["--input-hs", "test/stableptr/stableptr.hs", "--run"]
+      <> args

--- a/asterius/test/stableptr/stableptr.hs
+++ b/asterius/test/stableptr/stableptr.hs
@@ -8,7 +8,7 @@ foreign import ccall unsafe "print_i64" print_i64 :: Int -> IO ()
 
 main :: IO ()
 main = do
-  sps <- for [233..250] newStablePtr
+  sps <- for [233 .. 250] newStablePtr
   xs <- for sps deRefStablePtr
   for_ xs print_i64
   for_ sps freeStablePtr

--- a/asterius/test/teletype.hs
+++ b/asterius/test/teletype.hs
@@ -5,4 +5,5 @@ main :: IO ()
 main = do
   args <- getArgs
   callProcess "ahc-link" $
-    ["--input-hs", "test/teletype/teletype.hs", "--run"] <> args
+    ["--input-hs", "test/teletype/teletype.hs", "--run"]
+      <> args

--- a/asterius/test/teletype/teletype.hs
+++ b/asterius/test/teletype/teletype.hs
@@ -5,27 +5,27 @@ import Data.Char
 import Data.Coerce
 import System.IO
 
-foreign import javascript safe "(new Date()).toString() + String.fromCodePoint(0x10000)" js_get_str
-  :: IO JSString
+foreign import javascript safe "(new Date()).toString() + String.fromCodePoint(0x10000)"
+  js_get_str :: IO JSString
 
 foreign import javascript safe "['asdf', 'zer0']" js_get_arr :: IO JSArray
 
-foreign import javascript safe "(new Uint8Array([2, 3, 5, 7])).buffer" js_get_buf
-  :: IO JSArrayBuffer
+foreign import javascript safe "(new Uint8Array([2, 3, 5, 7])).buffer"
+  js_get_buf :: IO JSArrayBuffer
 
-foreign import javascript safe "console.log(new Uint8Array(${1}))" js_print_buf
-  :: JSArrayBuffer -> IO ()
+foreign import javascript safe "console.log(new Uint8Array(${1}))"
+  js_print_buf :: JSArrayBuffer -> IO ()
 
 foreign import javascript safe "console.log(${1})" js_print :: JSVal -> IO ()
 
-foreign import javascript safe "setTimeout(${1},${2},${3})" js_setTimeout
-  :: JSFunction -> Int -> JSVal -> IO ()
+foreign import javascript safe "setTimeout(${1},${2},${3})"
+  js_setTimeout :: JSFunction -> Int -> JSVal -> IO ()
 
-foreign import javascript safe "console.log([${1},${2}])" js_print2
-  :: JSVal -> JSVal -> IO ()
+foreign import javascript safe "console.log([${1},${2}])"
+  js_print2 :: JSVal -> JSVal -> IO ()
 
-foreign import javascript safe "setTimeout(${1},${2},${3},${4})" js_setTimeout2
-  :: JSFunction -> Int -> JSVal -> JSVal -> IO ()
+foreign import javascript safe "setTimeout(${1},${2},${3},${4})"
+  js_setTimeout2 :: JSFunction -> Int -> JSVal -> JSVal -> IO ()
 
 main :: IO ()
 main = do
@@ -35,9 +35,10 @@ main = do
     "The trouble with the world is that the stupid are cocksure and the intelligent are full of doubt."
   js_str <- js_get_str
   let hs_str = fromJSString js_str
-  js_print $
-    coerce $
-    toJSString $ "From Haskell: " <> hs_str <> " " <> show (ord (last hs_str))
+  js_print $ coerce $ toJSString $
+    "From Haskell: " <> hs_str <> " "
+      <> show
+        (ord (last hs_str))
   js_arr <- js_get_arr
   js_print $ coerce $ toJSArray $ fromJSArray js_arr
   js_buf <- js_get_buf

--- a/asterius/test/text.hs
+++ b/asterius/test/text.hs
@@ -4,5 +4,4 @@ import System.Process
 main :: IO ()
 main = do
   args <- getArgs
-  callProcess "ahc-link" $
-    ["--input-hs", "test/text/text.hs", "--run"] <> args
+  callProcess "ahc-link" $ ["--input-hs", "test/text/text.hs", "--run"] <> args

--- a/asterius/test/text/text.hs
+++ b/asterius/test/text/text.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
-import Data.Text as Text
+
 import Asterius.Types
-import Data.Coerce
-import qualified Data.Char as C
 import Control.Monad
+import qualified Data.Char as C
+import Data.Coerce
+import Data.Text as Text
 
 foreign import javascript "console.log(${1})" js_print_bool :: Bool -> IO ()
 
@@ -23,45 +24,36 @@ sampleText2 :: Text
 {-# NOINLINE sampleText2 #-}
 sampleText2 = Text.pack "Sample text number 2"
 
-
 main :: IO ()
 main = do
-   let js_print_string :: String -> IO ()
-       js_print_string s = js_print (coerce (toJSString s))
-
-       js_print_text :: Text -> IO ()
-       js_print_text t = js_print_string (Text.unpack t)
-
-   js_print_int (Text.length Text.empty)
-   let roundTrip = Text.unpack sampleText == sampleString
-   js_print_bool roundTrip
-
-   js_print_string (Text.unpack sampleText)
-   js_print_string (show sampleText)
-
-   js_print_bool (sampleText == sampleText2)
-   js_print_bool (sampleText == Text.copy sampleText)
-   js_print_bool (sampleText >= sampleText2)
-   js_print_bool (sampleText < sampleText2)
-
-   js_print_text (sampleText `Text.append` sampleText2)
-   js_print_text ('*' `Text.cons` sampleText)
-   js_print_text (sampleText `Text.snoc` '*')
-
-   js_print_text (Text.tail sampleText)
-   js_print_text (Text.init sampleText)
-   js_print_text (Text.map C.toUpper sampleText)
-   js_print_text (Text.intersperse '-' sampleText)
-   js_print_text (Text.intercalate " STOP " [sampleText,sampleText2])
-   js_print_text (Text.replace "ample" "uper" sampleText)
-
-   js_print_text (Text.toCaseFold sampleText2)
-   js_print_text (Text.toLower sampleText2)
-   js_print_text (Text.toUpper sampleText2)
-   js_print_text (Text.toTitle sampleText2)
-
-   js_print_text (Text.center 50 '~' sampleText)
-   js_print_text (Text.concat [sampleText, " -- ", sampleText2])
-   forM_ (Text.words sampleText2) js_print_text
-   js_print_text (Text.filter (`notElem` ("aeiouyAEIOUY" :: String)) sampleText)
-   js_print_text (Text.copy sampleText)
+  let js_print_string :: String -> IO ()
+      js_print_string s = js_print (coerce (toJSString s))
+      js_print_text :: Text -> IO ()
+      js_print_text t = js_print_string (Text.unpack t)
+  js_print_int (Text.length Text.empty)
+  let roundTrip = Text.unpack sampleText == sampleString
+  js_print_bool roundTrip
+  js_print_string (Text.unpack sampleText)
+  js_print_string (show sampleText)
+  js_print_bool (sampleText == sampleText2)
+  js_print_bool (sampleText == Text.copy sampleText)
+  js_print_bool (sampleText >= sampleText2)
+  js_print_bool (sampleText < sampleText2)
+  js_print_text (sampleText `Text.append` sampleText2)
+  js_print_text ('*' `Text.cons` sampleText)
+  js_print_text (sampleText `Text.snoc` '*')
+  js_print_text (Text.tail sampleText)
+  js_print_text (Text.init sampleText)
+  js_print_text (Text.map C.toUpper sampleText)
+  js_print_text (Text.intersperse '-' sampleText)
+  js_print_text (Text.intercalate " STOP " [sampleText, sampleText2])
+  js_print_text (Text.replace "ample" "uper" sampleText)
+  js_print_text (Text.toCaseFold sampleText2)
+  js_print_text (Text.toLower sampleText2)
+  js_print_text (Text.toUpper sampleText2)
+  js_print_text (Text.toTitle sampleText2)
+  js_print_text (Text.center 50 '~' sampleText)
+  js_print_text (Text.concat [sampleText, " -- ", sampleText2])
+  forM_ (Text.words sampleText2) js_print_text
+  js_print_text (Text.filter (`notElem` ("aeiouyAEIOUY" :: String)) sampleText)
+  js_print_text (Text.copy sampleText)

--- a/asterius/test/th/Fib.hs
+++ b/asterius/test/th/Fib.hs
@@ -1,6 +1,6 @@
 module Fib
-  ( fib
-    )
+  ( fib,
+  )
 where
 
 fib :: Int -> Int

--- a/asterius/test/th/th.hs
+++ b/asterius/test/th/th.hs
@@ -11,4 +11,4 @@ main =
          y <- newName "x"
          exts <- extsEnabled
          liftString $ show x <> ", " <> show y <> ", " <> show exts
-       )
+     )

--- a/asterius/test/todomvc.hs
+++ b/asterius/test/todomvc.hs
@@ -7,4 +7,5 @@ main = do
   args <- getArgs
   withCurrentDirectory "test/todomvc" $ callCommand "npm install"
   callProcess "ahc-link" $
-    ["--browser", "--bundle", "--input-hs", "test/todomvc/todomvc.hs"] <> args
+    ["--browser", "--bundle", "--input-hs", "test/todomvc/todomvc.hs"]
+      <> args

--- a/asterius/test/todomvc/ElementBuilder.hs
+++ b/asterius/test/todomvc/ElementBuilder.hs
@@ -2,10 +2,11 @@
 {-# LANGUAGE StrictData #-}
 
 module ElementBuilder
-  ( Element(..)
-  , emptyElement
-  , buildElement
-  ) where
+  ( Element (..),
+    emptyElement,
+    buildElement,
+  )
+where
 
 import Asterius.Types
 import Control.Monad
@@ -13,22 +14,23 @@ import Data.Foldable
 import WebAPI
 
 data Element
-  = Element { className :: String
-            , attributes :: [(String, String)]
-            , children :: [Element]
-            , hidden :: Bool
-            , eventHandlers :: [(String, JSObject -> IO ())] }
+  = Element
+      { className :: String,
+        attributes :: [(String, String)],
+        children :: [Element],
+        hidden :: Bool,
+        eventHandlers :: [(String, JSObject -> IO ())]
+      }
   | TextNode String
 
 emptyElement :: Element
-emptyElement =
-  Element
-    { className = ""
-    , attributes = mempty
-    , children = mempty
-    , hidden = False
-    , eventHandlers = mempty
-    }
+emptyElement = Element
+  { className = "",
+    attributes = mempty,
+    children = mempty,
+    hidden = False,
+    eventHandlers = mempty
+  }
 
 buildElement :: Element -> IO JSVal
 buildElement Element {..} = do

--- a/asterius/test/todomvc/TodoView.hs
+++ b/asterius/test/todomvc/TodoView.hs
@@ -2,36 +2,36 @@ module TodoView where
 
 import Asterius.Types
 
-foreign import javascript "document.querySelector(\".new-todo\")" newTodo
-  :: JSVal
+foreign import javascript "document.querySelector(\".new-todo\")"
+  newTodo :: JSVal
 
 foreign import javascript "document.querySelector(\".main\")" main' :: JSVal
 
-foreign import javascript "document.querySelector(\".toggle-all\")" toggleAll
-  :: JSVal
+foreign import javascript "document.querySelector(\".toggle-all\")"
+  toggleAll :: JSVal
 
-foreign import javascript "document.querySelector(\".toggle-all\").checked" toggleAllChecked
-  :: IO Bool
+foreign import javascript "document.querySelector(\".toggle-all\").checked"
+  toggleAllChecked :: IO Bool
 
-foreign import javascript "document.querySelector(\".todo-list\")" todoList
-  :: IO JSVal
+foreign import javascript "document.querySelector(\".todo-list\")"
+  todoList :: IO JSVal
 
 foreign import javascript "document.querySelector(\".footer\")" footer :: JSVal
 
-foreign import javascript "document.querySelector(\".todo-count\")" todoCount
-  :: IO JSVal
+foreign import javascript "document.querySelector(\".todo-count\")"
+  todoCount :: IO JSVal
 
-foreign import javascript "document.querySelector(\".filters\")" filters
-  :: JSVal
+foreign import javascript "document.querySelector(\".filters\")"
+  filters :: JSVal
 
-foreign import javascript "document.querySelector(\".filters > li:nth-child(1) > a\")" allAnchor
-  :: JSVal
+foreign import javascript "document.querySelector(\".filters > li:nth-child(1) > a\")"
+  allAnchor :: JSVal
 
-foreign import javascript "document.querySelector(\".filters > li:nth-child(2) > a\")" activeAnchor
-  :: JSVal
+foreign import javascript "document.querySelector(\".filters > li:nth-child(2) > a\")"
+  activeAnchor :: JSVal
 
-foreign import javascript "document.querySelector(\".filters > li:nth-child(3) > a\")" completedAnchor
-  :: JSVal
+foreign import javascript "document.querySelector(\".filters > li:nth-child(3) > a\")"
+  completedAnchor :: JSVal
 
-foreign import javascript "document.querySelector(\".clear-completed\")" clearCompleted
-  :: JSVal
+foreign import javascript "document.querySelector(\".clear-completed\")"
+  clearCompleted :: JSVal

--- a/asterius/test/todomvc/WebAPI.hs
+++ b/asterius/test/todomvc/WebAPI.hs
@@ -1,19 +1,20 @@
 module WebAPI
-  ( consoleLog
-  , createElement
-  , setAttribute
-  , appendChild
-  , setHidden
-  , addEventListener
-  , createTextNode
-  , replaceWith
-  , onPopstate
-  , getURLMode
-  , randomString
-  , getElementById
-  , localStorageSetItem
-  , localStorageGetItem
-  ) where
+  ( consoleLog,
+    createElement,
+    setAttribute,
+    appendChild,
+    setHidden,
+    addEventListener,
+    createTextNode,
+    replaceWith,
+    onPopstate,
+    getURLMode,
+    randomString,
+    getElementById,
+    localStorageSetItem,
+    localStorageGetItem,
+  )
+where
 
 import Asterius.ByteString
 import Asterius.Types
@@ -53,52 +54,55 @@ localStorageGetItem :: String -> IO (Maybe BS.ByteString)
 localStorageGetItem k = do
   f <- js_localStorage_hasItem js_k
   if f
-    then Just . byteStringFromJSArrayBuffer . jsStringEncodeLatin1 <$>
-         js_localStorage_getItem js_k
+    then
+      Just
+        . byteStringFromJSArrayBuffer
+        . jsStringEncodeLatin1
+        <$> js_localStorage_getItem js_k
     else pure Nothing
   where
     js_k = toJSString k
 
 foreign import javascript "console.log(${1})" consoleLog :: JSVal -> IO ()
 
-foreign import javascript "document.createElement(${1})" js_createElement
-  :: JSString -> IO JSVal
+foreign import javascript "document.createElement(${1})"
+  js_createElement :: JSString -> IO JSVal
 
-foreign import javascript "${1}.setAttribute(${2},${3})" js_setAttribute
-  :: JSVal -> JSString -> JSString -> IO ()
+foreign import javascript "${1}.setAttribute(${2},${3})"
+  js_setAttribute :: JSVal -> JSString -> JSString -> IO ()
 
-foreign import javascript "${1}.appendChild(${2})" appendChild
-  :: JSVal -> JSVal -> IO ()
+foreign import javascript "${1}.appendChild(${2})"
+  appendChild :: JSVal -> JSVal -> IO ()
 
-foreign import javascript "${1}.hidden = ${2}" setHidden
-  :: JSVal -> Bool -> IO ()
+foreign import javascript "${1}.hidden = ${2}"
+  setHidden :: JSVal -> Bool -> IO ()
 
-foreign import javascript "${1}.addEventListener(${2},${3})" js_addEventListener
-  :: JSVal -> JSString -> JSFunction -> IO ()
+foreign import javascript "${1}.addEventListener(${2},${3})"
+  js_addEventListener :: JSVal -> JSString -> JSFunction -> IO ()
 
-foreign import javascript "document.createTextNode(${1})" js_createTextNode
-  :: JSString -> IO JSVal
+foreign import javascript "document.createTextNode(${1})"
+  js_createTextNode :: JSString -> IO JSVal
 
-foreign import javascript "${1}.replaceWith(${2})" replaceWith
-  :: JSVal -> JSVal -> IO ()
+foreign import javascript "${1}.replaceWith(${2})"
+  replaceWith :: JSVal -> JSVal -> IO ()
 
-foreign import javascript "window.addEventListener(\"popstate\", ${1})" onPopstate
-  :: JSFunction -> IO ()
+foreign import javascript "window.addEventListener(\"popstate\", ${1})"
+  onPopstate :: JSFunction -> IO ()
 
-foreign import javascript "window.location.href.split(\"#/\")[1] || \"\"" js_url_mode
-  :: IO JSString
+foreign import javascript "window.location.href.split(\"#/\")[1] || \"\""
+  js_url_mode :: IO JSString
 
-foreign import javascript "Math.random().toString(36).slice(2)" js_randomString
-  :: IO JSString
+foreign import javascript "Math.random().toString(36).slice(2)"
+  js_randomString :: IO JSString
 
-foreign import javascript "document.getElementById(${1})" js_getElementById
-  :: JSString -> IO JSVal
+foreign import javascript "document.getElementById(${1})"
+  js_getElementById :: JSString -> IO JSVal
 
-foreign import javascript "localStorage.setItem(${1},${2})" js_localStorage_setItem
-  :: JSString -> JSString -> IO ()
+foreign import javascript "localStorage.setItem(${1},${2})"
+  js_localStorage_setItem :: JSString -> JSString -> IO ()
 
-foreign import javascript "localStorage.getItem(${1}) !== null" js_localStorage_hasItem
-  :: JSString -> IO Bool
+foreign import javascript "localStorage.getItem(${1}) !== null"
+  js_localStorage_hasItem :: JSString -> IO Bool
 
-foreign import javascript "localStorage.getItem(${1})" js_localStorage_getItem
-  :: JSString -> IO JSString
+foreign import javascript "localStorage.getItem(${1})"
+  js_localStorage_getItem :: JSString -> IO JSString

--- a/asterius/test/todomvc/todomvc.hs
+++ b/asterius/test/todomvc/todomvc.hs
@@ -15,16 +15,20 @@ import GHC.Generics
 import TodoView
 import WebAPI
 
-data Todo = Todo
-  { key, text :: String
-  , editing, completed :: Bool
-  } deriving (Generic)
+data Todo
+  = Todo
+      { key, text :: String,
+        editing, completed :: Bool
+      }
+  deriving (Generic)
 
 instance Binary Todo
 
-newtype TodoModel = TodoModel
-  { todos :: [Todo]
-  } deriving (Generic)
+newtype TodoModel
+  = TodoModel
+      { todos :: [Todo]
+      }
+  deriving (Generic)
 
 instance Binary TodoModel
 
@@ -52,100 +56,104 @@ modifyTodo model k f =
   model
     { todos =
         [ if key todo == k
-          then f todo
-          else todo
-        | todo <- todos model
+            then f todo
+            else todo
+          | todo <- todos model
         ]
     }
 
 buildTodoElement :: Route -> IORef TodoModel -> Todo -> Element
 buildTodoElement route model_ref current_todo =
   emptyElement
-    { className = "li"
-    , attributes =
-        (if editing current_todo
-           then [("class", "editing")]
-           else [("class", "completed") | completed current_todo]) <>
-        [("id", key current_todo)]
-    , children =
+    { className = "li",
+      attributes =
+        ( if editing current_todo
+            then [("class", "editing")]
+            else [("class", "completed") | completed current_todo]
+        )
+          <> [("id", key current_todo)],
+      children =
         [ emptyElement
-            { className = "div"
-            , attributes = [("class", "view")]
-            , children =
+            { className = "div",
+              attributes = [("class", "view")],
+              children =
                 [ emptyElement
-                    { className = "input"
-                    , attributes =
-                        [("checked", "true") | completed current_todo] <>
-                        [("class", "toggle"), ("type", "checkbox")]
-                    , eventHandlers =
-                        [ ( "click"
-                          , const $ do
+                    { className = "input",
+                      attributes =
+                        [("checked", "true") | completed current_todo]
+                          <> [("class", "toggle"), ("type", "checkbox")],
+                      eventHandlers =
+                        [ ( "click",
+                            const $ do
                               modifyIORef' model_ref $ \model ->
                                 modifyTodo model (key current_todo) $ \todo ->
                                   todo {completed = not $ completed todo}
-                              render model_ref)
+                              render model_ref
+                          )
                         ]
-                    }
-                , emptyElement
-                    { className = "label"
-                    , children = [TextNode $ text current_todo]
-                    , eventHandlers =
-                        [ ( "dblclick"
-                          , const $ do
+                    },
+                  emptyElement
+                    { className = "label",
+                      children = [TextNode $ text current_todo],
+                      eventHandlers =
+                        [ ( "dblclick",
+                            const $ do
                               modifyIORef' model_ref $ \model ->
                                 modifyTodo model (key current_todo) $ \todo ->
                                   todo {editing = not $ editing todo}
-                              render model_ref)
+                              render model_ref
+                          )
                         ]
-                    }
-                , emptyElement
-                    { className = "button"
-                    , attributes = [("class", "destroy")]
-                    , eventHandlers =
-                        [ ( "click"
-                          , const $ do
+                    },
+                  emptyElement
+                    { className = "button",
+                      attributes = [("class", "destroy")],
+                      eventHandlers =
+                        [ ( "click",
+                            const $ do
                               modifyIORef' model_ref $ \model ->
                                 model
                                   { todos =
                                       filter
-                                        (\todo -> key todo /= key current_todo) $
-                                      todos model
+                                        (\todo -> key todo /= key current_todo)
+                                        $ todos model
                                   }
-                              render model_ref)
+                              render model_ref
+                          )
                         ]
                     }
                 ]
-            }
-        , emptyElement
-            { className = "input"
-            , attributes =
-                [ ("class", "edit")
-                , ("id", key current_todo <> "_input")
-                , ("value", text current_todo)
-                ]
-            , eventHandlers =
-                [ ( "keypress"
-                  , \ev -> do
+            },
+          emptyElement
+            { className = "input",
+              attributes =
+                [ ("class", "edit"),
+                  ("id", key current_todo <> "_input"),
+                  ("value", text current_todo)
+                ],
+              eventHandlers =
+                [ ( "keypress",
+                    \ev -> do
                       ev_key <- fromJSString . coerce <$> indexJSObject ev "key"
                       when (ev_key == "Enter") $ do
                         input_element <-
                           getElementById $ key current_todo <> "_input"
                         new_text <-
-                          trim . fromJSString . coerce <$>
-                          indexJSObject (coerce input_element) "value"
+                          trim . fromJSString . coerce
+                            <$> indexJSObject (coerce input_element) "value"
                         modifyIORef' model_ref $ \model ->
                           modifyTodo model (key current_todo) $ \todo ->
                             todo {text = new_text, editing = False}
-                        render model_ref)
-                | editing current_todo
+                        render model_ref
+                  )
+                  | editing current_todo
                 ]
             }
-        ]
-    , hidden =
-        case route of
-          All -> False
-          Active -> completed current_todo
-          Completed -> not $ completed current_todo
+        ],
+      hidden = case route of
+        All -> False
+        Active -> completed current_todo
+        Completed -> not $ completed current_todo
     }
 
 buildTodoList :: Route -> IORef TodoModel -> IO Element
@@ -153,9 +161,9 @@ buildTodoList route model_ref = do
   TodoModel {..} <- readIORef model_ref
   pure
     emptyElement
-      { className = "ul"
-      , attributes = [("class", "todo-list")]
-      , children = map (buildTodoElement route model_ref) todos
+      { className = "ul",
+        attributes = [("class", "todo-list")],
+        children = map (buildTodoElement route model_ref) todos
       }
 
 currentRoute :: IO Route
@@ -178,17 +186,17 @@ render model_ref = do
   new_todo_count <-
     buildElement
       emptyElement
-        { className = "span"
-        , attributes = [("class", "todo-count")]
-        , children =
+        { className = "span",
+          attributes = [("class", "todo-count")],
+          children =
             [ emptyElement
-                { className = "strong"
-                , children = [TextNode $ show active_todos]
-                }
-            , TextNode $
-              case active_todos of
-                1 -> " item"
-                _ -> " items"
+                { className = "strong",
+                  children = [TextNode $ show active_todos]
+                },
+              TextNode $
+                case active_todos of
+                  1 -> " item"
+                  _ -> " items"
             ]
         }
   old_todo_count <- todoCount
@@ -201,8 +209,9 @@ trim = reverse . dropWhile isSpace . reverse . dropWhile isSpace
 todoMVC :: IORef TodoModel -> IO ()
 todoMVC model_ref = do
   let m = render model_ref
-  addEventListener toggleAll "click" $
-    const $ do
+  addEventListener toggleAll "click"
+    $ const
+    $ do
       checked <- toggleAllChecked
       modifyIORef' model_ref $ \model ->
         model {todos = map (\todo -> todo {completed = checked}) $ todos model}
@@ -218,14 +227,15 @@ todoMVC model_ref = do
         modifyIORef' model_ref $ \model ->
           model
             { todos =
-                todos model <>
-                [Todo {key = k, text = val, editing = False, completed = False}]
+                todos model
+                  <> [Todo {key = k, text = val, editing = False, completed = False}]
             }
         setJSObject (coerce newTodo) "value" (coerce (toJSString ""))
         m
   makeHaskellCallback m >>= onPopstate
-  addEventListener clearCompleted "click" $
-    const $ do
+  addEventListener clearCompleted "click"
+    $ const
+    $ do
       modifyIORef' model_ref $ \model ->
         model {todos = filter (not . completed) $ todos model}
       m

--- a/binaryen/Setup.hs
+++ b/binaryen/Setup.hs
@@ -19,68 +19,65 @@ main :: IO ()
 main =
   defaultMainWithHooks
     simpleUserHooks
-      { hookedPrograms = [simpleProgram "cmake"]
-      , confHook =
-          \t@(g_pkg_descr, _) c -> do
-            lbi <- confHook simpleUserHooks t c
-            absBuildDir <- makeAbsolute $ buildDir lbi
-            pwd <- getCurrentDirectory
-            let pkg_descr = packageDescription g_pkg_descr
-                binaryen_builddir = absBuildDir </> "binaryen"
-                binaryen_installdirs =
-                  absoluteInstallDirs pkg_descr lbi NoCopyDest
-                binaryen_libdir = libdir binaryen_installdirs
-                binaryen_bindir = bindir binaryen_installdirs
-                run' prog args stdin_s =
-                  runProgramInvocation
-                    normal
-                    (simpleProgramInvocation prog args)
-                      {progInvokeInput = Just stdin_s}
-                run prog args stdin_s =
-                  let Just conf_prog = lookupProgram prog (withPrograms lbi)
-                   in runProgramInvocation
-                        (fromFlagOrDefault
-                           normal
-                           (configVerbosity (configFlags lbi)))
-                        (programInvocation conf_prog args)
-                          {progInvokeInput = Just stdin_s}
-            for_ [binaryen_builddir, binaryen_libdir, binaryen_bindir] $
-              createDirectoryIfMissing True
-            withCurrentDirectory binaryen_builddir $
-              for_
-                [ [ "-DCMAKE_BUILD_TYPE=Release"
-                  , "-DBUILD_STATIC_LIB=ON"
-                  , "-G"
-                  , "Unix Makefiles"
-                  , pwd </> "binaryen"
-                  ]
-                , ["--build", binaryen_builddir]
-                ] $ \args -> run (simpleProgram "cmake") args ""
-            binaryen_libs <- listDirectory $ binaryen_builddir </> "lib"
-            let output_fn = binaryen_libdir </> "libHSbinaryen-binaryen.a"
-                archives =
-                  [binaryen_builddir </> "lib" </> l | l <- binaryen_libs]
-                (write_ar, is_symdef)
-                  | buildOS == OSX = (writeBSDAr, isBSDSymdef)
-                  | otherwise = (writeGNUAr, isGNUSymdef)
-            ar <- foldlM (\acc p -> (<> acc) <$> loadAr p) mempty archives
-            write_ar output_fn $ afilter (not . is_symdef) ar
-            run' "ranlib" [output_fn] ""
-            binaryen_bins <- listDirectory $ binaryen_builddir </> "bin"
-            for_ binaryen_bins $ \b ->
-              copyFile
-                (binaryen_builddir </> "bin" </> b)
-                (binaryen_bindir </> b)
-            pure
-              lbi
-                { localPkgDescr =
-                    updatePackageDescription
-                      ( Just
-                          emptyBuildInfo
-                            { extraLibs = ["HSbinaryen-binaryen", "stdc++"]
-                            , extraLibDirs = [binaryen_libdir]
-                            }
-                      , []) $
-                    localPkgDescr lbi
-                }
+      { hookedPrograms = [simpleProgram "cmake"],
+        confHook = \t@(g_pkg_descr, _) c -> do
+          lbi <- confHook simpleUserHooks t c
+          absBuildDir <- makeAbsolute $ buildDir lbi
+          pwd <- getCurrentDirectory
+          let pkg_descr = packageDescription g_pkg_descr
+              binaryen_builddir = absBuildDir </> "binaryen"
+              binaryen_installdirs = absoluteInstallDirs pkg_descr lbi NoCopyDest
+              binaryen_libdir = libdir binaryen_installdirs
+              binaryen_bindir = bindir binaryen_installdirs
+              run' prog args stdin_s =
+                runProgramInvocation
+                  normal
+                  (simpleProgramInvocation prog args) {progInvokeInput = Just stdin_s}
+              run prog args stdin_s =
+                let Just conf_prog = lookupProgram prog (withPrograms lbi)
+                 in runProgramInvocation
+                      (fromFlagOrDefault normal (configVerbosity (configFlags lbi)))
+                      (programInvocation conf_prog args)
+                        { progInvokeInput =
+                            Just
+                              stdin_s
+                        }
+          for_ [binaryen_builddir, binaryen_libdir, binaryen_bindir] $
+            createDirectoryIfMissing True
+          withCurrentDirectory binaryen_builddir
+            $ for_
+              [ [ "-DCMAKE_BUILD_TYPE=Release",
+                  "-DBUILD_STATIC_LIB=ON",
+                  "-G",
+                  "Unix Makefiles",
+                  pwd </> "binaryen"
+                ],
+                ["--build", binaryen_builddir]
+              ]
+            $ \args -> run (simpleProgram "cmake") args ""
+          binaryen_libs <- listDirectory $ binaryen_builddir </> "lib"
+          let output_fn = binaryen_libdir </> "libHSbinaryen-binaryen.a"
+              archives = [binaryen_builddir </> "lib" </> l | l <- binaryen_libs]
+              (write_ar, is_symdef)
+                | buildOS == OSX = (writeBSDAr, isBSDSymdef)
+                | otherwise = (writeGNUAr, isGNUSymdef)
+          ar <- foldlM (\acc p -> (<> acc) <$> loadAr p) mempty archives
+          write_ar output_fn $ afilter (not . is_symdef) ar
+          run' "ranlib" [output_fn] ""
+          binaryen_bins <- listDirectory $ binaryen_builddir </> "bin"
+          for_ binaryen_bins $ \b ->
+            copyFile (binaryen_builddir </> "bin" </> b) (binaryen_bindir </> b)
+          pure
+            lbi
+              { localPkgDescr =
+                  updatePackageDescription
+                    ( Just
+                        emptyBuildInfo
+                          { extraLibs = ["HSbinaryen-binaryen", "stdc++"],
+                            extraLibDirs = [binaryen_libdir]
+                          },
+                      []
+                    )
+                    $ localPkgDescr lbi
+              }
       }

--- a/binaryen/src/Bindings/Binaryen/Raw.hs
+++ b/binaryen/src/Bindings/Binaryen/Raw.hs
@@ -7,184 +7,184 @@ type BinaryenIndex = Word32
 
 type BinaryenType = Word32
 
-foreign import ccall unsafe "BinaryenTypeNone" c_BinaryenTypeNone
-  :: BinaryenType
+foreign import ccall unsafe "BinaryenTypeNone"
+  c_BinaryenTypeNone :: BinaryenType
 
-foreign import ccall unsafe "BinaryenTypeInt32" c_BinaryenTypeInt32
-  :: BinaryenType
+foreign import ccall unsafe "BinaryenTypeInt32"
+  c_BinaryenTypeInt32 :: BinaryenType
 
-foreign import ccall unsafe "BinaryenTypeInt64" c_BinaryenTypeInt64
-  :: BinaryenType
+foreign import ccall unsafe "BinaryenTypeInt64"
+  c_BinaryenTypeInt64 :: BinaryenType
 
-foreign import ccall unsafe "BinaryenTypeFloat32" c_BinaryenTypeFloat32
-  :: BinaryenType
+foreign import ccall unsafe "BinaryenTypeFloat32"
+  c_BinaryenTypeFloat32 :: BinaryenType
 
-foreign import ccall unsafe "BinaryenTypeFloat64" c_BinaryenTypeFloat64
-  :: BinaryenType
+foreign import ccall unsafe "BinaryenTypeFloat64"
+  c_BinaryenTypeFloat64 :: BinaryenType
 
-foreign import ccall unsafe "BinaryenTypeVec128" c_BinaryenTypeVec128
-  :: BinaryenType
+foreign import ccall unsafe "BinaryenTypeVec128"
+  c_BinaryenTypeVec128 :: BinaryenType
 
-foreign import ccall unsafe "BinaryenTypeExnref" c_BinaryenTypeExnref
-  :: BinaryenType
+foreign import ccall unsafe "BinaryenTypeExnref"
+  c_BinaryenTypeExnref :: BinaryenType
 
-foreign import ccall unsafe "BinaryenTypeUnreachable" c_BinaryenTypeUnreachable
-  :: BinaryenType
+foreign import ccall unsafe "BinaryenTypeUnreachable"
+  c_BinaryenTypeUnreachable :: BinaryenType
 
-foreign import ccall unsafe "BinaryenTypeAuto" c_BinaryenTypeAuto
-  :: BinaryenType
+foreign import ccall unsafe "BinaryenTypeAuto"
+  c_BinaryenTypeAuto :: BinaryenType
 
 type BinaryenExpressionId = Word32
 
-foreign import ccall unsafe "BinaryenInvalidId" c_BinaryenInvalidId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenInvalidId"
+  c_BinaryenInvalidId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenBlockId" c_BinaryenBlockId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenBlockId"
+  c_BinaryenBlockId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenIfId" c_BinaryenIfId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenIfId"
+  c_BinaryenIfId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenLoopId" c_BinaryenLoopId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenLoopId"
+  c_BinaryenLoopId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenBreakId" c_BinaryenBreakId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenBreakId"
+  c_BinaryenBreakId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenSwitchId" c_BinaryenSwitchId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenSwitchId"
+  c_BinaryenSwitchId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenCallId" c_BinaryenCallId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenCallId"
+  c_BinaryenCallId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenCallIndirectId" c_BinaryenCallIndirectId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenCallIndirectId"
+  c_BinaryenCallIndirectId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenLocalGetId" c_BinaryenLocalGetId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenLocalGetId"
+  c_BinaryenLocalGetId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenLocalSetId" c_BinaryenLocalSetId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenLocalSetId"
+  c_BinaryenLocalSetId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenGlobalGetId" c_BinaryenGlobalGetId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenGlobalGetId"
+  c_BinaryenGlobalGetId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenGlobalSetId" c_BinaryenGlobalSetId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenGlobalSetId"
+  c_BinaryenGlobalSetId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenLoadId" c_BinaryenLoadId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenLoadId"
+  c_BinaryenLoadId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenStoreId" c_BinaryenStoreId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenStoreId"
+  c_BinaryenStoreId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenConstId" c_BinaryenConstId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenConstId"
+  c_BinaryenConstId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenUnaryId" c_BinaryenUnaryId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenUnaryId"
+  c_BinaryenUnaryId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenBinaryId" c_BinaryenBinaryId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenBinaryId"
+  c_BinaryenBinaryId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenSelectId" c_BinaryenSelectId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenSelectId"
+  c_BinaryenSelectId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenDropId" c_BinaryenDropId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenDropId"
+  c_BinaryenDropId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenReturnId" c_BinaryenReturnId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenReturnId"
+  c_BinaryenReturnId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenHostId" c_BinaryenHostId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenHostId"
+  c_BinaryenHostId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenNopId" c_BinaryenNopId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenNopId"
+  c_BinaryenNopId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenUnreachableId" c_BinaryenUnreachableId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenUnreachableId"
+  c_BinaryenUnreachableId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenAtomicCmpxchgId" c_BinaryenAtomicCmpxchgId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenAtomicCmpxchgId"
+  c_BinaryenAtomicCmpxchgId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenAtomicRMWId" c_BinaryenAtomicRMWId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenAtomicRMWId"
+  c_BinaryenAtomicRMWId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenAtomicWaitId" c_BinaryenAtomicWaitId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenAtomicWaitId"
+  c_BinaryenAtomicWaitId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenAtomicNotifyId" c_BinaryenAtomicNotifyId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenAtomicNotifyId"
+  c_BinaryenAtomicNotifyId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenSIMDExtractId" c_BinaryenSIMDExtractId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenSIMDExtractId"
+  c_BinaryenSIMDExtractId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenSIMDReplaceId" c_BinaryenSIMDReplaceId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenSIMDReplaceId"
+  c_BinaryenSIMDReplaceId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenSIMDShuffleId" c_BinaryenSIMDShuffleId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenSIMDShuffleId"
+  c_BinaryenSIMDShuffleId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenSIMDBitselectId" c_BinaryenSIMDBitselectId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenSIMDBitselectId"
+  c_BinaryenSIMDBitselectId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenSIMDShiftId" c_BinaryenSIMDShiftId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenSIMDShiftId"
+  c_BinaryenSIMDShiftId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenMemoryInitId" c_BinaryenMemoryInitId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenMemoryInitId"
+  c_BinaryenMemoryInitId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenDataDropId" c_BinaryenDataDropId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenDataDropId"
+  c_BinaryenDataDropId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenMemoryCopyId" c_BinaryenMemoryCopyId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenMemoryCopyId"
+  c_BinaryenMemoryCopyId :: BinaryenExpressionId
 
-foreign import ccall unsafe "BinaryenMemoryFillId" c_BinaryenMemoryFillId
-  :: BinaryenExpressionId
+foreign import ccall unsafe "BinaryenMemoryFillId"
+  c_BinaryenMemoryFillId :: BinaryenExpressionId
 
 type BinaryenExternalKind = Word32
 
-foreign import ccall unsafe "BinaryenExternalFunction" c_BinaryenExternalFunction
-  :: BinaryenExternalKind
+foreign import ccall unsafe "BinaryenExternalFunction"
+  c_BinaryenExternalFunction :: BinaryenExternalKind
 
-foreign import ccall unsafe "BinaryenExternalTable" c_BinaryenExternalTable
-  :: BinaryenExternalKind
+foreign import ccall unsafe "BinaryenExternalTable"
+  c_BinaryenExternalTable :: BinaryenExternalKind
 
-foreign import ccall unsafe "BinaryenExternalMemory" c_BinaryenExternalMemory
-  :: BinaryenExternalKind
+foreign import ccall unsafe "BinaryenExternalMemory"
+  c_BinaryenExternalMemory :: BinaryenExternalKind
 
-foreign import ccall unsafe "BinaryenExternalGlobal" c_BinaryenExternalGlobal
-  :: BinaryenExternalKind
+foreign import ccall unsafe "BinaryenExternalGlobal"
+  c_BinaryenExternalGlobal :: BinaryenExternalKind
 
-foreign import ccall unsafe "BinaryenExternalEvent" c_BinaryenExternalEvent
-  :: BinaryenExternalKind
+foreign import ccall unsafe "BinaryenExternalEvent"
+  c_BinaryenExternalEvent :: BinaryenExternalKind
 
 type BinaryenFeatures = Word32
 
 foreign import ccall unsafe "BinaryenFeatureMVP" c_BinaryenFeatureMVP :: Word32
 
-foreign import ccall unsafe "BinaryenFeatureAtomics" c_BinaryenFeatureAtomics
-  :: Word32
+foreign import ccall unsafe "BinaryenFeatureAtomics"
+  c_BinaryenFeatureAtomics :: Word32
 
-foreign import ccall unsafe "BinaryenFeatureBulkMemory" c_BinaryenFeatureBulkMemory
-  :: Word32
+foreign import ccall unsafe "BinaryenFeatureBulkMemory"
+  c_BinaryenFeatureBulkMemory :: Word32
 
-foreign import ccall unsafe "BinaryenFeatureMutableGlobals" c_BinaryenFeatureMutableGlobals
-  :: Word32
+foreign import ccall unsafe "BinaryenFeatureMutableGlobals"
+  c_BinaryenFeatureMutableGlobals :: Word32
 
-foreign import ccall unsafe "BinaryenFeatureNontrappingFPToInt" c_BinaryenFeatureNontrappingFPToInt
-  :: Word32
+foreign import ccall unsafe "BinaryenFeatureNontrappingFPToInt"
+  c_BinaryenFeatureNontrappingFPToInt :: Word32
 
-foreign import ccall unsafe "BinaryenFeatureSignExt" c_BinaryenFeatureSignExt
-  :: Word32
+foreign import ccall unsafe "BinaryenFeatureSignExt"
+  c_BinaryenFeatureSignExt :: Word32
 
-foreign import ccall unsafe "BinaryenFeatureSIMD128" c_BinaryenFeatureSIMD128
-  :: Word32
+foreign import ccall unsafe "BinaryenFeatureSIMD128"
+  c_BinaryenFeatureSIMD128 :: Word32
 
-foreign import ccall unsafe "BinaryenFeatureExceptionHandling" c_BinaryenFeatureExceptionHandling
-  :: Word32
+foreign import ccall unsafe "BinaryenFeatureExceptionHandling"
+  c_BinaryenFeatureExceptionHandling :: Word32
 
 foreign import ccall unsafe "BinaryenFeatureAll" c_BinaryenFeatureAll :: Word32
 
@@ -192,45 +192,48 @@ data BinaryenModule
 
 type BinaryenModuleRef = Ptr BinaryenModule
 
-foreign import ccall unsafe "BinaryenModuleCreate" c_BinaryenModuleCreate
-  :: IO BinaryenModuleRef
+foreign import ccall unsafe "BinaryenModuleCreate"
+  c_BinaryenModuleCreate :: IO BinaryenModuleRef
 
-foreign import ccall unsafe "BinaryenModuleDispose" c_BinaryenModuleDispose
-  :: BinaryenModuleRef -> IO ()
+foreign import ccall unsafe "BinaryenModuleDispose"
+  c_BinaryenModuleDispose :: BinaryenModuleRef -> IO ()
 
 data BinaryenFunctionType
 
 type BinaryenFunctionTypeRef = Ptr BinaryenFunctionType
 
-foreign import ccall unsafe "BinaryenAddFunctionType" c_BinaryenAddFunctionType
-  :: BinaryenModuleRef ->
-  Ptr CChar ->
+foreign import ccall unsafe "BinaryenAddFunctionType"
+  c_BinaryenAddFunctionType ::
+    BinaryenModuleRef ->
+    Ptr CChar ->
     BinaryenType ->
-      Ptr BinaryenType -> BinaryenIndex -> IO BinaryenFunctionTypeRef
+    Ptr BinaryenType ->
+    BinaryenIndex ->
+    IO BinaryenFunctionTypeRef
 
-foreign import ccall unsafe "BinaryenRemoveFunctionType" c_BinaryenRemoveFunctionType
-  :: BinaryenModuleRef -> Ptr CChar -> IO ()
+foreign import ccall unsafe "BinaryenRemoveFunctionType"
+  c_BinaryenRemoveFunctionType :: BinaryenModuleRef -> Ptr CChar -> IO ()
 
-foreign import ccall unsafe "BinaryenConstInt32" c_BinaryenConstInt32
-  :: BinaryenModuleRef -> Int32 -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenConstInt32"
+  c_BinaryenConstInt32 :: BinaryenModuleRef -> Int32 -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenConstInt64" c_BinaryenConstInt64
-  :: BinaryenModuleRef -> Int64 -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenConstInt64"
+  c_BinaryenConstInt64 :: BinaryenModuleRef -> Int64 -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenConstFloat32" c_BinaryenConstFloat32
-  :: BinaryenModuleRef -> Float -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenConstFloat32"
+  c_BinaryenConstFloat32 :: BinaryenModuleRef -> Float -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenConstFloat64" c_BinaryenConstFloat64
-  :: BinaryenModuleRef -> Double -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenConstFloat64"
+  c_BinaryenConstFloat64 :: BinaryenModuleRef -> Double -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenConstVec128" c_BinaryenConstVec128
-  :: BinaryenModuleRef -> Ptr Word8 -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenConstVec128"
+  c_BinaryenConstVec128 :: BinaryenModuleRef -> Ptr Word8 -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenConstFloat32Bits" c_BinaryenConstFloat32Bits
-  :: BinaryenModuleRef -> Int32 -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenConstFloat32Bits"
+  c_BinaryenConstFloat32Bits :: BinaryenModuleRef -> Int32 -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenConstFloat64Bits" c_BinaryenConstFloat64Bits
-  :: BinaryenModuleRef -> Int64 -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenConstFloat64Bits"
+  c_BinaryenConstFloat64Bits :: BinaryenModuleRef -> Int64 -> IO BinaryenExpressionRef
 
 type BinaryenOp = Int32
 
@@ -238,29 +241,29 @@ foreign import ccall unsafe "BinaryenClzInt32" c_BinaryenClzInt32 :: BinaryenOp
 
 foreign import ccall unsafe "BinaryenCtzInt32" c_BinaryenCtzInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenPopcntInt32" c_BinaryenPopcntInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenPopcntInt32"
+  c_BinaryenPopcntInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenNegFloat32" c_BinaryenNegFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenNegFloat32"
+  c_BinaryenNegFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAbsFloat32" c_BinaryenAbsFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAbsFloat32"
+  c_BinaryenAbsFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenCeilFloat32" c_BinaryenCeilFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenCeilFloat32"
+  c_BinaryenCeilFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenFloorFloat32" c_BinaryenFloorFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenFloorFloat32"
+  c_BinaryenFloorFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncFloat32" c_BinaryenTruncFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncFloat32"
+  c_BinaryenTruncFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenNearestFloat32" c_BinaryenNearestFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenNearestFloat32"
+  c_BinaryenNearestFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSqrtFloat32" c_BinaryenSqrtFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSqrtFloat32"
+  c_BinaryenSqrtFloat32 :: BinaryenOp
 
 foreign import ccall unsafe "BinaryenEqZInt32" c_BinaryenEqZInt32 :: BinaryenOp
 
@@ -268,121 +271,121 @@ foreign import ccall unsafe "BinaryenClzInt64" c_BinaryenClzInt64 :: BinaryenOp
 
 foreign import ccall unsafe "BinaryenCtzInt64" c_BinaryenCtzInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenPopcntInt64" c_BinaryenPopcntInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenPopcntInt64"
+  c_BinaryenPopcntInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenNegFloat64" c_BinaryenNegFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenNegFloat64"
+  c_BinaryenNegFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAbsFloat64" c_BinaryenAbsFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAbsFloat64"
+  c_BinaryenAbsFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenCeilFloat64" c_BinaryenCeilFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenCeilFloat64"
+  c_BinaryenCeilFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenFloorFloat64" c_BinaryenFloorFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenFloorFloat64"
+  c_BinaryenFloorFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncFloat64" c_BinaryenTruncFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncFloat64"
+  c_BinaryenTruncFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenNearestFloat64" c_BinaryenNearestFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenNearestFloat64"
+  c_BinaryenNearestFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSqrtFloat64" c_BinaryenSqrtFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSqrtFloat64"
+  c_BinaryenSqrtFloat64 :: BinaryenOp
 
 foreign import ccall unsafe "BinaryenEqZInt64" c_BinaryenEqZInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenExtendSInt32" c_BinaryenExtendSInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenExtendSInt32"
+  c_BinaryenExtendSInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenExtendUInt32" c_BinaryenExtendUInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenExtendUInt32"
+  c_BinaryenExtendUInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenWrapInt64" c_BinaryenWrapInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenWrapInt64"
+  c_BinaryenWrapInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncSFloat32ToInt32" c_BinaryenTruncSFloat32ToInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncSFloat32ToInt32"
+  c_BinaryenTruncSFloat32ToInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncSFloat32ToInt64" c_BinaryenTruncSFloat32ToInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncSFloat32ToInt64"
+  c_BinaryenTruncSFloat32ToInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncUFloat32ToInt32" c_BinaryenTruncUFloat32ToInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncUFloat32ToInt32"
+  c_BinaryenTruncUFloat32ToInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncUFloat32ToInt64" c_BinaryenTruncUFloat32ToInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncUFloat32ToInt64"
+  c_BinaryenTruncUFloat32ToInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncSFloat64ToInt32" c_BinaryenTruncSFloat64ToInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncSFloat64ToInt32"
+  c_BinaryenTruncSFloat64ToInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncSFloat64ToInt64" c_BinaryenTruncSFloat64ToInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncSFloat64ToInt64"
+  c_BinaryenTruncSFloat64ToInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncUFloat64ToInt32" c_BinaryenTruncUFloat64ToInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncUFloat64ToInt32"
+  c_BinaryenTruncUFloat64ToInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncUFloat64ToInt64" c_BinaryenTruncUFloat64ToInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncUFloat64ToInt64"
+  c_BinaryenTruncUFloat64ToInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenReinterpretFloat32" c_BinaryenReinterpretFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenReinterpretFloat32"
+  c_BinaryenReinterpretFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenReinterpretFloat64" c_BinaryenReinterpretFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenReinterpretFloat64"
+  c_BinaryenReinterpretFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenConvertSInt32ToFloat32" c_BinaryenConvertSInt32ToFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenConvertSInt32ToFloat32"
+  c_BinaryenConvertSInt32ToFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenConvertSInt32ToFloat64" c_BinaryenConvertSInt32ToFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenConvertSInt32ToFloat64"
+  c_BinaryenConvertSInt32ToFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenConvertUInt32ToFloat32" c_BinaryenConvertUInt32ToFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenConvertUInt32ToFloat32"
+  c_BinaryenConvertUInt32ToFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenConvertUInt32ToFloat64" c_BinaryenConvertUInt32ToFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenConvertUInt32ToFloat64"
+  c_BinaryenConvertUInt32ToFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenConvertSInt64ToFloat32" c_BinaryenConvertSInt64ToFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenConvertSInt64ToFloat32"
+  c_BinaryenConvertSInt64ToFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenConvertSInt64ToFloat64" c_BinaryenConvertSInt64ToFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenConvertSInt64ToFloat64"
+  c_BinaryenConvertSInt64ToFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenConvertUInt64ToFloat32" c_BinaryenConvertUInt64ToFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenConvertUInt64ToFloat32"
+  c_BinaryenConvertUInt64ToFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenConvertUInt64ToFloat64" c_BinaryenConvertUInt64ToFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenConvertUInt64ToFloat64"
+  c_BinaryenConvertUInt64ToFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenPromoteFloat32" c_BinaryenPromoteFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenPromoteFloat32"
+  c_BinaryenPromoteFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenDemoteFloat64" c_BinaryenDemoteFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenDemoteFloat64"
+  c_BinaryenDemoteFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenReinterpretInt32" c_BinaryenReinterpretInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenReinterpretInt32"
+  c_BinaryenReinterpretInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenReinterpretInt64" c_BinaryenReinterpretInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenReinterpretInt64"
+  c_BinaryenReinterpretInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenExtendS8Int32" c_BinaryenExtendS8Int32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenExtendS8Int32"
+  c_BinaryenExtendS8Int32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenExtendS16Int32" c_BinaryenExtendS16Int32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenExtendS16Int32"
+  c_BinaryenExtendS16Int32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenExtendS8Int64" c_BinaryenExtendS8Int64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenExtendS8Int64"
+  c_BinaryenExtendS8Int64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenExtendS16Int64" c_BinaryenExtendS16Int64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenExtendS16Int64"
+  c_BinaryenExtendS16Int64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenExtendS32Int64" c_BinaryenExtendS32Int64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenExtendS32Int64"
+  c_BinaryenExtendS32Int64 :: BinaryenOp
 
 foreign import ccall unsafe "BinaryenAddInt32" c_BinaryenAddInt32 :: BinaryenOp
 
@@ -390,17 +393,17 @@ foreign import ccall unsafe "BinaryenSubInt32" c_BinaryenSubInt32 :: BinaryenOp
 
 foreign import ccall unsafe "BinaryenMulInt32" c_BinaryenMulInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenDivSInt32" c_BinaryenDivSInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenDivSInt32"
+  c_BinaryenDivSInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenDivUInt32" c_BinaryenDivUInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenDivUInt32"
+  c_BinaryenDivUInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenRemSInt32" c_BinaryenRemSInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenRemSInt32"
+  c_BinaryenRemSInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenRemUInt32" c_BinaryenRemUInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenRemUInt32"
+  c_BinaryenRemUInt32 :: BinaryenOp
 
 foreign import ccall unsafe "BinaryenAndInt32" c_BinaryenAndInt32 :: BinaryenOp
 
@@ -410,17 +413,17 @@ foreign import ccall unsafe "BinaryenXorInt32" c_BinaryenXorInt32 :: BinaryenOp
 
 foreign import ccall unsafe "BinaryenShlInt32" c_BinaryenShlInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenShrUInt32" c_BinaryenShrUInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenShrUInt32"
+  c_BinaryenShrUInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenShrSInt32" c_BinaryenShrSInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenShrSInt32"
+  c_BinaryenShrSInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenRotLInt32" c_BinaryenRotLInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenRotLInt32"
+  c_BinaryenRotLInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenRotRInt32" c_BinaryenRotRInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenRotRInt32"
+  c_BinaryenRotRInt32 :: BinaryenOp
 
 foreign import ccall unsafe "BinaryenEqInt32" c_BinaryenEqInt32 :: BinaryenOp
 
@@ -448,17 +451,17 @@ foreign import ccall unsafe "BinaryenSubInt64" c_BinaryenSubInt64 :: BinaryenOp
 
 foreign import ccall unsafe "BinaryenMulInt64" c_BinaryenMulInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenDivSInt64" c_BinaryenDivSInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenDivSInt64"
+  c_BinaryenDivSInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenDivUInt64" c_BinaryenDivUInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenDivUInt64"
+  c_BinaryenDivUInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenRemSInt64" c_BinaryenRemSInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenRemSInt64"
+  c_BinaryenRemSInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenRemUInt64" c_BinaryenRemUInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenRemUInt64"
+  c_BinaryenRemUInt64 :: BinaryenOp
 
 foreign import ccall unsafe "BinaryenAndInt64" c_BinaryenAndInt64 :: BinaryenOp
 
@@ -468,17 +471,17 @@ foreign import ccall unsafe "BinaryenXorInt64" c_BinaryenXorInt64 :: BinaryenOp
 
 foreign import ccall unsafe "BinaryenShlInt64" c_BinaryenShlInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenShrUInt64" c_BinaryenShrUInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenShrUInt64"
+  c_BinaryenShrUInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenShrSInt64" c_BinaryenShrSInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenShrSInt64"
+  c_BinaryenShrSInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenRotLInt64" c_BinaryenRotLInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenRotLInt64"
+  c_BinaryenRotLInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenRotRInt64" c_BinaryenRotRInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenRotRInt64"
+  c_BinaryenRotRInt64 :: BinaryenOp
 
 foreign import ccall unsafe "BinaryenEqInt64" c_BinaryenEqInt64 :: BinaryenOp
 
@@ -500,1365 +503,1511 @@ foreign import ccall unsafe "BinaryenGeSInt64" c_BinaryenGeSInt64 :: BinaryenOp
 
 foreign import ccall unsafe "BinaryenGeUInt64" c_BinaryenGeUInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAddFloat32" c_BinaryenAddFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAddFloat32"
+  c_BinaryenAddFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSubFloat32" c_BinaryenSubFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSubFloat32"
+  c_BinaryenSubFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenMulFloat32" c_BinaryenMulFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenMulFloat32"
+  c_BinaryenMulFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenDivFloat32" c_BinaryenDivFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenDivFloat32"
+  c_BinaryenDivFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenCopySignFloat32" c_BinaryenCopySignFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenCopySignFloat32"
+  c_BinaryenCopySignFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenMinFloat32" c_BinaryenMinFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenMinFloat32"
+  c_BinaryenMinFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenMaxFloat32" c_BinaryenMaxFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenMaxFloat32"
+  c_BinaryenMaxFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenEqFloat32" c_BinaryenEqFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenEqFloat32"
+  c_BinaryenEqFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenNeFloat32" c_BinaryenNeFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenNeFloat32"
+  c_BinaryenNeFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLtFloat32" c_BinaryenLtFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLtFloat32"
+  c_BinaryenLtFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLeFloat32" c_BinaryenLeFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLeFloat32"
+  c_BinaryenLeFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGtFloat32" c_BinaryenGtFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGtFloat32"
+  c_BinaryenGtFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGeFloat32" c_BinaryenGeFloat32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGeFloat32"
+  c_BinaryenGeFloat32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAddFloat64" c_BinaryenAddFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAddFloat64"
+  c_BinaryenAddFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSubFloat64" c_BinaryenSubFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSubFloat64"
+  c_BinaryenSubFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenMulFloat64" c_BinaryenMulFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenMulFloat64"
+  c_BinaryenMulFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenDivFloat64" c_BinaryenDivFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenDivFloat64"
+  c_BinaryenDivFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenCopySignFloat64" c_BinaryenCopySignFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenCopySignFloat64"
+  c_BinaryenCopySignFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenMinFloat64" c_BinaryenMinFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenMinFloat64"
+  c_BinaryenMinFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenMaxFloat64" c_BinaryenMaxFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenMaxFloat64"
+  c_BinaryenMaxFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenEqFloat64" c_BinaryenEqFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenEqFloat64"
+  c_BinaryenEqFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenNeFloat64" c_BinaryenNeFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenNeFloat64"
+  c_BinaryenNeFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLtFloat64" c_BinaryenLtFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLtFloat64"
+  c_BinaryenLtFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLeFloat64" c_BinaryenLeFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLeFloat64"
+  c_BinaryenLeFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGtFloat64" c_BinaryenGtFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGtFloat64"
+  c_BinaryenGtFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGeFloat64" c_BinaryenGeFloat64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGeFloat64"
+  c_BinaryenGeFloat64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenMemorySize" c_BinaryenMemorySize
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenMemorySize"
+  c_BinaryenMemorySize :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenMemoryGrow" c_BinaryenMemoryGrow
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenMemoryGrow"
+  c_BinaryenMemoryGrow :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAtomicRMWAdd" c_BinaryenAtomicRMWAdd
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAtomicRMWAdd"
+  c_BinaryenAtomicRMWAdd :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAtomicRMWSub" c_BinaryenAtomicRMWSub
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAtomicRMWSub"
+  c_BinaryenAtomicRMWSub :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAtomicRMWAnd" c_BinaryenAtomicRMWAnd
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAtomicRMWAnd"
+  c_BinaryenAtomicRMWAnd :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAtomicRMWOr" c_BinaryenAtomicRMWOr
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAtomicRMWOr"
+  c_BinaryenAtomicRMWOr :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAtomicRMWXor" c_BinaryenAtomicRMWXor
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAtomicRMWXor"
+  c_BinaryenAtomicRMWXor :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAtomicRMWXchg" c_BinaryenAtomicRMWXchg
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAtomicRMWXchg"
+  c_BinaryenAtomicRMWXchg :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncSatSFloat32ToInt32" c_BinaryenTruncSatSFloat32ToInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncSatSFloat32ToInt32"
+  c_BinaryenTruncSatSFloat32ToInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncSatSFloat32ToInt64" c_BinaryenTruncSatSFloat32ToInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncSatSFloat32ToInt64"
+  c_BinaryenTruncSatSFloat32ToInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncSatUFloat32ToInt32" c_BinaryenTruncSatUFloat32ToInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncSatUFloat32ToInt32"
+  c_BinaryenTruncSatUFloat32ToInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncSatUFloat32ToInt64" c_BinaryenTruncSatUFloat32ToInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncSatUFloat32ToInt64"
+  c_BinaryenTruncSatUFloat32ToInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncSatSFloat64ToInt32" c_BinaryenTruncSatSFloat64ToInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncSatSFloat64ToInt32"
+  c_BinaryenTruncSatSFloat64ToInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncSatSFloat64ToInt64" c_BinaryenTruncSatSFloat64ToInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncSatSFloat64ToInt64"
+  c_BinaryenTruncSatSFloat64ToInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncSatUFloat64ToInt32" c_BinaryenTruncSatUFloat64ToInt32
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncSatUFloat64ToInt32"
+  c_BinaryenTruncSatUFloat64ToInt32 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncSatUFloat64ToInt64" c_BinaryenTruncSatUFloat64ToInt64
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncSatUFloat64ToInt64"
+  c_BinaryenTruncSatUFloat64ToInt64 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSplatVecI8x16" c_BinaryenSplatVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSplatVecI8x16"
+  c_BinaryenSplatVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenExtractLaneSVecI8x16" c_BinaryenExtractLaneSVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenExtractLaneSVecI8x16"
+  c_BinaryenExtractLaneSVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenExtractLaneUVecI8x16" c_BinaryenExtractLaneUVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenExtractLaneUVecI8x16"
+  c_BinaryenExtractLaneUVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenReplaceLaneVecI8x16" c_BinaryenReplaceLaneVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenReplaceLaneVecI8x16"
+  c_BinaryenReplaceLaneVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSplatVecI16x8" c_BinaryenSplatVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSplatVecI16x8"
+  c_BinaryenSplatVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenExtractLaneSVecI16x8" c_BinaryenExtractLaneSVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenExtractLaneSVecI16x8"
+  c_BinaryenExtractLaneSVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenExtractLaneUVecI16x8" c_BinaryenExtractLaneUVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenExtractLaneUVecI16x8"
+  c_BinaryenExtractLaneUVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenReplaceLaneVecI16x8" c_BinaryenReplaceLaneVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenReplaceLaneVecI16x8"
+  c_BinaryenReplaceLaneVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSplatVecI32x4" c_BinaryenSplatVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSplatVecI32x4"
+  c_BinaryenSplatVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenExtractLaneVecI32x4" c_BinaryenExtractLaneVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenExtractLaneVecI32x4"
+  c_BinaryenExtractLaneVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenReplaceLaneVecI32x4" c_BinaryenReplaceLaneVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenReplaceLaneVecI32x4"
+  c_BinaryenReplaceLaneVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSplatVecI64x2" c_BinaryenSplatVecI64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSplatVecI64x2"
+  c_BinaryenSplatVecI64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenExtractLaneVecI64x2" c_BinaryenExtractLaneVecI64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenExtractLaneVecI64x2"
+  c_BinaryenExtractLaneVecI64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenReplaceLaneVecI64x2" c_BinaryenReplaceLaneVecI64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenReplaceLaneVecI64x2"
+  c_BinaryenReplaceLaneVecI64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSplatVecF32x4" c_BinaryenSplatVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSplatVecF32x4"
+  c_BinaryenSplatVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenExtractLaneVecF32x4" c_BinaryenExtractLaneVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenExtractLaneVecF32x4"
+  c_BinaryenExtractLaneVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenReplaceLaneVecF32x4" c_BinaryenReplaceLaneVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenReplaceLaneVecF32x4"
+  c_BinaryenReplaceLaneVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSplatVecF64x2" c_BinaryenSplatVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSplatVecF64x2"
+  c_BinaryenSplatVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenExtractLaneVecF64x2" c_BinaryenExtractLaneVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenExtractLaneVecF64x2"
+  c_BinaryenExtractLaneVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenReplaceLaneVecF64x2" c_BinaryenReplaceLaneVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenReplaceLaneVecF64x2"
+  c_BinaryenReplaceLaneVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenEqVecI8x16" c_BinaryenEqVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenEqVecI8x16"
+  c_BinaryenEqVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenNeVecI8x16" c_BinaryenNeVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenNeVecI8x16"
+  c_BinaryenNeVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLtSVecI8x16" c_BinaryenLtSVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLtSVecI8x16"
+  c_BinaryenLtSVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLtUVecI8x16" c_BinaryenLtUVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLtUVecI8x16"
+  c_BinaryenLtUVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGtSVecI8x16" c_BinaryenGtSVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGtSVecI8x16"
+  c_BinaryenGtSVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGtUVecI8x16" c_BinaryenGtUVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGtUVecI8x16"
+  c_BinaryenGtUVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLeSVecI8x16" c_BinaryenLeSVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLeSVecI8x16"
+  c_BinaryenLeSVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLeUVecI8x16" c_BinaryenLeUVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLeUVecI8x16"
+  c_BinaryenLeUVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGeSVecI8x16" c_BinaryenGeSVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGeSVecI8x16"
+  c_BinaryenGeSVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGeUVecI8x16" c_BinaryenGeUVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGeUVecI8x16"
+  c_BinaryenGeUVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenEqVecI16x8" c_BinaryenEqVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenEqVecI16x8"
+  c_BinaryenEqVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenNeVecI16x8" c_BinaryenNeVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenNeVecI16x8"
+  c_BinaryenNeVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLtSVecI16x8" c_BinaryenLtSVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLtSVecI16x8"
+  c_BinaryenLtSVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLtUVecI16x8" c_BinaryenLtUVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLtUVecI16x8"
+  c_BinaryenLtUVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGtSVecI16x8" c_BinaryenGtSVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGtSVecI16x8"
+  c_BinaryenGtSVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGtUVecI16x8" c_BinaryenGtUVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGtUVecI16x8"
+  c_BinaryenGtUVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLeSVecI16x8" c_BinaryenLeSVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLeSVecI16x8"
+  c_BinaryenLeSVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLeUVecI16x8" c_BinaryenLeUVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLeUVecI16x8"
+  c_BinaryenLeUVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGeSVecI16x8" c_BinaryenGeSVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGeSVecI16x8"
+  c_BinaryenGeSVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGeUVecI16x8" c_BinaryenGeUVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGeUVecI16x8"
+  c_BinaryenGeUVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenEqVecI32x4" c_BinaryenEqVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenEqVecI32x4"
+  c_BinaryenEqVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenNeVecI32x4" c_BinaryenNeVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenNeVecI32x4"
+  c_BinaryenNeVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLtSVecI32x4" c_BinaryenLtSVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLtSVecI32x4"
+  c_BinaryenLtSVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLtUVecI32x4" c_BinaryenLtUVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLtUVecI32x4"
+  c_BinaryenLtUVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGtSVecI32x4" c_BinaryenGtSVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGtSVecI32x4"
+  c_BinaryenGtSVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGtUVecI32x4" c_BinaryenGtUVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGtUVecI32x4"
+  c_BinaryenGtUVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLeSVecI32x4" c_BinaryenLeSVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLeSVecI32x4"
+  c_BinaryenLeSVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLeUVecI32x4" c_BinaryenLeUVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLeUVecI32x4"
+  c_BinaryenLeUVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGeSVecI32x4" c_BinaryenGeSVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGeSVecI32x4"
+  c_BinaryenGeSVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGeUVecI32x4" c_BinaryenGeUVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGeUVecI32x4"
+  c_BinaryenGeUVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenEqVecF32x4" c_BinaryenEqVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenEqVecF32x4"
+  c_BinaryenEqVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenNeVecF32x4" c_BinaryenNeVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenNeVecF32x4"
+  c_BinaryenNeVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLtVecF32x4" c_BinaryenLtVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLtVecF32x4"
+  c_BinaryenLtVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGtVecF32x4" c_BinaryenGtVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGtVecF32x4"
+  c_BinaryenGtVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLeVecF32x4" c_BinaryenLeVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLeVecF32x4"
+  c_BinaryenLeVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGeVecF32x4" c_BinaryenGeVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGeVecF32x4"
+  c_BinaryenGeVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenEqVecF64x2" c_BinaryenEqVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenEqVecF64x2"
+  c_BinaryenEqVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenNeVecF64x2" c_BinaryenNeVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenNeVecF64x2"
+  c_BinaryenNeVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLtVecF64x2" c_BinaryenLtVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLtVecF64x2"
+  c_BinaryenLtVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGtVecF64x2" c_BinaryenGtVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGtVecF64x2"
+  c_BinaryenGtVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenLeVecF64x2" c_BinaryenLeVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenLeVecF64x2"
+  c_BinaryenLeVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenGeVecF64x2" c_BinaryenGeVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenGeVecF64x2"
+  c_BinaryenGeVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenNotVec128" c_BinaryenNotVec128
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenNotVec128"
+  c_BinaryenNotVec128 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAndVec128" c_BinaryenAndVec128
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAndVec128"
+  c_BinaryenAndVec128 :: BinaryenOp
 
 foreign import ccall unsafe "BinaryenOrVec128" c_BinaryenOrVec128 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenXorVec128" c_BinaryenXorVec128
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenXorVec128"
+  c_BinaryenXorVec128 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenNegVecI8x16" c_BinaryenNegVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenNegVecI8x16"
+  c_BinaryenNegVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAnyTrueVecI8x16" c_BinaryenAnyTrueVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAnyTrueVecI8x16"
+  c_BinaryenAnyTrueVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAllTrueVecI8x16" c_BinaryenAllTrueVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAllTrueVecI8x16"
+  c_BinaryenAllTrueVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenShlVecI8x16" c_BinaryenShlVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenShlVecI8x16"
+  c_BinaryenShlVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenShrSVecI8x16" c_BinaryenShrSVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenShrSVecI8x16"
+  c_BinaryenShrSVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenShrUVecI8x16" c_BinaryenShrUVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenShrUVecI8x16"
+  c_BinaryenShrUVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAddVecI8x16" c_BinaryenAddVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAddVecI8x16"
+  c_BinaryenAddVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAddSatSVecI8x16" c_BinaryenAddSatSVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAddSatSVecI8x16"
+  c_BinaryenAddSatSVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAddSatUVecI8x16" c_BinaryenAddSatUVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAddSatUVecI8x16"
+  c_BinaryenAddSatUVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSubVecI8x16" c_BinaryenSubVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSubVecI8x16"
+  c_BinaryenSubVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSubSatSVecI8x16" c_BinaryenSubSatSVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSubSatSVecI8x16"
+  c_BinaryenSubSatSVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSubSatUVecI8x16" c_BinaryenSubSatUVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSubSatUVecI8x16"
+  c_BinaryenSubSatUVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenMulVecI8x16" c_BinaryenMulVecI8x16
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenMulVecI8x16"
+  c_BinaryenMulVecI8x16 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenNegVecI16x8" c_BinaryenNegVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenNegVecI16x8"
+  c_BinaryenNegVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAnyTrueVecI16x8" c_BinaryenAnyTrueVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAnyTrueVecI16x8"
+  c_BinaryenAnyTrueVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAllTrueVecI16x8" c_BinaryenAllTrueVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAllTrueVecI16x8"
+  c_BinaryenAllTrueVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenShlVecI16x8" c_BinaryenShlVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenShlVecI16x8"
+  c_BinaryenShlVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenShrSVecI16x8" c_BinaryenShrSVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenShrSVecI16x8"
+  c_BinaryenShrSVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenShrUVecI16x8" c_BinaryenShrUVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenShrUVecI16x8"
+  c_BinaryenShrUVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAddVecI16x8" c_BinaryenAddVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAddVecI16x8"
+  c_BinaryenAddVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAddSatSVecI16x8" c_BinaryenAddSatSVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAddSatSVecI16x8"
+  c_BinaryenAddSatSVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAddSatUVecI16x8" c_BinaryenAddSatUVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAddSatUVecI16x8"
+  c_BinaryenAddSatUVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSubVecI16x8" c_BinaryenSubVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSubVecI16x8"
+  c_BinaryenSubVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSubSatSVecI16x8" c_BinaryenSubSatSVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSubSatSVecI16x8"
+  c_BinaryenSubSatSVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSubSatUVecI16x8" c_BinaryenSubSatUVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSubSatUVecI16x8"
+  c_BinaryenSubSatUVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenMulVecI16x8" c_BinaryenMulVecI16x8
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenMulVecI16x8"
+  c_BinaryenMulVecI16x8 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenNegVecI32x4" c_BinaryenNegVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenNegVecI32x4"
+  c_BinaryenNegVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAnyTrueVecI32x4" c_BinaryenAnyTrueVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAnyTrueVecI32x4"
+  c_BinaryenAnyTrueVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAllTrueVecI32x4" c_BinaryenAllTrueVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAllTrueVecI32x4"
+  c_BinaryenAllTrueVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenShlVecI32x4" c_BinaryenShlVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenShlVecI32x4"
+  c_BinaryenShlVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenShrSVecI32x4" c_BinaryenShrSVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenShrSVecI32x4"
+  c_BinaryenShrSVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenShrUVecI32x4" c_BinaryenShrUVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenShrUVecI32x4"
+  c_BinaryenShrUVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAddVecI32x4" c_BinaryenAddVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAddVecI32x4"
+  c_BinaryenAddVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSubVecI32x4" c_BinaryenSubVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSubVecI32x4"
+  c_BinaryenSubVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenMulVecI32x4" c_BinaryenMulVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenMulVecI32x4"
+  c_BinaryenMulVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenNegVecI64x2" c_BinaryenNegVecI64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenNegVecI64x2"
+  c_BinaryenNegVecI64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAnyTrueVecI64x2" c_BinaryenAnyTrueVecI64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAnyTrueVecI64x2"
+  c_BinaryenAnyTrueVecI64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAllTrueVecI64x2" c_BinaryenAllTrueVecI64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAllTrueVecI64x2"
+  c_BinaryenAllTrueVecI64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenShlVecI64x2" c_BinaryenShlVecI64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenShlVecI64x2"
+  c_BinaryenShlVecI64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenShrSVecI64x2" c_BinaryenShrSVecI64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenShrSVecI64x2"
+  c_BinaryenShrSVecI64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenShrUVecI64x2" c_BinaryenShrUVecI64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenShrUVecI64x2"
+  c_BinaryenShrUVecI64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAddVecI64x2" c_BinaryenAddVecI64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAddVecI64x2"
+  c_BinaryenAddVecI64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSubVecI64x2" c_BinaryenSubVecI64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSubVecI64x2"
+  c_BinaryenSubVecI64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAbsVecF32x4" c_BinaryenAbsVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAbsVecF32x4"
+  c_BinaryenAbsVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenNegVecF32x4" c_BinaryenNegVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenNegVecF32x4"
+  c_BinaryenNegVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSqrtVecF32x4" c_BinaryenSqrtVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSqrtVecF32x4"
+  c_BinaryenSqrtVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAddVecF32x4" c_BinaryenAddVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAddVecF32x4"
+  c_BinaryenAddVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSubVecF32x4" c_BinaryenSubVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSubVecF32x4"
+  c_BinaryenSubVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenMulVecF32x4" c_BinaryenMulVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenMulVecF32x4"
+  c_BinaryenMulVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenDivVecF32x4" c_BinaryenDivVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenDivVecF32x4"
+  c_BinaryenDivVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenMinVecF32x4" c_BinaryenMinVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenMinVecF32x4"
+  c_BinaryenMinVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenMaxVecF32x4" c_BinaryenMaxVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenMaxVecF32x4"
+  c_BinaryenMaxVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAbsVecF64x2" c_BinaryenAbsVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAbsVecF64x2"
+  c_BinaryenAbsVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenNegVecF64x2" c_BinaryenNegVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenNegVecF64x2"
+  c_BinaryenNegVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSqrtVecF64x2" c_BinaryenSqrtVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSqrtVecF64x2"
+  c_BinaryenSqrtVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenAddVecF64x2" c_BinaryenAddVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenAddVecF64x2"
+  c_BinaryenAddVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenSubVecF64x2" c_BinaryenSubVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenSubVecF64x2"
+  c_BinaryenSubVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenMulVecF64x2" c_BinaryenMulVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenMulVecF64x2"
+  c_BinaryenMulVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenDivVecF64x2" c_BinaryenDivVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenDivVecF64x2"
+  c_BinaryenDivVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenMinVecF64x2" c_BinaryenMinVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenMinVecF64x2"
+  c_BinaryenMinVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenMaxVecF64x2" c_BinaryenMaxVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenMaxVecF64x2"
+  c_BinaryenMaxVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncSatSVecF32x4ToVecI32x4" c_BinaryenTruncSatSVecF32x4ToVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncSatSVecF32x4ToVecI32x4"
+  c_BinaryenTruncSatSVecF32x4ToVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncSatUVecF32x4ToVecI32x4" c_BinaryenTruncSatUVecF32x4ToVecI32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncSatUVecF32x4ToVecI32x4"
+  c_BinaryenTruncSatUVecF32x4ToVecI32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncSatSVecF64x2ToVecI64x2" c_BinaryenTruncSatSVecF64x2ToVecI64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncSatSVecF64x2ToVecI64x2"
+  c_BinaryenTruncSatSVecF64x2ToVecI64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenTruncSatUVecF64x2ToVecI64x2" c_BinaryenTruncSatUVecF64x2ToVecI64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenTruncSatUVecF64x2ToVecI64x2"
+  c_BinaryenTruncSatUVecF64x2ToVecI64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenConvertSVecI32x4ToVecF32x4" c_BinaryenConvertSVecI32x4ToVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenConvertSVecI32x4ToVecF32x4"
+  c_BinaryenConvertSVecI32x4ToVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenConvertUVecI32x4ToVecF32x4" c_BinaryenConvertUVecI32x4ToVecF32x4
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenConvertUVecI32x4ToVecF32x4"
+  c_BinaryenConvertUVecI32x4ToVecF32x4 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenConvertSVecI64x2ToVecF64x2" c_BinaryenConvertSVecI64x2ToVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenConvertSVecI64x2ToVecF64x2"
+  c_BinaryenConvertSVecI64x2ToVecF64x2 :: BinaryenOp
 
-foreign import ccall unsafe "BinaryenConvertUVecI64x2ToVecF64x2" c_BinaryenConvertUVecI64x2ToVecF64x2
-  :: BinaryenOp
+foreign import ccall unsafe "BinaryenConvertUVecI64x2ToVecF64x2"
+  c_BinaryenConvertUVecI64x2ToVecF64x2 :: BinaryenOp
 
 data BinaryenExpression
 
 type BinaryenExpressionRef = Ptr BinaryenExpression
 
-foreign import ccall unsafe "BinaryenBlock" c_BinaryenBlock
-  :: BinaryenModuleRef ->
-  Ptr CChar ->
-    Ptr BinaryenExpressionRef ->
-      BinaryenIndex -> BinaryenType -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenIf" c_BinaryenIf
-  :: BinaryenModuleRef ->
-  BinaryenExpressionRef ->
-    BinaryenExpressionRef ->
-      BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenLoop" c_BinaryenLoop
-  :: BinaryenModuleRef ->
-  Ptr CChar -> BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenBreak" c_BinaryenBreak
-  :: BinaryenModuleRef ->
-  Ptr CChar ->
-    BinaryenExpressionRef ->
-      BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenSwitch" c_BinaryenSwitch
-  :: BinaryenModuleRef ->
-  Ptr (Ptr CChar) ->
-    BinaryenIndex ->
-      Ptr CChar ->
-        BinaryenExpressionRef ->
-          BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenCall" c_BinaryenCall
-  :: BinaryenModuleRef ->
-  Ptr CChar ->
-    Ptr BinaryenExpressionRef ->
-      BinaryenIndex -> BinaryenType -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenCallIndirect" c_BinaryenCallIndirect
-  :: BinaryenModuleRef ->
-  BinaryenExpressionRef ->
-    Ptr BinaryenExpressionRef ->
-      BinaryenIndex -> Ptr CChar -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenReturnCall" c_BinaryenReturnCall
-  :: BinaryenModuleRef ->
-  Ptr CChar ->
-    Ptr BinaryenExpressionRef ->
-      BinaryenIndex -> BinaryenType -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenReturnCallIndirect" c_BinaryenReturnCallIndirect
-  :: BinaryenModuleRef ->
-  BinaryenExpressionRef ->
-    Ptr BinaryenExpressionRef ->
-      BinaryenIndex -> Ptr CChar -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenLocalGet" c_BinaryenLocalGet
-  :: BinaryenModuleRef ->
-  BinaryenIndex -> BinaryenType -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenLocalSet" c_BinaryenLocalSet
-  :: BinaryenModuleRef ->
-  BinaryenIndex -> BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenLocalTee" c_BinaryenLocalTee
-  :: BinaryenModuleRef ->
-  BinaryenIndex -> BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenGlobalGet" c_BinaryenGlobalGet
-  :: BinaryenModuleRef ->
-  Ptr CChar -> BinaryenType -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenGlobalSet" c_BinaryenGlobalSet
-  :: BinaryenModuleRef ->
-  Ptr CChar -> BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenLoad" c_BinaryenLoad
-  :: BinaryenModuleRef ->
-  Word32 ->
-    Int8 ->
-      Word32 ->
-        Word32 ->
-          BinaryenType -> BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenStore" c_BinaryenStore
-  :: BinaryenModuleRef ->
-  Word32 ->
-    Word32 ->
-      Word32 ->
-        BinaryenExpressionRef ->
-          BinaryenExpressionRef -> BinaryenType -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenUnary" c_BinaryenUnary
-  :: BinaryenModuleRef ->
-  BinaryenOp -> BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenBinary" c_BinaryenBinary
-  :: BinaryenModuleRef ->
-  BinaryenOp ->
-    BinaryenExpressionRef ->
-      BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenSelect" c_BinaryenSelect
-  :: BinaryenModuleRef ->
-  BinaryenExpressionRef ->
-    BinaryenExpressionRef ->
-      BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenDrop" c_BinaryenDrop
-  :: BinaryenModuleRef ->
-  BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenReturn" c_BinaryenReturn
-  :: BinaryenModuleRef ->
-  BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenHost" c_BinaryenHost
-  :: BinaryenModuleRef ->
-  BinaryenOp ->
+foreign import ccall unsafe "BinaryenBlock"
+  c_BinaryenBlock ::
+    BinaryenModuleRef ->
     Ptr CChar ->
-      Ptr BinaryenExpressionRef ->
-        BinaryenIndex -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenNop" c_BinaryenNop
-  :: BinaryenModuleRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenUnreachable" c_BinaryenUnreachable
-  :: BinaryenModuleRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenAtomicLoad" c_BinaryenAtomicLoad
-  :: BinaryenModuleRef ->
-  Word32 ->
-    Word32 ->
-      BinaryenType -> BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenAtomicStore" c_BinaryenAtomicStore
-  :: BinaryenModuleRef ->
-  Word32 ->
-    Word32 ->
-      BinaryenExpressionRef ->
-        BinaryenExpressionRef -> BinaryenType -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenAtomicRMW" c_BinaryenAtomicRMW
-  :: BinaryenModuleRef ->
-  BinaryenOp ->
+    Ptr BinaryenExpressionRef ->
     BinaryenIndex ->
-      BinaryenIndex ->
-        BinaryenExpressionRef ->
-          BinaryenExpressionRef -> BinaryenType -> IO BinaryenExpressionRef
+    BinaryenType ->
+    IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenAtomicCmpxchg" c_BinaryenAtomicCmpxchg
-  :: BinaryenModuleRef ->
-  BinaryenIndex ->
+foreign import ccall unsafe "BinaryenIf"
+  c_BinaryenIf ::
+    BinaryenModuleRef ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenLoop"
+  c_BinaryenLoop ::
+    BinaryenModuleRef ->
+    Ptr CChar ->
+    BinaryenExpressionRef ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenBreak"
+  c_BinaryenBreak ::
+    BinaryenModuleRef ->
+    Ptr CChar ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenSwitch"
+  c_BinaryenSwitch ::
+    BinaryenModuleRef ->
+    Ptr (Ptr CChar) ->
     BinaryenIndex ->
-      BinaryenExpressionRef ->
-        BinaryenExpressionRef ->
-          BinaryenExpressionRef -> BinaryenType -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenAtomicWait" c_BinaryenAtomicWait
-  :: BinaryenModuleRef ->
-  BinaryenExpressionRef ->
+    Ptr CChar ->
     BinaryenExpressionRef ->
-      BinaryenExpressionRef -> BinaryenType -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenAtomicNotify" c_BinaryenAtomicNotify
-  :: BinaryenModuleRef ->
-  BinaryenExpressionRef ->
-    BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenSIMDExtract" c_BinaryenSIMDExtract
-  :: BinaryenModuleRef ->
-  BinaryenOp ->
-    BinaryenExpressionRef -> Word8 -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenSIMDReplace" c_BinaryenSIMDReplace
-  :: BinaryenModuleRef ->
-  BinaryenOp ->
     BinaryenExpressionRef ->
-      Word8 -> BinaryenExpressionRef -> IO BinaryenExpressionRef
+    IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSIMDShuffle" c_BinaryenSIMDShuffle
-  :: BinaryenModuleRef ->
-  BinaryenExpressionRef ->
-    BinaryenExpressionRef -> Ptr Word8 -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenCall"
+  c_BinaryenCall ::
+    BinaryenModuleRef ->
+    Ptr CChar ->
+    Ptr BinaryenExpressionRef ->
+    BinaryenIndex ->
+    BinaryenType ->
+    IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSIMDBitselect" c_BinaryenSIMDBitselect
-  :: BinaryenModuleRef ->
-  BinaryenExpressionRef ->
+foreign import ccall unsafe "BinaryenCallIndirect"
+  c_BinaryenCallIndirect ::
+    BinaryenModuleRef ->
     BinaryenExpressionRef ->
-      BinaryenExpressionRef -> IO BinaryenExpressionRef
+    Ptr BinaryenExpressionRef ->
+    BinaryenIndex ->
+    Ptr CChar ->
+    IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSIMDShift" c_BinaryenSIMDShift
-  :: BinaryenModuleRef ->
-  BinaryenOp ->
+foreign import ccall unsafe "BinaryenReturnCall"
+  c_BinaryenReturnCall ::
+    BinaryenModuleRef ->
+    Ptr CChar ->
+    Ptr BinaryenExpressionRef ->
+    BinaryenIndex ->
+    BinaryenType ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenReturnCallIndirect"
+  c_BinaryenReturnCallIndirect ::
+    BinaryenModuleRef ->
     BinaryenExpressionRef ->
-      BinaryenExpressionRef -> IO BinaryenExpressionRef
+    Ptr BinaryenExpressionRef ->
+    BinaryenIndex ->
+    Ptr CChar ->
+    IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenMemoryInit" c_BinaryenMemoryInit
-  :: BinaryenModuleRef ->
-  Word32 ->
+foreign import ccall unsafe "BinaryenLocalGet"
+  c_BinaryenLocalGet ::
+    BinaryenModuleRef ->
+    BinaryenIndex ->
+    BinaryenType ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenLocalSet"
+  c_BinaryenLocalSet ::
+    BinaryenModuleRef ->
+    BinaryenIndex ->
     BinaryenExpressionRef ->
-      BinaryenExpressionRef ->
-        BinaryenExpressionRef -> IO BinaryenExpressionRef
+    IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenDataDrop" c_BinaryenDataDrop
-  :: BinaryenModuleRef -> Word32 -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenMemoryCopy" c_BinaryenMemoryCopy
-  :: BinaryenModuleRef ->
-  BinaryenExpressionRef ->
+foreign import ccall unsafe "BinaryenLocalTee"
+  c_BinaryenLocalTee ::
+    BinaryenModuleRef ->
+    BinaryenIndex ->
     BinaryenExpressionRef ->
-      BinaryenExpressionRef -> IO BinaryenExpressionRef
+    IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenMemoryFill" c_BinaryenMemoryFill
-  :: BinaryenModuleRef ->
-  BinaryenExpressionRef ->
+foreign import ccall unsafe "BinaryenGlobalGet"
+  c_BinaryenGlobalGet ::
+    BinaryenModuleRef ->
+    Ptr CChar ->
+    BinaryenType ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenGlobalSet"
+  c_BinaryenGlobalSet ::
+    BinaryenModuleRef ->
+    Ptr CChar ->
     BinaryenExpressionRef ->
-      BinaryenExpressionRef -> IO BinaryenExpressionRef
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenLoad"
+  c_BinaryenLoad ::
+    BinaryenModuleRef ->
+    Word32 ->
+    Int8 ->
+    Word32 ->
+    Word32 ->
+    BinaryenType ->
+    BinaryenExpressionRef ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenStore"
+  c_BinaryenStore ::
+    BinaryenModuleRef ->
+    Word32 ->
+    Word32 ->
+    Word32 ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    BinaryenType ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenUnary"
+  c_BinaryenUnary ::
+    BinaryenModuleRef ->
+    BinaryenOp ->
+    BinaryenExpressionRef ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenBinary"
+  c_BinaryenBinary ::
+    BinaryenModuleRef ->
+    BinaryenOp ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenSelect"
+  c_BinaryenSelect ::
+    BinaryenModuleRef ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenDrop"
+  c_BinaryenDrop ::
+    BinaryenModuleRef ->
+    BinaryenExpressionRef ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenReturn"
+  c_BinaryenReturn ::
+    BinaryenModuleRef ->
+    BinaryenExpressionRef ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenHost"
+  c_BinaryenHost ::
+    BinaryenModuleRef ->
+    BinaryenOp ->
+    Ptr CChar ->
+    Ptr BinaryenExpressionRef ->
+    BinaryenIndex ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenNop"
+  c_BinaryenNop :: BinaryenModuleRef -> IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenUnreachable"
+  c_BinaryenUnreachable :: BinaryenModuleRef -> IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenAtomicLoad"
+  c_BinaryenAtomicLoad ::
+    BinaryenModuleRef ->
+    Word32 ->
+    Word32 ->
+    BinaryenType ->
+    BinaryenExpressionRef ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenAtomicStore"
+  c_BinaryenAtomicStore ::
+    BinaryenModuleRef ->
+    Word32 ->
+    Word32 ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    BinaryenType ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenAtomicRMW"
+  c_BinaryenAtomicRMW ::
+    BinaryenModuleRef ->
+    BinaryenOp ->
+    BinaryenIndex ->
+    BinaryenIndex ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    BinaryenType ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenAtomicCmpxchg"
+  c_BinaryenAtomicCmpxchg ::
+    BinaryenModuleRef ->
+    BinaryenIndex ->
+    BinaryenIndex ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    BinaryenType ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenAtomicWait"
+  c_BinaryenAtomicWait ::
+    BinaryenModuleRef ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    BinaryenType ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenAtomicNotify"
+  c_BinaryenAtomicNotify ::
+    BinaryenModuleRef ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenSIMDExtract"
+  c_BinaryenSIMDExtract ::
+    BinaryenModuleRef ->
+    BinaryenOp ->
+    BinaryenExpressionRef ->
+    Word8 ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenSIMDReplace"
+  c_BinaryenSIMDReplace ::
+    BinaryenModuleRef ->
+    BinaryenOp ->
+    BinaryenExpressionRef ->
+    Word8 ->
+    BinaryenExpressionRef ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenSIMDShuffle"
+  c_BinaryenSIMDShuffle ::
+    BinaryenModuleRef ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    Ptr Word8 ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenSIMDBitselect"
+  c_BinaryenSIMDBitselect ::
+    BinaryenModuleRef ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenSIMDShift"
+  c_BinaryenSIMDShift ::
+    BinaryenModuleRef ->
+    BinaryenOp ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenMemoryInit"
+  c_BinaryenMemoryInit ::
+    BinaryenModuleRef ->
+    Word32 ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenDataDrop"
+  c_BinaryenDataDrop :: BinaryenModuleRef -> Word32 -> IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenMemoryCopy"
+  c_BinaryenMemoryCopy ::
+    BinaryenModuleRef ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenMemoryFill"
+  c_BinaryenMemoryFill ::
+    BinaryenModuleRef ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenExpressionGetId"
+  c_BinaryenExpressionGetId :: BinaryenExpressionRef -> IO BinaryenExpressionId
+
+foreign import ccall unsafe "BinaryenExpressionGetType"
+  c_BinaryenExpressionGetType :: BinaryenExpressionRef -> IO BinaryenType
+
+foreign import ccall unsafe "BinaryenExpressionPrint"
+  c_BinaryenExpressionPrint :: BinaryenExpressionRef -> IO ()
+
+foreign import ccall unsafe "BinaryenBlockGetName"
+  c_BinaryenBlockGetName :: BinaryenExpressionRef -> IO (Ptr CChar)
+
+foreign import ccall unsafe "BinaryenBlockGetNumChildren"
+  c_BinaryenBlockGetNumChildren :: BinaryenExpressionRef -> IO BinaryenIndex
+
+foreign import ccall unsafe "BinaryenBlockGetChild"
+  c_BinaryenBlockGetChild :: BinaryenExpressionRef -> BinaryenIndex -> IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenIfGetCondition"
+  c_BinaryenIfGetCondition :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenIfGetIfTrue"
+  c_BinaryenIfGetIfTrue :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenIfGetIfFalse"
+  c_BinaryenIfGetIfFalse :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenLoopGetName"
+  c_BinaryenLoopGetName :: BinaryenExpressionRef -> IO (Ptr CChar)
+
+foreign import ccall unsafe "BinaryenLoopGetBody"
+  c_BinaryenLoopGetBody :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenBreakGetName"
+  c_BinaryenBreakGetName :: BinaryenExpressionRef -> IO (Ptr CChar)
+
+foreign import ccall unsafe "BinaryenBreakGetCondition"
+  c_BinaryenBreakGetCondition :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenBreakGetValue"
+  c_BinaryenBreakGetValue :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+
+foreign import ccall unsafe "BinaryenSwitchGetNumNames"
+  c_BinaryenSwitchGetNumNames :: BinaryenExpressionRef -> IO BinaryenIndex
 
-foreign import ccall unsafe "BinaryenExpressionGetId" c_BinaryenExpressionGetId
-  :: BinaryenExpressionRef -> IO BinaryenExpressionId
+foreign import ccall unsafe "BinaryenSwitchGetName"
+  c_BinaryenSwitchGetName :: BinaryenExpressionRef -> BinaryenIndex -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenExpressionGetType" c_BinaryenExpressionGetType
-  :: BinaryenExpressionRef -> IO BinaryenType
+foreign import ccall unsafe "BinaryenSwitchGetDefaultName"
+  c_BinaryenSwitchGetDefaultName :: BinaryenExpressionRef -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenExpressionPrint" c_BinaryenExpressionPrint
-  :: BinaryenExpressionRef -> IO ()
+foreign import ccall unsafe "BinaryenSwitchGetCondition"
+  c_BinaryenSwitchGetCondition :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenBlockGetName" c_BinaryenBlockGetName
-  :: BinaryenExpressionRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenSwitchGetValue"
+  c_BinaryenSwitchGetValue :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenBlockGetNumChildren" c_BinaryenBlockGetNumChildren
-  :: BinaryenExpressionRef -> IO BinaryenIndex
+foreign import ccall unsafe "BinaryenCallGetTarget"
+  c_BinaryenCallGetTarget :: BinaryenExpressionRef -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenBlockGetChild" c_BinaryenBlockGetChild
-  :: BinaryenExpressionRef -> BinaryenIndex -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenCallGetNumOperands"
+  c_BinaryenCallGetNumOperands :: BinaryenExpressionRef -> IO BinaryenIndex
 
-foreign import ccall unsafe "BinaryenIfGetCondition" c_BinaryenIfGetCondition
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenCallGetOperand"
+  c_BinaryenCallGetOperand :: BinaryenExpressionRef -> BinaryenIndex -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenIfGetIfTrue" c_BinaryenIfGetIfTrue
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenCallIndirectGetTarget"
+  c_BinaryenCallIndirectGetTarget :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenIfGetIfFalse" c_BinaryenIfGetIfFalse
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenCallIndirectGetNumOperands"
+  c_BinaryenCallIndirectGetNumOperands :: BinaryenExpressionRef -> IO BinaryenIndex
 
-foreign import ccall unsafe "BinaryenLoopGetName" c_BinaryenLoopGetName
-  :: BinaryenExpressionRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenCallIndirectGetOperand"
+  c_BinaryenCallIndirectGetOperand :: BinaryenExpressionRef -> BinaryenIndex -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenLoopGetBody" c_BinaryenLoopGetBody
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenLocalGetGetIndex"
+  c_BinaryenLocalGetGetIndex :: BinaryenExpressionRef -> IO BinaryenIndex
 
-foreign import ccall unsafe "BinaryenBreakGetName" c_BinaryenBreakGetName
-  :: BinaryenExpressionRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenLocalSetIsTee"
+  c_BinaryenLocalSetIsTee :: BinaryenExpressionRef -> IO CInt
 
-foreign import ccall unsafe "BinaryenBreakGetCondition" c_BinaryenBreakGetCondition
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenLocalSetGetIndex"
+  c_BinaryenLocalSetGetIndex :: BinaryenExpressionRef -> IO BinaryenIndex
 
-foreign import ccall unsafe "BinaryenBreakGetValue" c_BinaryenBreakGetValue
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenLocalSetGetValue"
+  c_BinaryenLocalSetGetValue :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSwitchGetNumNames" c_BinaryenSwitchGetNumNames
-  :: BinaryenExpressionRef -> IO BinaryenIndex
+foreign import ccall unsafe "BinaryenGlobalGetGetName"
+  c_BinaryenGlobalGetGetName :: BinaryenExpressionRef -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenSwitchGetName" c_BinaryenSwitchGetName
-  :: BinaryenExpressionRef -> BinaryenIndex -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenGlobalSetGetName"
+  c_BinaryenGlobalSetGetName :: BinaryenExpressionRef -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenSwitchGetDefaultName" c_BinaryenSwitchGetDefaultName
-  :: BinaryenExpressionRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenGlobalSetGetValue"
+  c_BinaryenGlobalSetGetValue :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSwitchGetCondition" c_BinaryenSwitchGetCondition
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenHostGetOp"
+  c_BinaryenHostGetOp :: BinaryenExpressionRef -> IO BinaryenOp
 
-foreign import ccall unsafe "BinaryenSwitchGetValue" c_BinaryenSwitchGetValue
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenHostGetNameOperand"
+  c_BinaryenHostGetNameOperand :: BinaryenExpressionRef -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenCallGetTarget" c_BinaryenCallGetTarget
-  :: BinaryenExpressionRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenHostGetNumOperands"
+  c_BinaryenHostGetNumOperands :: BinaryenExpressionRef -> IO BinaryenIndex
 
-foreign import ccall unsafe "BinaryenCallGetNumOperands" c_BinaryenCallGetNumOperands
-  :: BinaryenExpressionRef -> IO BinaryenIndex
+foreign import ccall unsafe "BinaryenHostGetOperand"
+  c_BinaryenHostGetOperand :: BinaryenExpressionRef -> BinaryenIndex -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenCallGetOperand" c_BinaryenCallGetOperand
-  :: BinaryenExpressionRef -> BinaryenIndex -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenLoadIsAtomic"
+  c_BinaryenLoadIsAtomic :: BinaryenExpressionRef -> IO CInt
 
-foreign import ccall unsafe "BinaryenCallIndirectGetTarget" c_BinaryenCallIndirectGetTarget
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenLoadIsSigned"
+  c_BinaryenLoadIsSigned :: BinaryenExpressionRef -> IO CInt
 
-foreign import ccall unsafe "BinaryenCallIndirectGetNumOperands" c_BinaryenCallIndirectGetNumOperands
-  :: BinaryenExpressionRef -> IO BinaryenIndex
+foreign import ccall unsafe "BinaryenLoadGetOffset"
+  c_BinaryenLoadGetOffset :: BinaryenExpressionRef -> IO Word32
 
-foreign import ccall unsafe "BinaryenCallIndirectGetOperand" c_BinaryenCallIndirectGetOperand
-  :: BinaryenExpressionRef -> BinaryenIndex -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenLoadGetBytes"
+  c_BinaryenLoadGetBytes :: BinaryenExpressionRef -> IO Word32
 
-foreign import ccall unsafe "BinaryenLocalGetGetIndex" c_BinaryenLocalGetGetIndex
-  :: BinaryenExpressionRef -> IO BinaryenIndex
+foreign import ccall unsafe "BinaryenLoadGetAlign"
+  c_BinaryenLoadGetAlign :: BinaryenExpressionRef -> IO Word32
 
-foreign import ccall unsafe "BinaryenLocalSetIsTee" c_BinaryenLocalSetIsTee
-  :: BinaryenExpressionRef -> IO CInt
+foreign import ccall unsafe "BinaryenLoadGetPtr"
+  c_BinaryenLoadGetPtr :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenLocalSetGetIndex" c_BinaryenLocalSetGetIndex
-  :: BinaryenExpressionRef -> IO BinaryenIndex
+foreign import ccall unsafe "BinaryenStoreIsAtomic"
+  c_BinaryenStoreIsAtomic :: BinaryenExpressionRef -> IO CInt
 
-foreign import ccall unsafe "BinaryenLocalSetGetValue" c_BinaryenLocalSetGetValue
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenStoreGetBytes"
+  c_BinaryenStoreGetBytes :: BinaryenExpressionRef -> IO Word32
 
-foreign import ccall unsafe "BinaryenGlobalGetGetName" c_BinaryenGlobalGetGetName
-  :: BinaryenExpressionRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenStoreGetOffset"
+  c_BinaryenStoreGetOffset :: BinaryenExpressionRef -> IO Word32
 
-foreign import ccall unsafe "BinaryenGlobalSetGetName" c_BinaryenGlobalSetGetName
-  :: BinaryenExpressionRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenStoreGetAlign"
+  c_BinaryenStoreGetAlign :: BinaryenExpressionRef -> IO Word32
 
-foreign import ccall unsafe "BinaryenGlobalSetGetValue" c_BinaryenGlobalSetGetValue
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenStoreGetPtr"
+  c_BinaryenStoreGetPtr :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenHostGetOp" c_BinaryenHostGetOp
-  :: BinaryenExpressionRef -> IO BinaryenOp
+foreign import ccall unsafe "BinaryenStoreGetValue"
+  c_BinaryenStoreGetValue :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenHostGetNameOperand" c_BinaryenHostGetNameOperand
-  :: BinaryenExpressionRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenConstGetValueI32"
+  c_BinaryenConstGetValueI32 :: BinaryenExpressionRef -> IO Int32
 
-foreign import ccall unsafe "BinaryenHostGetNumOperands" c_BinaryenHostGetNumOperands
-  :: BinaryenExpressionRef -> IO BinaryenIndex
+foreign import ccall unsafe "BinaryenConstGetValueI64"
+  c_BinaryenConstGetValueI64 :: BinaryenExpressionRef -> IO Int64
 
-foreign import ccall unsafe "BinaryenHostGetOperand" c_BinaryenHostGetOperand
-  :: BinaryenExpressionRef -> BinaryenIndex -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenConstGetValueI64Low"
+  c_BinaryenConstGetValueI64Low :: BinaryenExpressionRef -> IO Int32
 
-foreign import ccall unsafe "BinaryenLoadIsAtomic" c_BinaryenLoadIsAtomic
-  :: BinaryenExpressionRef -> IO CInt
+foreign import ccall unsafe "BinaryenConstGetValueI64High"
+  c_BinaryenConstGetValueI64High :: BinaryenExpressionRef -> IO Int32
 
-foreign import ccall unsafe "BinaryenLoadIsSigned" c_BinaryenLoadIsSigned
-  :: BinaryenExpressionRef -> IO CInt
+foreign import ccall unsafe "BinaryenConstGetValueF32"
+  c_BinaryenConstGetValueF32 :: BinaryenExpressionRef -> IO CFloat
 
-foreign import ccall unsafe "BinaryenLoadGetOffset" c_BinaryenLoadGetOffset
-  :: BinaryenExpressionRef -> IO Word32
+foreign import ccall unsafe "BinaryenConstGetValueF64"
+  c_BinaryenConstGetValueF64 :: BinaryenExpressionRef -> IO CDouble
 
-foreign import ccall unsafe "BinaryenLoadGetBytes" c_BinaryenLoadGetBytes
-  :: BinaryenExpressionRef -> IO Word32
+foreign import ccall unsafe "BinaryenUnaryGetOp"
+  c_BinaryenUnaryGetOp :: BinaryenExpressionRef -> IO BinaryenOp
 
-foreign import ccall unsafe "BinaryenLoadGetAlign" c_BinaryenLoadGetAlign
-  :: BinaryenExpressionRef -> IO Word32
+foreign import ccall unsafe "BinaryenUnaryGetValue"
+  c_BinaryenUnaryGetValue :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenLoadGetPtr" c_BinaryenLoadGetPtr
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenBinaryGetOp"
+  c_BinaryenBinaryGetOp :: BinaryenExpressionRef -> IO BinaryenOp
 
-foreign import ccall unsafe "BinaryenStoreIsAtomic" c_BinaryenStoreIsAtomic
-  :: BinaryenExpressionRef -> IO CInt
+foreign import ccall unsafe "BinaryenBinaryGetLeft"
+  c_BinaryenBinaryGetLeft :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenStoreGetBytes" c_BinaryenStoreGetBytes
-  :: BinaryenExpressionRef -> IO Word32
+foreign import ccall unsafe "BinaryenBinaryGetRight"
+  c_BinaryenBinaryGetRight :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenStoreGetOffset" c_BinaryenStoreGetOffset
-  :: BinaryenExpressionRef -> IO Word32
+foreign import ccall unsafe "BinaryenSelectGetIfTrue"
+  c_BinaryenSelectGetIfTrue :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenStoreGetAlign" c_BinaryenStoreGetAlign
-  :: BinaryenExpressionRef -> IO Word32
+foreign import ccall unsafe "BinaryenSelectGetIfFalse"
+  c_BinaryenSelectGetIfFalse :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenStoreGetPtr" c_BinaryenStoreGetPtr
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenSelectGetCondition"
+  c_BinaryenSelectGetCondition :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenStoreGetValue" c_BinaryenStoreGetValue
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenDropGetValue"
+  c_BinaryenDropGetValue :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenConstGetValueI32" c_BinaryenConstGetValueI32
-  :: BinaryenExpressionRef -> IO Int32
+foreign import ccall unsafe "BinaryenReturnGetValue"
+  c_BinaryenReturnGetValue :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenConstGetValueI64" c_BinaryenConstGetValueI64
-  :: BinaryenExpressionRef -> IO Int64
+foreign import ccall unsafe "BinaryenAtomicRMWGetOp"
+  c_BinaryenAtomicRMWGetOp :: BinaryenExpressionRef -> IO BinaryenOp
 
-foreign import ccall unsafe "BinaryenConstGetValueI64Low" c_BinaryenConstGetValueI64Low
-  :: BinaryenExpressionRef -> IO Int32
+foreign import ccall unsafe "BinaryenAtomicRMWGetBytes"
+  c_BinaryenAtomicRMWGetBytes :: BinaryenExpressionRef -> IO Word32
 
-foreign import ccall unsafe "BinaryenConstGetValueI64High" c_BinaryenConstGetValueI64High
-  :: BinaryenExpressionRef -> IO Int32
+foreign import ccall unsafe "BinaryenAtomicRMWGetOffset"
+  c_BinaryenAtomicRMWGetOffset :: BinaryenExpressionRef -> IO Word32
 
-foreign import ccall unsafe "BinaryenConstGetValueF32" c_BinaryenConstGetValueF32
-  :: BinaryenExpressionRef -> IO CFloat
+foreign import ccall unsafe "BinaryenAtomicRMWGetPtr"
+  c_BinaryenAtomicRMWGetPtr :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenConstGetValueF64" c_BinaryenConstGetValueF64
-  :: BinaryenExpressionRef -> IO CDouble
+foreign import ccall unsafe "BinaryenAtomicRMWGetValue"
+  c_BinaryenAtomicRMWGetValue :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenUnaryGetOp" c_BinaryenUnaryGetOp
-  :: BinaryenExpressionRef -> IO BinaryenOp
+foreign import ccall unsafe "BinaryenAtomicCmpxchgGetBytes"
+  c_BinaryenAtomicCmpxchgGetBytes :: BinaryenExpressionRef -> IO Word32
 
-foreign import ccall unsafe "BinaryenUnaryGetValue" c_BinaryenUnaryGetValue
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenAtomicCmpxchgGetOffset"
+  c_BinaryenAtomicCmpxchgGetOffset :: BinaryenExpressionRef -> IO Word32
 
-foreign import ccall unsafe "BinaryenBinaryGetOp" c_BinaryenBinaryGetOp
-  :: BinaryenExpressionRef -> IO BinaryenOp
+foreign import ccall unsafe "BinaryenAtomicCmpxchgGetPtr"
+  c_BinaryenAtomicCmpxchgGetPtr :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenBinaryGetLeft" c_BinaryenBinaryGetLeft
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenAtomicCmpxchgGetExpected"
+  c_BinaryenAtomicCmpxchgGetExpected :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenBinaryGetRight" c_BinaryenBinaryGetRight
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenAtomicCmpxchgGetReplacement"
+  c_BinaryenAtomicCmpxchgGetReplacement :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSelectGetIfTrue" c_BinaryenSelectGetIfTrue
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenAtomicWaitGetPtr"
+  c_BinaryenAtomicWaitGetPtr :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSelectGetIfFalse" c_BinaryenSelectGetIfFalse
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenAtomicWaitGetExpected"
+  c_BinaryenAtomicWaitGetExpected :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSelectGetCondition" c_BinaryenSelectGetCondition
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenAtomicWaitGetTimeout"
+  c_BinaryenAtomicWaitGetTimeout :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenDropGetValue" c_BinaryenDropGetValue
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenAtomicWaitGetExpectedType"
+  c_BinaryenAtomicWaitGetExpectedType :: BinaryenExpressionRef -> IO BinaryenType
 
-foreign import ccall unsafe "BinaryenReturnGetValue" c_BinaryenReturnGetValue
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenAtomicNotifyGetPtr"
+  c_BinaryenAtomicNotifyGetPtr :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenAtomicRMWGetOp" c_BinaryenAtomicRMWGetOp
-  :: BinaryenExpressionRef -> IO BinaryenOp
+foreign import ccall unsafe "BinaryenAtomicNotifyGetNotifyCount"
+  c_BinaryenAtomicNotifyGetNotifyCount :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenAtomicRMWGetBytes" c_BinaryenAtomicRMWGetBytes
-  :: BinaryenExpressionRef -> IO Word32
+foreign import ccall unsafe "BinaryenSIMDExtractGetOp"
+  c_BinaryenSIMDExtractGetOp :: BinaryenExpressionRef -> IO BinaryenOp
 
-foreign import ccall unsafe "BinaryenAtomicRMWGetOffset" c_BinaryenAtomicRMWGetOffset
-  :: BinaryenExpressionRef -> IO Word32
+foreign import ccall unsafe "BinaryenSIMDExtractGetVec"
+  c_BinaryenSIMDExtractGetVec :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenAtomicRMWGetPtr" c_BinaryenAtomicRMWGetPtr
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenSIMDExtractGetIndex"
+  c_BinaryenSIMDExtractGetIndex :: BinaryenExpressionRef -> IO Word8
 
-foreign import ccall unsafe "BinaryenAtomicRMWGetValue" c_BinaryenAtomicRMWGetValue
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenSIMDReplaceGetOp"
+  c_BinaryenSIMDReplaceGetOp :: BinaryenExpressionRef -> IO BinaryenOp
 
-foreign import ccall unsafe "BinaryenAtomicCmpxchgGetBytes" c_BinaryenAtomicCmpxchgGetBytes
-  :: BinaryenExpressionRef -> IO Word32
+foreign import ccall unsafe "BinaryenSIMDReplaceGetVec"
+  c_BinaryenSIMDReplaceGetVec :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenAtomicCmpxchgGetOffset" c_BinaryenAtomicCmpxchgGetOffset
-  :: BinaryenExpressionRef -> IO Word32
+foreign import ccall unsafe "BinaryenSIMDReplaceGetIndex"
+  c_BinaryenSIMDReplaceGetIndex :: BinaryenExpressionRef -> IO Word8
 
-foreign import ccall unsafe "BinaryenAtomicCmpxchgGetPtr" c_BinaryenAtomicCmpxchgGetPtr
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenSIMDReplaceGetValue"
+  c_BinaryenSIMDReplaceGetValue :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenAtomicCmpxchgGetExpected" c_BinaryenAtomicCmpxchgGetExpected
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenSIMDShuffleGetLeft"
+  c_BinaryenSIMDShuffleGetLeft :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenAtomicCmpxchgGetReplacement" c_BinaryenAtomicCmpxchgGetReplacement
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenSIMDShuffleGetRight"
+  c_BinaryenSIMDShuffleGetRight :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenAtomicWaitGetPtr" c_BinaryenAtomicWaitGetPtr
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenSIMDShuffleGetMask"
+  c_BinaryenSIMDShuffleGetMask :: BinaryenExpressionRef -> Ptr Word8 -> IO ()
 
-foreign import ccall unsafe "BinaryenAtomicWaitGetExpected" c_BinaryenAtomicWaitGetExpected
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenSIMDBitselectGetLeft"
+  c_BinaryenSIMDBitselectGetLeft :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenAtomicWaitGetTimeout" c_BinaryenAtomicWaitGetTimeout
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenSIMDBitselectGetRight"
+  c_BinaryenSIMDBitselectGetRight :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenAtomicWaitGetExpectedType" c_BinaryenAtomicWaitGetExpectedType
-  :: BinaryenExpressionRef -> IO BinaryenType
+foreign import ccall unsafe "BinaryenSIMDBitselectGetCond"
+  c_BinaryenSIMDBitselectGetCond :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenAtomicNotifyGetPtr" c_BinaryenAtomicNotifyGetPtr
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenSIMDShiftGetOp"
+  c_BinaryenSIMDShiftGetOp :: BinaryenExpressionRef -> IO BinaryenOp
 
-foreign import ccall unsafe "BinaryenAtomicNotifyGetNotifyCount" c_BinaryenAtomicNotifyGetNotifyCount
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenSIMDShiftGetVec"
+  c_BinaryenSIMDShiftGetVec :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSIMDExtractGetOp" c_BinaryenSIMDExtractGetOp
-  :: BinaryenExpressionRef -> IO BinaryenOp
+foreign import ccall unsafe "BinaryenSIMDShiftGetShift"
+  c_BinaryenSIMDShiftGetShift :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSIMDExtractGetVec" c_BinaryenSIMDExtractGetVec
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenMemoryInitGetSegment"
+  c_BinaryenMemoryInitGetSegment :: BinaryenExpressionRef -> IO Word32
 
-foreign import ccall unsafe "BinaryenSIMDExtractGetIndex" c_BinaryenSIMDExtractGetIndex
-  :: BinaryenExpressionRef -> IO Word8
+foreign import ccall unsafe "BinaryenMemoryInitGetDest"
+  c_BinaryenMemoryInitGetDest :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSIMDReplaceGetOp" c_BinaryenSIMDReplaceGetOp
-  :: BinaryenExpressionRef -> IO BinaryenOp
+foreign import ccall unsafe "BinaryenMemoryInitGetOffset"
+  c_BinaryenMemoryInitGetOffset :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSIMDReplaceGetVec" c_BinaryenSIMDReplaceGetVec
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenMemoryInitGetSize"
+  c_BinaryenMemoryInitGetSize :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSIMDReplaceGetIndex" c_BinaryenSIMDReplaceGetIndex
-  :: BinaryenExpressionRef -> IO Word8
+foreign import ccall unsafe "BinaryenDataDropGetSegment"
+  c_BinaryenDataDropGetSegment :: BinaryenExpressionRef -> IO Word32
 
-foreign import ccall unsafe "BinaryenSIMDReplaceGetValue" c_BinaryenSIMDReplaceGetValue
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenMemoryCopyGetDest"
+  c_BinaryenMemoryCopyGetDest :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSIMDShuffleGetLeft" c_BinaryenSIMDShuffleGetLeft
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenMemoryCopyGetSource"
+  c_BinaryenMemoryCopyGetSource :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSIMDShuffleGetRight" c_BinaryenSIMDShuffleGetRight
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenMemoryCopyGetSize"
+  c_BinaryenMemoryCopyGetSize :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSIMDShuffleGetMask" c_BinaryenSIMDShuffleGetMask
-  :: BinaryenExpressionRef -> Ptr Word8 -> IO ()
+foreign import ccall unsafe "BinaryenMemoryFillGetDest"
+  c_BinaryenMemoryFillGetDest :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSIMDBitselectGetLeft" c_BinaryenSIMDBitselectGetLeft
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenMemoryFillGetValue"
+  c_BinaryenMemoryFillGetValue :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSIMDBitselectGetRight" c_BinaryenSIMDBitselectGetRight
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenSIMDBitselectGetCond" c_BinaryenSIMDBitselectGetCond
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenSIMDShiftGetOp" c_BinaryenSIMDShiftGetOp
-  :: BinaryenExpressionRef -> IO BinaryenOp
-
-foreign import ccall unsafe "BinaryenSIMDShiftGetVec" c_BinaryenSIMDShiftGetVec
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenSIMDShiftGetShift" c_BinaryenSIMDShiftGetShift
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenMemoryInitGetSegment" c_BinaryenMemoryInitGetSegment
-  :: BinaryenExpressionRef -> IO Word32
-
-foreign import ccall unsafe "BinaryenMemoryInitGetDest" c_BinaryenMemoryInitGetDest
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenMemoryInitGetOffset" c_BinaryenMemoryInitGetOffset
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenMemoryInitGetSize" c_BinaryenMemoryInitGetSize
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenDataDropGetSegment" c_BinaryenDataDropGetSegment
-  :: BinaryenExpressionRef -> IO Word32
-
-foreign import ccall unsafe "BinaryenMemoryCopyGetDest" c_BinaryenMemoryCopyGetDest
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenMemoryCopyGetSource" c_BinaryenMemoryCopyGetSource
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenMemoryCopyGetSize" c_BinaryenMemoryCopyGetSize
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenMemoryFillGetDest" c_BinaryenMemoryFillGetDest
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenMemoryFillGetValue" c_BinaryenMemoryFillGetValue
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
-
-foreign import ccall unsafe "BinaryenMemoryFillGetSize" c_BinaryenMemoryFillGetSize
-  :: BinaryenExpressionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenMemoryFillGetSize"
+  c_BinaryenMemoryFillGetSize :: BinaryenExpressionRef -> IO BinaryenExpressionRef
 
 data BinaryenFunction
 
 type BinaryenFunctionRef = Ptr BinaryenFunction
 
-foreign import ccall unsafe "BinaryenAddFunction" c_BinaryenAddFunction
-  :: BinaryenModuleRef ->
-  Ptr CChar ->
-    BinaryenFunctionTypeRef ->
-      Ptr BinaryenType ->
-        BinaryenIndex -> BinaryenExpressionRef -> IO BinaryenFunctionRef
-
-foreign import ccall unsafe "BinaryenGetFunction" c_BinaryenGetFunction
-  :: BinaryenModuleRef -> Ptr CChar -> IO BinaryenFunctionRef
-
-foreign import ccall unsafe "BinaryenRemoveFunction" c_BinaryenRemoveFunction
-  :: BinaryenModuleRef -> Ptr CChar -> IO ()
-
-foreign import ccall unsafe "BinaryenAddFunctionImport" c_BinaryenAddFunctionImport
-  :: BinaryenModuleRef ->
-  Ptr CChar ->
-    Ptr CChar -> Ptr CChar -> BinaryenFunctionTypeRef -> IO ()
-
-foreign import ccall unsafe "BinaryenAddTableImport" c_BinaryenAddTableImport
-  :: BinaryenModuleRef -> Ptr CChar -> Ptr CChar -> Ptr CChar -> IO ()
-
-foreign import ccall unsafe "BinaryenAddMemoryImport" c_BinaryenAddMemoryImport
-  :: BinaryenModuleRef ->
-  Ptr CChar -> Ptr CChar -> Ptr CChar -> Word8 -> IO ()
-
-foreign import ccall unsafe "BinaryenAddGlobalImport" c_BinaryenAddGlobalImport
-  :: BinaryenModuleRef ->
-  Ptr CChar -> Ptr CChar -> Ptr CChar -> BinaryenType -> IO ()
-
-foreign import ccall unsafe "BinaryenAddEventImport" c_BinaryenAddEventImport
-  :: BinaryenModuleRef ->
-  Ptr CChar ->
+foreign import ccall unsafe "BinaryenAddFunction"
+  c_BinaryenAddFunction ::
+    BinaryenModuleRef ->
     Ptr CChar ->
-      Ptr CChar -> Word32 -> BinaryenFunctionTypeRef -> IO ()
+    BinaryenFunctionTypeRef ->
+    Ptr BinaryenType ->
+    BinaryenIndex ->
+    BinaryenExpressionRef ->
+    IO BinaryenFunctionRef
+
+foreign import ccall unsafe "BinaryenGetFunction"
+  c_BinaryenGetFunction :: BinaryenModuleRef -> Ptr CChar -> IO BinaryenFunctionRef
+
+foreign import ccall unsafe "BinaryenRemoveFunction"
+  c_BinaryenRemoveFunction :: BinaryenModuleRef -> Ptr CChar -> IO ()
+
+foreign import ccall unsafe "BinaryenAddFunctionImport"
+  c_BinaryenAddFunctionImport ::
+    BinaryenModuleRef ->
+    Ptr CChar ->
+    Ptr CChar ->
+    Ptr CChar ->
+    BinaryenFunctionTypeRef ->
+    IO ()
+
+foreign import ccall unsafe "BinaryenAddTableImport"
+  c_BinaryenAddTableImport :: BinaryenModuleRef -> Ptr CChar -> Ptr CChar -> Ptr CChar -> IO ()
+
+foreign import ccall unsafe "BinaryenAddMemoryImport"
+  c_BinaryenAddMemoryImport ::
+    BinaryenModuleRef ->
+    Ptr CChar ->
+    Ptr CChar ->
+    Ptr CChar ->
+    Word8 ->
+    IO ()
+
+foreign import ccall unsafe "BinaryenAddGlobalImport"
+  c_BinaryenAddGlobalImport ::
+    BinaryenModuleRef ->
+    Ptr CChar ->
+    Ptr CChar ->
+    Ptr CChar ->
+    BinaryenType ->
+    IO ()
+
+foreign import ccall unsafe "BinaryenAddEventImport"
+  c_BinaryenAddEventImport ::
+    BinaryenModuleRef ->
+    Ptr CChar ->
+    Ptr CChar ->
+    Ptr CChar ->
+    Word32 ->
+    BinaryenFunctionTypeRef ->
+    IO ()
 
 data BinaryenExport
 
 type BinaryenExportRef = Ptr BinaryenExport
 
-foreign import ccall unsafe "BinaryenAddFunctionExport" c_BinaryenAddFunctionExport
-  :: BinaryenModuleRef -> Ptr CChar -> Ptr CChar -> IO BinaryenExportRef
+foreign import ccall unsafe "BinaryenAddFunctionExport"
+  c_BinaryenAddFunctionExport :: BinaryenModuleRef -> Ptr CChar -> Ptr CChar -> IO BinaryenExportRef
 
-foreign import ccall unsafe "BinaryenAddTableExport" c_BinaryenAddTableExport
-  :: BinaryenModuleRef -> Ptr CChar -> Ptr CChar -> IO BinaryenExportRef
+foreign import ccall unsafe "BinaryenAddTableExport"
+  c_BinaryenAddTableExport :: BinaryenModuleRef -> Ptr CChar -> Ptr CChar -> IO BinaryenExportRef
 
-foreign import ccall unsafe "BinaryenAddMemoryExport" c_BinaryenAddMemoryExport
-  :: BinaryenModuleRef -> Ptr CChar -> Ptr CChar -> IO BinaryenExportRef
+foreign import ccall unsafe "BinaryenAddMemoryExport"
+  c_BinaryenAddMemoryExport :: BinaryenModuleRef -> Ptr CChar -> Ptr CChar -> IO BinaryenExportRef
 
-foreign import ccall unsafe "BinaryenAddGlobalExport" c_BinaryenAddGlobalExport
-  :: BinaryenModuleRef -> Ptr CChar -> Ptr CChar -> IO BinaryenExportRef
+foreign import ccall unsafe "BinaryenAddGlobalExport"
+  c_BinaryenAddGlobalExport :: BinaryenModuleRef -> Ptr CChar -> Ptr CChar -> IO BinaryenExportRef
 
-foreign import ccall unsafe "BinaryenAddEventExport" c_BinaryenAddEventExport
-  :: BinaryenModuleRef -> Ptr CChar -> Ptr CChar -> IO BinaryenExportRef
+foreign import ccall unsafe "BinaryenAddEventExport"
+  c_BinaryenAddEventExport :: BinaryenModuleRef -> Ptr CChar -> Ptr CChar -> IO BinaryenExportRef
 
-foreign import ccall unsafe "BinaryenRemoveExport" c_BinaryenRemoveExport
-  :: BinaryenModuleRef -> Ptr CChar -> IO ()
+foreign import ccall unsafe "BinaryenRemoveExport"
+  c_BinaryenRemoveExport :: BinaryenModuleRef -> Ptr CChar -> IO ()
 
 data BinaryenGlobal
 
 type BinaryenGlobalRef = Ptr BinaryenGlobal
 
-foreign import ccall unsafe "BinaryenAddGlobal" c_BinaryenAddGlobal
-  :: BinaryenModuleRef ->
-  Ptr CChar ->
+foreign import ccall unsafe "BinaryenAddGlobal"
+  c_BinaryenAddGlobal ::
+    BinaryenModuleRef ->
+    Ptr CChar ->
     BinaryenType ->
-      Int8 -> BinaryenExpressionRef -> IO BinaryenGlobalRef
+    Int8 ->
+    BinaryenExpressionRef ->
+    IO BinaryenGlobalRef
 
-foreign import ccall unsafe "BinaryenGetGlobal" c_BinaryenGetGlobal
-  :: BinaryenModuleRef -> Ptr CChar -> IO BinaryenGlobalRef
+foreign import ccall unsafe "BinaryenGetGlobal"
+  c_BinaryenGetGlobal :: BinaryenModuleRef -> Ptr CChar -> IO BinaryenGlobalRef
 
-foreign import ccall unsafe "BinaryenRemoveGlobal" c_BinaryenRemoveGlobal
-  :: BinaryenModuleRef -> Ptr CChar -> IO ()
+foreign import ccall unsafe "BinaryenRemoveGlobal"
+  c_BinaryenRemoveGlobal :: BinaryenModuleRef -> Ptr CChar -> IO ()
 
 data BinaryenEvent
 
 type BinaryenEventRef = Ptr BinaryenEvent
 
-foreign import ccall unsafe "BinaryenAddEvent" c_BinaryenAddEvent
-  :: BinaryenModuleRef ->
-  Ptr CChar ->
-    Word32 -> BinaryenFunctionTypeRef -> IO BinaryenEventRef
+foreign import ccall unsafe "BinaryenAddEvent"
+  c_BinaryenAddEvent ::
+    BinaryenModuleRef ->
+    Ptr CChar ->
+    Word32 ->
+    BinaryenFunctionTypeRef ->
+    IO BinaryenEventRef
 
-foreign import ccall unsafe "BinaryenGetEvent" c_BinaryenGetEvent
-  :: BinaryenModuleRef -> Ptr CChar -> IO BinaryenEventRef
+foreign import ccall unsafe "BinaryenGetEvent"
+  c_BinaryenGetEvent :: BinaryenModuleRef -> Ptr CChar -> IO BinaryenEventRef
 
-foreign import ccall unsafe "BinaryenRemoveEvent" c_BinaryenRemoveEvent
-  :: BinaryenModuleRef -> Ptr CChar -> IO ()
+foreign import ccall unsafe "BinaryenRemoveEvent"
+  c_BinaryenRemoveEvent :: BinaryenModuleRef -> Ptr CChar -> IO ()
 
-foreign import ccall unsafe "BinaryenSetFunctionTable" c_BinaryenSetFunctionTable
-  :: BinaryenModuleRef ->
-  BinaryenIndex ->
-    BinaryenIndex -> Ptr (Ptr CChar) -> BinaryenIndex -> IO ()
-
-foreign import ccall unsafe "BinaryenSetFunctionTableWithOffset" c_BinaryenSetFunctionTableWithOffset
-  :: BinaryenModuleRef ->
-  BinaryenIndex ->
+foreign import ccall unsafe "BinaryenSetFunctionTable"
+  c_BinaryenSetFunctionTable ::
+    BinaryenModuleRef ->
     BinaryenIndex ->
-      BinaryenIndex -> Ptr (Ptr CChar) -> BinaryenIndex -> IO ()
-
-foreign import ccall unsafe "BinaryenSetMemory" c_BinaryenSetMemory
-  :: BinaryenModuleRef ->
-  BinaryenIndex ->
     BinaryenIndex ->
-      Ptr CChar ->
-        Ptr (Ptr CChar) ->
-          Ptr Int8 ->
-            Ptr BinaryenExpressionRef ->
-              Ptr BinaryenIndex -> BinaryenIndex -> Word8 -> IO ()
+    Ptr (Ptr CChar) ->
+    BinaryenIndex ->
+    IO ()
 
-foreign import ccall unsafe "BinaryenSetStart" c_BinaryenSetStart
-  :: BinaryenModuleRef -> BinaryenFunctionRef -> IO ()
+foreign import ccall unsafe "BinaryenSetFunctionTableWithOffset"
+  c_BinaryenSetFunctionTableWithOffset ::
+    BinaryenModuleRef ->
+    BinaryenIndex ->
+    BinaryenIndex ->
+    BinaryenIndex ->
+    Ptr (Ptr CChar) ->
+    BinaryenIndex ->
+    IO ()
 
-foreign import ccall unsafe "BinaryenModuleGetFeatures" c_BinaryenModuleGetFeatures
-  :: BinaryenModuleRef -> IO BinaryenFeatures
+foreign import ccall unsafe "BinaryenSetMemory"
+  c_BinaryenSetMemory ::
+    BinaryenModuleRef ->
+    BinaryenIndex ->
+    BinaryenIndex ->
+    Ptr CChar ->
+    Ptr (Ptr CChar) ->
+    Ptr Int8 ->
+    Ptr BinaryenExpressionRef ->
+    Ptr BinaryenIndex ->
+    BinaryenIndex ->
+    Word8 ->
+    IO ()
 
-foreign import ccall unsafe "BinaryenModuleSetFeatures" c_BinaryenModuleSetFeatures
-  :: BinaryenModuleRef -> BinaryenFeatures -> IO ()
+foreign import ccall unsafe "BinaryenSetStart"
+  c_BinaryenSetStart :: BinaryenModuleRef -> BinaryenFunctionRef -> IO ()
 
-foreign import ccall unsafe "BinaryenModuleParse" c_BinaryenModuleParse
-  :: Ptr CChar -> IO BinaryenModuleRef
+foreign import ccall unsafe "BinaryenModuleGetFeatures"
+  c_BinaryenModuleGetFeatures :: BinaryenModuleRef -> IO BinaryenFeatures
 
-foreign import ccall unsafe "BinaryenModulePrint" c_BinaryenModulePrint
-  :: BinaryenModuleRef -> IO ()
+foreign import ccall unsafe "BinaryenModuleSetFeatures"
+  c_BinaryenModuleSetFeatures :: BinaryenModuleRef -> BinaryenFeatures -> IO ()
 
-foreign import ccall unsafe "BinaryenModulePrintAsmjs" c_BinaryenModulePrintAsmjs
-  :: BinaryenModuleRef -> IO ()
+foreign import ccall unsafe "BinaryenModuleParse"
+  c_BinaryenModuleParse :: Ptr CChar -> IO BinaryenModuleRef
 
-foreign import ccall unsafe "BinaryenModuleValidate" c_BinaryenModuleValidate
-  :: BinaryenModuleRef -> IO CInt
+foreign import ccall unsafe "BinaryenModulePrint"
+  c_BinaryenModulePrint :: BinaryenModuleRef -> IO ()
 
-foreign import ccall unsafe "BinaryenModuleOptimize" c_BinaryenModuleOptimize
-  :: BinaryenModuleRef -> IO ()
+foreign import ccall unsafe "BinaryenModulePrintAsmjs"
+  c_BinaryenModulePrintAsmjs :: BinaryenModuleRef -> IO ()
 
-foreign import ccall unsafe "BinaryenGetOptimizeLevel" c_BinaryenGetOptimizeLevel
-  :: IO CInt
+foreign import ccall unsafe "BinaryenModuleValidate"
+  c_BinaryenModuleValidate :: BinaryenModuleRef -> IO CInt
 
-foreign import ccall unsafe "BinaryenSetOptimizeLevel" c_BinaryenSetOptimizeLevel
-  :: CInt -> IO ()
+foreign import ccall unsafe "BinaryenModuleOptimize"
+  c_BinaryenModuleOptimize :: BinaryenModuleRef -> IO ()
 
-foreign import ccall unsafe "BinaryenGetShrinkLevel" c_BinaryenGetShrinkLevel
-  :: IO CInt
+foreign import ccall unsafe "BinaryenGetOptimizeLevel"
+  c_BinaryenGetOptimizeLevel :: IO CInt
 
-foreign import ccall unsafe "BinaryenSetShrinkLevel" c_BinaryenSetShrinkLevel
-  :: CInt -> IO ()
+foreign import ccall unsafe "BinaryenSetOptimizeLevel"
+  c_BinaryenSetOptimizeLevel :: CInt -> IO ()
 
-foreign import ccall unsafe "BinaryenGetDebugInfo" c_BinaryenGetDebugInfo
-  :: IO CInt
+foreign import ccall unsafe "BinaryenGetShrinkLevel"
+  c_BinaryenGetShrinkLevel :: IO CInt
 
-foreign import ccall unsafe "BinaryenSetDebugInfo" c_BinaryenSetDebugInfo
-  :: CInt -> IO ()
+foreign import ccall unsafe "BinaryenSetShrinkLevel"
+  c_BinaryenSetShrinkLevel :: CInt -> IO ()
 
-foreign import ccall unsafe "BinaryenModuleRunPasses" c_BinaryenModuleRunPasses
-  :: BinaryenModuleRef -> Ptr (Ptr CChar) -> BinaryenIndex -> IO ()
+foreign import ccall unsafe "BinaryenGetDebugInfo"
+  c_BinaryenGetDebugInfo :: IO CInt
 
-foreign import ccall unsafe "BinaryenModuleAutoDrop" c_BinaryenModuleAutoDrop
-  :: BinaryenModuleRef -> IO ()
+foreign import ccall unsafe "BinaryenSetDebugInfo"
+  c_BinaryenSetDebugInfo :: CInt -> IO ()
 
-foreign import ccall unsafe "BinaryenModuleWrite" c_BinaryenModuleWrite
-  :: BinaryenModuleRef -> Ptr CChar -> CSize -> IO CSize
+foreign import ccall unsafe "BinaryenModuleRunPasses"
+  c_BinaryenModuleRunPasses :: BinaryenModuleRef -> Ptr (Ptr CChar) -> BinaryenIndex -> IO ()
 
-foreign import ccall unsafe "BinaryenModuleWriteText" c_BinaryenModuleWriteText
-  :: BinaryenModuleRef -> Ptr CChar -> CSize -> IO CSize
+foreign import ccall unsafe "BinaryenModuleAutoDrop"
+  c_BinaryenModuleAutoDrop :: BinaryenModuleRef -> IO ()
 
-foreign import ccall unsafe "BinaryenModuleAllocateAndWriteMut" c_BinaryenModuleAllocateAndWriteMut
-  :: BinaryenModuleRef ->
-  Ptr CChar -> Ptr (Ptr ()) -> Ptr CSize -> Ptr (Ptr CChar) -> IO ()
+foreign import ccall unsafe "BinaryenModuleWrite"
+  c_BinaryenModuleWrite :: BinaryenModuleRef -> Ptr CChar -> CSize -> IO CSize
 
-foreign import ccall unsafe "BinaryenModuleAllocateAndWriteText" c_BinaryenModuleAllocateAndWriteText
-  :: BinaryenModuleRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenModuleWriteText"
+  c_BinaryenModuleWriteText :: BinaryenModuleRef -> Ptr CChar -> CSize -> IO CSize
 
-foreign import ccall unsafe "BinaryenModuleRead" c_BinaryenModuleRead
-  :: Ptr CChar -> CSize -> IO BinaryenModuleRef
+foreign import ccall unsafe "BinaryenModuleAllocateAndWriteMut"
+  c_BinaryenModuleAllocateAndWriteMut ::
+    BinaryenModuleRef ->
+    Ptr CChar ->
+    Ptr (Ptr ()) ->
+    Ptr CSize ->
+    Ptr (Ptr CChar) ->
+    IO ()
 
-foreign import ccall unsafe "BinaryenModuleInterpret" c_BinaryenModuleInterpret
-  :: BinaryenModuleRef -> IO ()
+foreign import ccall unsafe "BinaryenModuleAllocateAndWriteText"
+  c_BinaryenModuleAllocateAndWriteText :: BinaryenModuleRef -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenModuleAddDebugInfoFileName" c_BinaryenModuleAddDebugInfoFileName
-  :: BinaryenModuleRef -> Ptr CChar -> IO BinaryenIndex
+foreign import ccall unsafe "BinaryenModuleRead"
+  c_BinaryenModuleRead :: Ptr CChar -> CSize -> IO BinaryenModuleRef
 
-foreign import ccall unsafe "BinaryenModuleGetDebugInfoFileName" c_BinaryenModuleGetDebugInfoFileName
-  :: BinaryenModuleRef -> BinaryenIndex -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenModuleInterpret"
+  c_BinaryenModuleInterpret :: BinaryenModuleRef -> IO ()
 
-foreign import ccall unsafe "BinaryenFunctionTypeGetName" c_BinaryenFunctionTypeGetName
-  :: BinaryenFunctionTypeRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenModuleAddDebugInfoFileName"
+  c_BinaryenModuleAddDebugInfoFileName :: BinaryenModuleRef -> Ptr CChar -> IO BinaryenIndex
 
-foreign import ccall unsafe "BinaryenFunctionTypeGetNumParams" c_BinaryenFunctionTypeGetNumParams
-  :: BinaryenFunctionTypeRef -> IO BinaryenIndex
+foreign import ccall unsafe "BinaryenModuleGetDebugInfoFileName"
+  c_BinaryenModuleGetDebugInfoFileName :: BinaryenModuleRef -> BinaryenIndex -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenFunctionTypeGetParam" c_BinaryenFunctionTypeGetParam
-  :: BinaryenFunctionTypeRef -> BinaryenIndex -> IO BinaryenType
+foreign import ccall unsafe "BinaryenFunctionTypeGetName"
+  c_BinaryenFunctionTypeGetName :: BinaryenFunctionTypeRef -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenFunctionTypeGetResult" c_BinaryenFunctionTypeGetResult
-  :: BinaryenFunctionTypeRef -> IO BinaryenType
+foreign import ccall unsafe "BinaryenFunctionTypeGetNumParams"
+  c_BinaryenFunctionTypeGetNumParams :: BinaryenFunctionTypeRef -> IO BinaryenIndex
 
-foreign import ccall unsafe "BinaryenFunctionGetName" c_BinaryenFunctionGetName
-  :: BinaryenFunctionRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenFunctionTypeGetParam"
+  c_BinaryenFunctionTypeGetParam :: BinaryenFunctionTypeRef -> BinaryenIndex -> IO BinaryenType
 
-foreign import ccall unsafe "BinaryenFunctionGetType" c_BinaryenFunctionGetType
-  :: BinaryenFunctionRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenFunctionTypeGetResult"
+  c_BinaryenFunctionTypeGetResult :: BinaryenFunctionTypeRef -> IO BinaryenType
 
-foreign import ccall unsafe "BinaryenFunctionGetNumParams" c_BinaryenFunctionGetNumParams
-  :: BinaryenFunctionRef -> IO BinaryenIndex
+foreign import ccall unsafe "BinaryenFunctionGetName"
+  c_BinaryenFunctionGetName :: BinaryenFunctionRef -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenFunctionGetParam" c_BinaryenFunctionGetParam
-  :: BinaryenFunctionRef -> BinaryenIndex -> IO BinaryenType
+foreign import ccall unsafe "BinaryenFunctionGetType"
+  c_BinaryenFunctionGetType :: BinaryenFunctionRef -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenFunctionGetResult" c_BinaryenFunctionGetResult
-  :: BinaryenFunctionRef -> IO BinaryenType
+foreign import ccall unsafe "BinaryenFunctionGetNumParams"
+  c_BinaryenFunctionGetNumParams :: BinaryenFunctionRef -> IO BinaryenIndex
 
-foreign import ccall unsafe "BinaryenFunctionGetNumVars" c_BinaryenFunctionGetNumVars
-  :: BinaryenFunctionRef -> IO BinaryenIndex
+foreign import ccall unsafe "BinaryenFunctionGetParam"
+  c_BinaryenFunctionGetParam :: BinaryenFunctionRef -> BinaryenIndex -> IO BinaryenType
 
-foreign import ccall unsafe "BinaryenFunctionGetVar" c_BinaryenFunctionGetVar
-  :: BinaryenFunctionRef -> BinaryenIndex -> IO BinaryenType
+foreign import ccall unsafe "BinaryenFunctionGetResult"
+  c_BinaryenFunctionGetResult :: BinaryenFunctionRef -> IO BinaryenType
 
-foreign import ccall unsafe "BinaryenFunctionGetBody" c_BinaryenFunctionGetBody
-  :: BinaryenFunctionRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenFunctionGetNumVars"
+  c_BinaryenFunctionGetNumVars :: BinaryenFunctionRef -> IO BinaryenIndex
 
-foreign import ccall unsafe "BinaryenFunctionOptimize" c_BinaryenFunctionOptimize
-  :: BinaryenFunctionRef -> BinaryenModuleRef -> IO ()
+foreign import ccall unsafe "BinaryenFunctionGetVar"
+  c_BinaryenFunctionGetVar :: BinaryenFunctionRef -> BinaryenIndex -> IO BinaryenType
 
-foreign import ccall unsafe "BinaryenFunctionRunPasses" c_BinaryenFunctionRunPasses
-  :: BinaryenFunctionRef ->
-  BinaryenModuleRef -> Ptr (Ptr CChar) -> BinaryenIndex -> IO ()
+foreign import ccall unsafe "BinaryenFunctionGetBody"
+  c_BinaryenFunctionGetBody :: BinaryenFunctionRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenFunctionSetDebugLocation" c_BinaryenFunctionSetDebugLocation
-  :: BinaryenFunctionRef ->
-  BinaryenExpressionRef ->
-    BinaryenIndex -> BinaryenIndex -> BinaryenIndex -> IO ()
+foreign import ccall unsafe "BinaryenFunctionOptimize"
+  c_BinaryenFunctionOptimize :: BinaryenFunctionRef -> BinaryenModuleRef -> IO ()
 
-foreign import ccall unsafe "BinaryenGlobalGetName" c_BinaryenGlobalGetName
-  :: BinaryenGlobalRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenFunctionRunPasses"
+  c_BinaryenFunctionRunPasses ::
+    BinaryenFunctionRef ->
+    BinaryenModuleRef ->
+    Ptr (Ptr CChar) ->
+    BinaryenIndex ->
+    IO ()
 
-foreign import ccall unsafe "BinaryenGlobalGetType" c_BinaryenGlobalGetType
-  :: BinaryenGlobalRef -> IO BinaryenType
+foreign import ccall unsafe "BinaryenFunctionSetDebugLocation"
+  c_BinaryenFunctionSetDebugLocation ::
+    BinaryenFunctionRef ->
+    BinaryenExpressionRef ->
+    BinaryenIndex ->
+    BinaryenIndex ->
+    BinaryenIndex ->
+    IO ()
 
-foreign import ccall unsafe "BinaryenGlobalIsMutable" c_BinaryenGlobalIsMutable
-  :: BinaryenGlobalRef -> IO CInt
+foreign import ccall unsafe "BinaryenGlobalGetName"
+  c_BinaryenGlobalGetName :: BinaryenGlobalRef -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenGlobalGetInitExpr" c_BinaryenGlobalGetInitExpr
-  :: BinaryenGlobalRef -> IO BinaryenExpressionRef
+foreign import ccall unsafe "BinaryenGlobalGetType"
+  c_BinaryenGlobalGetType :: BinaryenGlobalRef -> IO BinaryenType
 
-foreign import ccall unsafe "BinaryenEventGetName" c_BinaryenEventGetName
-  :: BinaryenEventRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenGlobalIsMutable"
+  c_BinaryenGlobalIsMutable :: BinaryenGlobalRef -> IO CInt
 
-foreign import ccall unsafe "BinaryenEventGetAttribute" c_BinaryenEventGetAttribute
-  :: BinaryenEventRef -> IO CInt
+foreign import ccall unsafe "BinaryenGlobalGetInitExpr"
+  c_BinaryenGlobalGetInitExpr :: BinaryenGlobalRef -> IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenEventGetType" c_BinaryenEventGetType
-  :: BinaryenEventRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenEventGetName"
+  c_BinaryenEventGetName :: BinaryenEventRef -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenEventGetNumParams" c_BinaryenEventGetNumParams
-  :: BinaryenEventRef -> IO BinaryenIndex
+foreign import ccall unsafe "BinaryenEventGetAttribute"
+  c_BinaryenEventGetAttribute :: BinaryenEventRef -> IO CInt
 
-foreign import ccall unsafe "BinaryenEventGetParam" c_BinaryenEventGetParam
-  :: BinaryenEventRef -> BinaryenIndex -> IO BinaryenType
+foreign import ccall unsafe "BinaryenEventGetType"
+  c_BinaryenEventGetType :: BinaryenEventRef -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenFunctionImportGetModule" c_BinaryenFunctionImportGetModule
-  :: BinaryenFunctionRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenEventGetNumParams"
+  c_BinaryenEventGetNumParams :: BinaryenEventRef -> IO BinaryenIndex
 
-foreign import ccall unsafe "BinaryenGlobalImportGetModule" c_BinaryenGlobalImportGetModule
-  :: BinaryenGlobalRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenEventGetParam"
+  c_BinaryenEventGetParam :: BinaryenEventRef -> BinaryenIndex -> IO BinaryenType
 
-foreign import ccall unsafe "BinaryenEventImportGetModule" c_BinaryenEventImportGetModule
-  :: BinaryenEventRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenFunctionImportGetModule"
+  c_BinaryenFunctionImportGetModule :: BinaryenFunctionRef -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenFunctionImportGetBase" c_BinaryenFunctionImportGetBase
-  :: BinaryenFunctionRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenGlobalImportGetModule"
+  c_BinaryenGlobalImportGetModule :: BinaryenGlobalRef -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenGlobalImportGetBase" c_BinaryenGlobalImportGetBase
-  :: BinaryenGlobalRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenEventImportGetModule"
+  c_BinaryenEventImportGetModule :: BinaryenEventRef -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenEventImportGetBase" c_BinaryenEventImportGetBase
-  :: BinaryenEventRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenFunctionImportGetBase"
+  c_BinaryenFunctionImportGetBase :: BinaryenFunctionRef -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenExportGetKind" c_BinaryenExportGetKind
-  :: BinaryenExportRef -> IO BinaryenExternalKind
+foreign import ccall unsafe "BinaryenGlobalImportGetBase"
+  c_BinaryenGlobalImportGetBase :: BinaryenGlobalRef -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenExportGetName" c_BinaryenExportGetName
-  :: BinaryenExportRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenEventImportGetBase"
+  c_BinaryenEventImportGetBase :: BinaryenEventRef -> IO (Ptr CChar)
 
-foreign import ccall unsafe "BinaryenExportGetValue" c_BinaryenExportGetValue
-  :: BinaryenExportRef -> IO (Ptr CChar)
+foreign import ccall unsafe "BinaryenExportGetKind"
+  c_BinaryenExportGetKind :: BinaryenExportRef -> IO BinaryenExternalKind
+
+foreign import ccall unsafe "BinaryenExportGetName"
+  c_BinaryenExportGetName :: BinaryenExportRef -> IO (Ptr CChar)
+
+foreign import ccall unsafe "BinaryenExportGetValue"
+  c_BinaryenExportGetValue :: BinaryenExportRef -> IO (Ptr CChar)
 
 data Relooper
 
@@ -1868,42 +2017,56 @@ data RelooperBlock
 
 type RelooperBlockRef = Ptr RelooperBlock
 
-foreign import ccall unsafe "RelooperCreate" c_RelooperCreate
-  :: BinaryenModuleRef -> IO RelooperRef
+foreign import ccall unsafe "RelooperCreate"
+  c_RelooperCreate :: BinaryenModuleRef -> IO RelooperRef
 
-foreign import ccall unsafe "RelooperAddBlock" c_RelooperAddBlock
-  :: RelooperRef -> BinaryenExpressionRef -> IO RelooperBlockRef
+foreign import ccall unsafe "RelooperAddBlock"
+  c_RelooperAddBlock :: RelooperRef -> BinaryenExpressionRef -> IO RelooperBlockRef
 
-foreign import ccall unsafe "RelooperAddBranch" c_RelooperAddBranch
-  :: RelooperBlockRef ->
-  RelooperBlockRef ->
-    BinaryenExpressionRef -> BinaryenExpressionRef -> IO ()
+foreign import ccall unsafe "RelooperAddBranch"
+  c_RelooperAddBranch ::
+    RelooperBlockRef ->
+    RelooperBlockRef ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    IO ()
 
-foreign import ccall unsafe "RelooperAddBlockWithSwitch" c_RelooperAddBlockWithSwitch
-  :: RelooperRef ->
-  BinaryenExpressionRef ->
-    BinaryenExpressionRef -> IO RelooperBlockRef
+foreign import ccall unsafe "RelooperAddBlockWithSwitch"
+  c_RelooperAddBlockWithSwitch ::
+    RelooperRef ->
+    BinaryenExpressionRef ->
+    BinaryenExpressionRef ->
+    IO RelooperBlockRef
 
-foreign import ccall unsafe "RelooperAddBranchForSwitch" c_RelooperAddBranchForSwitch
-  :: RelooperBlockRef ->
-  RelooperBlockRef ->
+foreign import ccall unsafe "RelooperAddBranchForSwitch"
+  c_RelooperAddBranchForSwitch ::
+    RelooperBlockRef ->
+    RelooperBlockRef ->
     Ptr BinaryenIndex ->
-      BinaryenIndex -> BinaryenExpressionRef -> IO ()
+    BinaryenIndex ->
+    BinaryenExpressionRef ->
+    IO ()
 
-foreign import ccall unsafe "RelooperRenderAndDispose" c_RelooperRenderAndDispose
-  :: RelooperRef ->
-  RelooperBlockRef -> BinaryenIndex -> IO BinaryenExpressionRef
+foreign import ccall unsafe "RelooperRenderAndDispose"
+  c_RelooperRenderAndDispose ::
+    RelooperRef ->
+    RelooperBlockRef ->
+    BinaryenIndex ->
+    IO BinaryenExpressionRef
 
-foreign import ccall unsafe "BinaryenSetAPITracing" c_BinaryenSetAPITracing
-  :: CInt -> IO ()
+foreign import ccall unsafe "BinaryenSetAPITracing"
+  c_BinaryenSetAPITracing :: CInt -> IO ()
 
-foreign import ccall unsafe "BinaryenGetFunctionTypeBySignature" c_BinaryenGetFunctionTypeBySignature
-  :: BinaryenModuleRef ->
-  BinaryenType ->
-    Ptr BinaryenType -> BinaryenIndex -> IO BinaryenFunctionTypeRef
+foreign import ccall unsafe "BinaryenGetFunctionTypeBySignature"
+  c_BinaryenGetFunctionTypeBySignature ::
+    BinaryenModuleRef ->
+    BinaryenType ->
+    Ptr BinaryenType ->
+    BinaryenIndex ->
+    IO BinaryenFunctionTypeRef
 
-foreign import ccall unsafe "BinaryenSetColorsEnabled" c_BinaryenSetColorsEnabled
-  :: CInt -> IO ()
+foreign import ccall unsafe "BinaryenSetColorsEnabled"
+  c_BinaryenSetColorsEnabled :: CInt -> IO ()
 
-foreign import ccall unsafe "BinaryenAreColorsEnabled" c_BinaryenAreColorsEnabled
-  :: IO CInt
+foreign import ccall unsafe "BinaryenAreColorsEnabled"
+  c_BinaryenAreColorsEnabled :: IO CInt

--- a/binaryen/test/binaryen-test.hs
+++ b/binaryen/test/binaryen-test.hs
@@ -5,10 +5,8 @@ import Foreign.C
 main :: IO ()
 main = do
   m <- c_BinaryenModuleCreate
-  ft <-
-    withCString "func_type" $ \p0 ->
-      withArray [c_BinaryenTypeInt32] $ \p1 ->
-        c_BinaryenAddFunctionType m p0 c_BinaryenTypeInt32 p1 1
+  ft <- withCString "func_type" $ \p0 -> withArray [c_BinaryenTypeInt32] $
+    \p1 -> c_BinaryenAddFunctionType m p0 c_BinaryenTypeInt32 p1 1
   e <- c_BinaryenUnreachable m
   _ <- withCString "func" $ \p0 -> c_BinaryenAddFunction m p0 ft nullPtr 0 e
   c_BinaryenModulePrint m

--- a/ghc-toolkit/Setup.hs
+++ b/ghc-toolkit/Setup.hs
@@ -3,7 +3,9 @@
 
 import qualified Data.Map as M
 import Distribution.Simple
-import Distribution.Simple.BuildPaths hiding (exeExtension)
+import Distribution.Simple.BuildPaths hiding
+  ( exeExtension,
+  )
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.Program
 import Distribution.Types.BuildInfo
@@ -17,61 +19,56 @@ main :: IO ()
 main =
   defaultMainWithHooks
     simpleUserHooks
-      { confHook =
-          \t f -> do
-            lbi@LocalBuildInfo { localPkgDescr = pkg_descr@PackageDescription {library = Just lib@Library {libBuildInfo = bi}}
-                               , compiler = Compiler {compilerProperties = m}
-                               , withPrograms = prog_db
-                               } <- confHook simpleUserHooks t f
-            let [clbi@LibComponentLocalBuildInfo {componentUnitId = uid}] =
-                  componentNameMap lbi M.! CLibName
-                amp = autogenComponentModulesDir lbi clbi
-                self_installdirs =
-                  absoluteComponentInstallDirs pkg_descr lbi uid NoCopyDest
-                self_bindir = bindir self_installdirs
-                self_datadir = datadir self_installdirs
-                rts_datadir = self_datadir </> "boot-libs" </> "rts"
-                Just ghc_prog = lookupProgram ghcProgram prog_db
-                Just gcc_prog = lookupProgram gccProgram prog_db
-            createDirectoryIfMissing True amp
-            writeFile (amp </> "BuildInfo_ghc_toolkit.hs") $
-              "module BuildInfo_ghc_toolkit where\nghcLibDir :: FilePath\nghcLibDir = " ++
-              show (m M.! "LibDir") ++
-              "\ndataDir :: FilePath\ndataDir = " ++
-              show self_datadir ++
-              "\nbinDir :: FilePath\nbinDir = " ++
-              show self_bindir ++
-              "\ngccPath :: FilePath\ngccPath = " ++
-              show (locationPath (programLocation gcc_prog))
-            autoapply <-
-              readProcess
-                (replaceBaseName
-                   (locationPath (programLocation ghc_prog))
-                   "runghc")
-                [ "--ghc-arg=-Ighc-libdir/include"
-                , "--ghc-arg=-Iinclude-private"
-                , "genapply" </> "Main.hs"
-                ]
-                ""
-            createDirectoryIfMissing True rts_datadir
-            writeFile (rts_datadir </> "AutoApply.cmm") autoapply
-            pure
-              lbi
-                { localPkgDescr =
-                    pkg_descr
-                      { library =
-                          Just
-                            lib
-                              { libBuildInfo =
-                                  bi
-                                    { otherModules =
-                                        "BuildInfo_ghc_toolkit" :
-                                        otherModules bi
-                                    , autogenModules =
-                                        "BuildInfo_ghc_toolkit" :
-                                        autogenModules bi
-                                    }
-                              }
-                      }
-                }
+      { confHook = \t f -> do
+          lbi@LocalBuildInfo {localPkgDescr = pkg_descr@PackageDescription {library = Just lib@Library {libBuildInfo = bi}}, compiler = Compiler {compilerProperties = m}, withPrograms = prog_db} <-
+            confHook simpleUserHooks t f
+          let [clbi@LibComponentLocalBuildInfo {componentUnitId = uid}] =
+                componentNameMap lbi M.! CLibName
+              amp = autogenComponentModulesDir lbi clbi
+              self_installdirs =
+                absoluteComponentInstallDirs pkg_descr lbi uid NoCopyDest
+              self_bindir = bindir self_installdirs
+              self_datadir = datadir self_installdirs
+              rts_datadir = self_datadir </> "boot-libs" </> "rts"
+              Just ghc_prog = lookupProgram ghcProgram prog_db
+              Just gcc_prog = lookupProgram gccProgram prog_db
+          createDirectoryIfMissing True amp
+          writeFile (amp </> "BuildInfo_ghc_toolkit.hs") $
+            "module BuildInfo_ghc_toolkit where\nghcLibDir :: FilePath\nghcLibDir = "
+              ++ show (m M.! "LibDir")
+              ++ "\ndataDir :: FilePath\ndataDir = "
+              ++ show self_datadir
+              ++ "\nbinDir :: FilePath\nbinDir = "
+              ++ show self_bindir
+              ++ "\ngccPath :: FilePath\ngccPath = "
+              ++ show (locationPath (programLocation gcc_prog))
+          autoapply <-
+            readProcess
+              (replaceBaseName (locationPath (programLocation ghc_prog)) "runghc")
+              [ "--ghc-arg=-Ighc-libdir/include",
+                "--ghc-arg=-Iinclude-private",
+                "genapply" </> "Main.hs"
+              ]
+              ""
+          createDirectoryIfMissing True rts_datadir
+          writeFile (rts_datadir </> "AutoApply.cmm") autoapply
+          pure
+            lbi
+              { localPkgDescr =
+                  pkg_descr
+                    { library =
+                        Just
+                          lib
+                            { libBuildInfo =
+                                bi
+                                  { otherModules =
+                                      "BuildInfo_ghc_toolkit"
+                                        : otherModules bi,
+                                    autogenModules =
+                                      "BuildInfo_ghc_toolkit"
+                                        : autogenModules bi
+                                  }
+                            }
+                    }
+              }
       }

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/BuildInfo.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/BuildInfo.hs
@@ -1,15 +1,15 @@
 module Language.Haskell.GHC.Toolkit.BuildInfo
-  ( bootLibsPath
-  , sandboxGhcLibDir
-  , ghcLibDir
-  , dataDir
-  , gccPath
-  ) where
+  ( bootLibsPath,
+    sandboxGhcLibDir,
+    ghcLibDir,
+    dataDir,
+    gccPath,
+  )
+where
 
 import BuildInfo_ghc_toolkit
 import System.FilePath
 
 bootLibsPath, sandboxGhcLibDir :: FilePath
 bootLibsPath = dataDir </> "boot-libs"
-
 sandboxGhcLibDir = dataDir </> "ghc-libdir"

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Compiler.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Compiler.hs
@@ -4,8 +4,8 @@
 module Language.Haskell.GHC.Toolkit.Compiler
   ( HaskellIR (..),
     CmmIR (..),
-    Compiler (..)
-    )
+    Compiler (..),
+  )
 where
 
 import Cmm
@@ -17,21 +17,20 @@ data HaskellIR
   = HaskellIR
       { stg :: [StgTopBinding],
         cmmRaw :: [[RawCmmDecl]]
-        }
+      }
 
 newtype CmmIR
   = CmmIR
       { cmmRaw :: [[RawCmmDecl]]
-        }
+      }
 
 data Compiler
   = Compiler
       { withHaskellIR :: ModSummary -> HaskellIR -> FilePath -> CompPipeline (),
         withCmmIR :: CmmIR -> FilePath -> CompPipeline ()
-        }
+      }
 
 instance Semigroup Compiler where
-
   c0 <> c1 = Compiler
     { withHaskellIR = \mod_summary hs_ir obj_path -> do
         withHaskellIR c0 mod_summary hs_ir obj_path
@@ -39,9 +38,8 @@ instance Semigroup Compiler where
       withCmmIR = \cmm_ir obj_path -> do
         withCmmIR c0 cmm_ir obj_path
         withCmmIR c1 cmm_ir obj_path
-      }
+    }
 
 instance Monoid Compiler where
-
   mempty =
     Compiler {withHaskellIR = \_ _ _ -> pure (), withCmmIR = \_ _ -> pure ()}

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Constants.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Constants.hs
@@ -2,8 +2,8 @@ module Language.Haskell.GHC.Toolkit.Constants where
 
 foreign import ccall unsafe "roundup" roundup :: Int -> Int -> Int
 
-foreign import ccall unsafe "roundup_bytes_to_words" roundup_bytes_to_words
-  :: Int -> Int
+foreign import ccall unsafe "roundup_bytes_to_words"
+  roundup_bytes_to_words :: Int -> Int
 
 foreign import ccall unsafe "block_size" block_size :: Int
 
@@ -41,74 +41,74 @@ foreign import ccall unsafe "offset_Capability_r" offset_Capability_r :: Int
 
 foreign import ccall unsafe "offset_Capability_no" offset_Capability_no :: Int
 
-foreign import ccall unsafe "offset_Capability_node" offset_Capability_node
-  :: Int
+foreign import ccall unsafe "offset_Capability_node"
+  offset_Capability_node :: Int
 
-foreign import ccall unsafe "offset_Capability_running_task" offset_Capability_running_task
-  :: Int
+foreign import ccall unsafe "offset_Capability_running_task"
+  offset_Capability_running_task :: Int
 
-foreign import ccall unsafe "offset_Capability_in_haskell" offset_Capability_in_haskell
-  :: Int
+foreign import ccall unsafe "offset_Capability_in_haskell"
+  offset_Capability_in_haskell :: Int
 
-foreign import ccall unsafe "offset_Capability_idle" offset_Capability_idle
-  :: Int
+foreign import ccall unsafe "offset_Capability_idle"
+  offset_Capability_idle :: Int
 
-foreign import ccall unsafe "offset_Capability_disabled" offset_Capability_disabled
-  :: Int
+foreign import ccall unsafe "offset_Capability_disabled"
+  offset_Capability_disabled :: Int
 
-foreign import ccall unsafe "offset_Capability_run_queue_hd" offset_Capability_run_queue_hd
-  :: Int
+foreign import ccall unsafe "offset_Capability_run_queue_hd"
+  offset_Capability_run_queue_hd :: Int
 
-foreign import ccall unsafe "offset_Capability_run_queue_tl" offset_Capability_run_queue_tl
-  :: Int
+foreign import ccall unsafe "offset_Capability_run_queue_tl"
+  offset_Capability_run_queue_tl :: Int
 
-foreign import ccall unsafe "offset_Capability_n_run_queue" offset_Capability_n_run_queue
-  :: Int
+foreign import ccall unsafe "offset_Capability_n_run_queue"
+  offset_Capability_n_run_queue :: Int
 
-foreign import ccall unsafe "offset_Capability_suspended_ccalls" offset_Capability_suspended_ccalls
-  :: Int
+foreign import ccall unsafe "offset_Capability_suspended_ccalls"
+  offset_Capability_suspended_ccalls :: Int
 
-foreign import ccall unsafe "offset_Capability_n_suspended_ccalls" offset_Capability_n_suspended_ccalls
-  :: Int
+foreign import ccall unsafe "offset_Capability_n_suspended_ccalls"
+  offset_Capability_n_suspended_ccalls :: Int
 
-foreign import ccall unsafe "offset_Capability_mut_lists" offset_Capability_mut_lists
-  :: Int
+foreign import ccall unsafe "offset_Capability_mut_lists"
+  offset_Capability_mut_lists :: Int
 
-foreign import ccall unsafe "offset_Capability_saved_mut_lists" offset_Capability_saved_mut_lists
-  :: Int
+foreign import ccall unsafe "offset_Capability_saved_mut_lists"
+  offset_Capability_saved_mut_lists :: Int
 
-foreign import ccall unsafe "offset_Capability_pinned_object_block" offset_Capability_pinned_object_block
-  :: Int
+foreign import ccall unsafe "offset_Capability_pinned_object_block"
+  offset_Capability_pinned_object_block :: Int
 
-foreign import ccall unsafe "offset_Capability_pinned_object_blocks" offset_Capability_pinned_object_blocks
-  :: Int
+foreign import ccall unsafe "offset_Capability_pinned_object_blocks"
+  offset_Capability_pinned_object_blocks :: Int
 
-foreign import ccall unsafe "offset_Capability_weak_ptr_list_hd" offset_Capability_weak_ptr_list_hd
-  :: Int
+foreign import ccall unsafe "offset_Capability_weak_ptr_list_hd"
+  offset_Capability_weak_ptr_list_hd :: Int
 
-foreign import ccall unsafe "offset_Capability_weak_ptr_list_tl" offset_Capability_weak_ptr_list_tl
-  :: Int
+foreign import ccall unsafe "offset_Capability_weak_ptr_list_tl"
+  offset_Capability_weak_ptr_list_tl :: Int
 
-foreign import ccall unsafe "offset_Capability_context_switch" offset_Capability_context_switch
-  :: Int
+foreign import ccall unsafe "offset_Capability_context_switch"
+  offset_Capability_context_switch :: Int
 
-foreign import ccall unsafe "offset_Capability_interrupt" offset_Capability_interrupt
-  :: Int
+foreign import ccall unsafe "offset_Capability_interrupt"
+  offset_Capability_interrupt :: Int
 
-foreign import ccall unsafe "offset_Capability_total_allocated" offset_Capability_total_allocated
-  :: Int
+foreign import ccall unsafe "offset_Capability_total_allocated"
+  offset_Capability_total_allocated :: Int
 
-foreign import ccall unsafe "offset_Capability_free_tvar_watch_queues" offset_Capability_free_tvar_watch_queues
-  :: Int
+foreign import ccall unsafe "offset_Capability_free_tvar_watch_queues"
+  offset_Capability_free_tvar_watch_queues :: Int
 
-foreign import ccall unsafe "offset_Capability_free_trec_chunks" offset_Capability_free_trec_chunks
-  :: Int
+foreign import ccall unsafe "offset_Capability_free_trec_chunks"
+  offset_Capability_free_trec_chunks :: Int
 
-foreign import ccall unsafe "offset_Capability_free_trec_headers" offset_Capability_free_trec_headers
-  :: Int
+foreign import ccall unsafe "offset_Capability_free_trec_headers"
+  offset_Capability_free_trec_headers :: Int
 
-foreign import ccall unsafe "offset_Capability_transaction_tokens" offset_Capability_transaction_tokens
-  :: Int
+foreign import ccall unsafe "offset_Capability_transaction_tokens"
+  offset_Capability_transaction_tokens :: Int
 
 foreign import ccall unsafe "sizeof_StgAP" sizeof_StgAP :: Int
 
@@ -122,98 +122,98 @@ foreign import ccall unsafe "offset_StgAP_payload" offset_StgAP_payload :: Int
 
 foreign import ccall unsafe "sizeof_StgAP_STACK" sizeof_StgAP_STACK :: Int
 
-foreign import ccall unsafe "offset_StgAP_STACK_size" offset_StgAP_STACK_size
-  :: Int
+foreign import ccall unsafe "offset_StgAP_STACK_size"
+  offset_StgAP_STACK_size :: Int
 
-foreign import ccall unsafe "offset_StgAP_STACK_fun" offset_StgAP_STACK_fun
-  :: Int
+foreign import ccall unsafe "offset_StgAP_STACK_fun"
+  offset_StgAP_STACK_fun :: Int
 
-foreign import ccall unsafe "offset_StgAP_STACK_payload" offset_StgAP_STACK_payload
-  :: Int
+foreign import ccall unsafe "offset_StgAP_STACK_payload"
+  offset_StgAP_STACK_payload :: Int
 
 foreign import ccall unsafe "sizeof_StgArrBytes" sizeof_StgArrBytes :: Int
 
-foreign import ccall unsafe "offset_StgArrBytes_bytes" offset_StgArrBytes_bytes
-  :: Int
+foreign import ccall unsafe "offset_StgArrBytes_bytes"
+  offset_StgArrBytes_bytes :: Int
 
-foreign import ccall unsafe "offset_StgArrBytes_payload" offset_StgArrBytes_payload
-  :: Int
+foreign import ccall unsafe "offset_StgArrBytes_payload"
+  offset_StgArrBytes_payload :: Int
 
 foreign import ccall unsafe "sizeof_StgClosure" sizeof_StgClosure :: Int
 
-foreign import ccall unsafe "offset_StgClosure_payload" offset_StgClosure_payload
-  :: Int
+foreign import ccall unsafe "offset_StgClosure_payload"
+  offset_StgClosure_payload :: Int
 
 foreign import ccall unsafe "sizeof_StgInd" sizeof_StgInd :: Int
 
-foreign import ccall unsafe "offset_StgInd_indirectee" offset_StgInd_indirectee
-  :: Int
+foreign import ccall unsafe "offset_StgInd_indirectee"
+  offset_StgInd_indirectee :: Int
 
 foreign import ccall unsafe "sizeof_StgIndStatic" sizeof_StgIndStatic :: Int
 
-foreign import ccall unsafe "offset_StgIndStatic_indirectee" offset_StgIndStatic_indirectee
-  :: Int
+foreign import ccall unsafe "offset_StgIndStatic_indirectee"
+  offset_StgIndStatic_indirectee :: Int
 
-foreign import ccall unsafe "offset_StgIndStatic_static_link" offset_StgIndStatic_static_link
-  :: Int
+foreign import ccall unsafe "offset_StgIndStatic_static_link"
+  offset_StgIndStatic_static_link :: Int
 
-foreign import ccall unsafe "offset_StgIndStatic_saved_info" offset_StgIndStatic_saved_info
-  :: Int
+foreign import ccall unsafe "offset_StgIndStatic_saved_info"
+  offset_StgIndStatic_saved_info :: Int
 
-foreign import ccall unsafe "offset_StgFunInfoExtraFwd_fun_type" offset_StgFunInfoExtraFwd_fun_type
-  :: Int
+foreign import ccall unsafe "offset_StgFunInfoExtraFwd_fun_type"
+  offset_StgFunInfoExtraFwd_fun_type :: Int
 
-foreign import ccall unsafe "offset_StgFunInfoExtraFwd_srt" offset_StgFunInfoExtraFwd_srt
-  :: Int
+foreign import ccall unsafe "offset_StgFunInfoExtraFwd_srt"
+  offset_StgFunInfoExtraFwd_srt :: Int
 
-foreign import ccall unsafe "offset_StgFunInfoExtraFwd_b" offset_StgFunInfoExtraFwd_b
-  :: Int
+foreign import ccall unsafe "offset_StgFunInfoExtraFwd_b"
+  offset_StgFunInfoExtraFwd_b :: Int
 
-foreign import ccall unsafe "offset_StgFunInfoTable_i" offset_StgFunInfoTable_i
-  :: Int
+foreign import ccall unsafe "offset_StgFunInfoTable_i"
+  offset_StgFunInfoTable_i :: Int
 
-foreign import ccall unsafe "offset_StgFunInfoTable_f" offset_StgFunInfoTable_f
-  :: Int
+foreign import ccall unsafe "offset_StgFunInfoTable_f"
+  offset_StgFunInfoTable_f :: Int
 
 foreign import ccall unsafe "sizeof_StgFunTable" sizeof_StgFunTable :: Int
 
-foreign import ccall unsafe "offset_StgFunTable_stgEagerBlackholeInfo" offset_StgFunTable_stgEagerBlackholeInfo
-  :: Int
+foreign import ccall unsafe "offset_StgFunTable_stgEagerBlackholeInfo"
+  offset_StgFunTable_stgEagerBlackholeInfo :: Int
 
-foreign import ccall unsafe "offset_StgFunTable_stgGCEnter1" offset_StgFunTable_stgGCEnter1
-  :: Int
+foreign import ccall unsafe "offset_StgFunTable_stgGCEnter1"
+  offset_StgFunTable_stgGCEnter1 :: Int
 
-foreign import ccall unsafe "offset_StgFunTable_stgGCFun" offset_StgFunTable_stgGCFun
-  :: Int
+foreign import ccall unsafe "offset_StgFunTable_stgGCFun"
+  offset_StgFunTable_stgGCFun :: Int
 
-foreign import ccall unsafe "offset_StgInfoTable_entry" offset_StgInfoTable_entry
-  :: Int
+foreign import ccall unsafe "offset_StgInfoTable_entry"
+  offset_StgInfoTable_entry :: Int
 
-foreign import ccall unsafe "offset_StgInfoTable_layout" offset_StgInfoTable_layout
-  :: Int
+foreign import ccall unsafe "offset_StgInfoTable_layout"
+  offset_StgInfoTable_layout :: Int
 
-foreign import ccall unsafe "offset_StgInfoTable_type" offset_StgInfoTable_type
-  :: Int
+foreign import ccall unsafe "offset_StgInfoTable_type"
+  offset_StgInfoTable_type :: Int
 
-foreign import ccall unsafe "offset_StgInfoTable_srt" offset_StgInfoTable_srt
-  :: Int
+foreign import ccall unsafe "offset_StgInfoTable_srt"
+  offset_StgInfoTable_srt :: Int
 
-foreign import ccall unsafe "offset_StgLargeBitmap_size" offset_StgLargeBitmap_size
-  :: Int
+foreign import ccall unsafe "offset_StgLargeBitmap_size"
+  offset_StgLargeBitmap_size :: Int
 
-foreign import ccall unsafe "offset_StgLargeBitmap_bitmap" offset_StgLargeBitmap_bitmap
-  :: Int
+foreign import ccall unsafe "offset_StgLargeBitmap_bitmap"
+  offset_StgLargeBitmap_bitmap :: Int
 
 foreign import ccall unsafe "sizeof_StgMutArrPtrs" sizeof_StgMutArrPtrs :: Int
 
-foreign import ccall unsafe "offset_StgMutArrPtrs_ptrs" offset_StgMutArrPtrs_ptrs
-  :: Int
+foreign import ccall unsafe "offset_StgMutArrPtrs_ptrs"
+  offset_StgMutArrPtrs_ptrs :: Int
 
-foreign import ccall unsafe "offset_StgMutArrPtrs_size" offset_StgMutArrPtrs_size
-  :: Int
+foreign import ccall unsafe "offset_StgMutArrPtrs_size"
+  offset_StgMutArrPtrs_size :: Int
 
-foreign import ccall unsafe "offset_StgMutArrPtrs_payload" offset_StgMutArrPtrs_payload
-  :: Int
+foreign import ccall unsafe "offset_StgMutArrPtrs_payload"
+  offset_StgMutArrPtrs_payload :: Int
 
 foreign import ccall unsafe "offset_StgMVar_head" offset_StgMVar_head :: Int
 
@@ -237,137 +237,137 @@ foreign import ccall unsafe "offset_StgRetFun_size" offset_StgRetFun_size :: Int
 
 foreign import ccall unsafe "offset_StgRetFun_fun" offset_StgRetFun_fun :: Int
 
-foreign import ccall unsafe "offset_StgRetFun_payload" offset_StgRetFun_payload
-  :: Int
+foreign import ccall unsafe "offset_StgRetFun_payload"
+  offset_StgRetFun_payload :: Int
 
-foreign import ccall unsafe "offset_StgRetInfoTable_i" offset_StgRetInfoTable_i
-  :: Int
+foreign import ccall unsafe "offset_StgRetInfoTable_i"
+  offset_StgRetInfoTable_i :: Int
 
-foreign import ccall unsafe "offset_StgRetInfoTable_srt" offset_StgRetInfoTable_srt
-  :: Int
+foreign import ccall unsafe "offset_StgRetInfoTable_srt"
+  offset_StgRetInfoTable_srt :: Int
 
 foreign import ccall unsafe "sizeof_StgRegTable" sizeof_StgRegTable :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rR1" offset_StgRegTable_rR1
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rR1"
+  offset_StgRegTable_rR1 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rR2" offset_StgRegTable_rR2
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rR2"
+  offset_StgRegTable_rR2 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rR3" offset_StgRegTable_rR3
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rR3"
+  offset_StgRegTable_rR3 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rR4" offset_StgRegTable_rR4
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rR4"
+  offset_StgRegTable_rR4 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rR5" offset_StgRegTable_rR5
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rR5"
+  offset_StgRegTable_rR5 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rR6" offset_StgRegTable_rR6
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rR6"
+  offset_StgRegTable_rR6 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rR7" offset_StgRegTable_rR7
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rR7"
+  offset_StgRegTable_rR7 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rR8" offset_StgRegTable_rR8
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rR8"
+  offset_StgRegTable_rR8 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rR9" offset_StgRegTable_rR9
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rR9"
+  offset_StgRegTable_rR9 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rR10" offset_StgRegTable_rR10
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rR10"
+  offset_StgRegTable_rR10 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rF1" offset_StgRegTable_rF1
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rF1"
+  offset_StgRegTable_rF1 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rF2" offset_StgRegTable_rF2
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rF2"
+  offset_StgRegTable_rF2 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rF3" offset_StgRegTable_rF3
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rF3"
+  offset_StgRegTable_rF3 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rF4" offset_StgRegTable_rF4
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rF4"
+  offset_StgRegTable_rF4 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rF5" offset_StgRegTable_rF5
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rF5"
+  offset_StgRegTable_rF5 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rF6" offset_StgRegTable_rF6
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rF6"
+  offset_StgRegTable_rF6 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rD1" offset_StgRegTable_rD1
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rD1"
+  offset_StgRegTable_rD1 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rD2" offset_StgRegTable_rD2
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rD2"
+  offset_StgRegTable_rD2 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rD3" offset_StgRegTable_rD3
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rD3"
+  offset_StgRegTable_rD3 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rD4" offset_StgRegTable_rD4
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rD4"
+  offset_StgRegTable_rD4 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rD5" offset_StgRegTable_rD5
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rD5"
+  offset_StgRegTable_rD5 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rD6" offset_StgRegTable_rD6
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rD6"
+  offset_StgRegTable_rD6 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rL1" offset_StgRegTable_rL1
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rL1"
+  offset_StgRegTable_rL1 :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rSp" offset_StgRegTable_rSp
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rSp"
+  offset_StgRegTable_rSp :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rSpLim" offset_StgRegTable_rSpLim
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rSpLim"
+  offset_StgRegTable_rSpLim :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rHp" offset_StgRegTable_rHp
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rHp"
+  offset_StgRegTable_rHp :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rHpLim" offset_StgRegTable_rHpLim
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rHpLim"
+  offset_StgRegTable_rHpLim :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rCCCS" offset_StgRegTable_rCCCS
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rCCCS"
+  offset_StgRegTable_rCCCS :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rNursery" offset_StgRegTable_rNursery
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rNursery"
+  offset_StgRegTable_rNursery :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rCurrentTSO" offset_StgRegTable_rCurrentTSO
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rCurrentTSO"
+  offset_StgRegTable_rCurrentTSO :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rCurrentNursery" offset_StgRegTable_rCurrentNursery
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rCurrentNursery"
+  offset_StgRegTable_rCurrentNursery :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rCurrentAlloc" offset_StgRegTable_rCurrentAlloc
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rCurrentAlloc"
+  offset_StgRegTable_rCurrentAlloc :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rHpAlloc" offset_StgRegTable_rHpAlloc
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rHpAlloc"
+  offset_StgRegTable_rHpAlloc :: Int
 
-foreign import ccall unsafe "offset_StgRegTable_rRet" offset_StgRegTable_rRet
-  :: Int
+foreign import ccall unsafe "offset_StgRegTable_rRet"
+  offset_StgRegTable_rRet :: Int
 
 foreign import ccall unsafe "sizeof_StgSelector" sizeof_StgSelector :: Int
 
-foreign import ccall unsafe "offset_StgSelector_selectee" offset_StgSelector_selectee
-  :: Int
+foreign import ccall unsafe "offset_StgSelector_selectee"
+  offset_StgSelector_selectee :: Int
 
-foreign import ccall unsafe "sizeof_StgSmallMutArrPtrs" sizeof_StgSmallMutArrPtrs
-  :: Int
+foreign import ccall unsafe "sizeof_StgSmallMutArrPtrs"
+  sizeof_StgSmallMutArrPtrs :: Int
 
-foreign import ccall unsafe "offset_StgSmallMutArrPtrs_ptrs" offset_StgSmallMutArrPtrs_ptrs
-  :: Int
+foreign import ccall unsafe "offset_StgSmallMutArrPtrs_ptrs"
+  offset_StgSmallMutArrPtrs_ptrs :: Int
 
-foreign import ccall unsafe "offset_StgSmallMutArrPtrs_payload" offset_StgSmallMutArrPtrs_payload
-  :: Int
+foreign import ccall unsafe "offset_StgSmallMutArrPtrs_payload"
+  offset_StgSmallMutArrPtrs_payload :: Int
 
 foreign import ccall unsafe "sizeof_StgStack" sizeof_StgStack :: Int
 
-foreign import ccall unsafe "offset_StgStack_stack_size" offset_StgStack_stack_size
-  :: Int
+foreign import ccall unsafe "offset_StgStack_stack_size"
+  offset_StgStack_stack_size :: Int
 
 foreign import ccall unsafe "offset_StgStack_dirty" offset_StgStack_dirty :: Int
 
@@ -379,37 +379,37 @@ foreign import ccall unsafe "sizeof_StgStopFrame" sizeof_StgStopFrame :: Int
 
 foreign import ccall unsafe "sizeof_StgThunk" sizeof_StgThunk :: Int
 
-foreign import ccall unsafe "offset_StgThunk_payload" offset_StgThunk_payload
-  :: Int
+foreign import ccall unsafe "offset_StgThunk_payload"
+  offset_StgThunk_payload :: Int
 
-foreign import ccall unsafe "offset_StgThunkInfoTable_i" offset_StgThunkInfoTable_i
-  :: Int
+foreign import ccall unsafe "offset_StgThunkInfoTable_i"
+  offset_StgThunkInfoTable_i :: Int
 
-foreign import ccall unsafe "offset_StgThunkInfoTable_srt" offset_StgThunkInfoTable_srt
-  :: Int
+foreign import ccall unsafe "offset_StgThunkInfoTable_srt"
+  offset_StgThunkInfoTable_srt :: Int
 
 foreign import ccall unsafe "sizeof_StgTSO" sizeof_StgTSO :: Int
 
 foreign import ccall unsafe "offset_StgTSO__link" offset_StgTSO__link :: Int
 
-foreign import ccall unsafe "offset_StgTSO_stackobj" offset_StgTSO_stackobj
-  :: Int
+foreign import ccall unsafe "offset_StgTSO_stackobj"
+  offset_StgTSO_stackobj :: Int
 
-foreign import ccall unsafe "offset_StgTSO_what_next" offset_StgTSO_what_next
-  :: Int
+foreign import ccall unsafe "offset_StgTSO_what_next"
+  offset_StgTSO_what_next :: Int
 
-foreign import ccall unsafe "offset_StgTSO_why_blocked" offset_StgTSO_why_blocked
-  :: Int
+foreign import ccall unsafe "offset_StgTSO_why_blocked"
+  offset_StgTSO_why_blocked :: Int
 
 foreign import ccall unsafe "offset_StgTSO_flags" offset_StgTSO_flags :: Int
 
-foreign import ccall unsafe "offset_StgTSO_block_info" offset_StgTSO_block_info
-  :: Int
+foreign import ccall unsafe "offset_StgTSO_block_info"
+  offset_StgTSO_block_info :: Int
 
 foreign import ccall unsafe "offset_StgTSO_id" offset_StgTSO_id :: Int
 
-foreign import ccall unsafe "offset_StgTSO_saved_errno" offset_StgTSO_saved_errno
-  :: Int
+foreign import ccall unsafe "offset_StgTSO_saved_errno"
+  offset_StgTSO_saved_errno :: Int
 
 foreign import ccall unsafe "offset_StgTSO_dirty" offset_StgTSO_dirty :: Int
 
@@ -419,40 +419,40 @@ foreign import ccall unsafe "offset_StgTSO_cap" offset_StgTSO_cap :: Int
 
 foreign import ccall unsafe "offset_StgTSO_trec" offset_StgTSO_trec :: Int
 
-foreign import ccall unsafe "offset_StgTSO_blocked_exceptions" offset_StgTSO_blocked_exceptions
-  :: Int
+foreign import ccall unsafe "offset_StgTSO_blocked_exceptions"
+  offset_StgTSO_blocked_exceptions :: Int
 
 foreign import ccall unsafe "offset_StgTSO_bq" offset_StgTSO_bq :: Int
 
-foreign import ccall unsafe "offset_StgTSO_alloc_limit" offset_StgTSO_alloc_limit
-  :: Int
+foreign import ccall unsafe "offset_StgTSO_alloc_limit"
+  offset_StgTSO_alloc_limit :: Int
 
-foreign import ccall unsafe "offset_StgTSO_tot_stack_size" offset_StgTSO_tot_stack_size
-  :: Int
+foreign import ccall unsafe "offset_StgTSO_tot_stack_size"
+  offset_StgTSO_tot_stack_size :: Int
 
-foreign import ccall unsafe "offset_StgTSO_saved_regs" offset_StgTSO_saved_regs
-  :: Int
+foreign import ccall unsafe "offset_StgTSO_saved_regs"
+  offset_StgTSO_saved_regs :: Int
 
-foreign import ccall unsafe "offset_StgTSO_ffi_func" offset_StgTSO_ffi_func
-  :: Int
+foreign import ccall unsafe "offset_StgTSO_ffi_func"
+  offset_StgTSO_ffi_func :: Int
 
-foreign import ccall unsafe "offset_StgTSO_ffi_return" offset_StgTSO_ffi_return
-  :: Int
+foreign import ccall unsafe "offset_StgTSO_ffi_return"
+  offset_StgTSO_ffi_return :: Int
 
-foreign import ccall unsafe "offset_StgUpdateFrame_updatee" offset_StgUpdateFrame_updatee
-  :: Int
+foreign import ccall unsafe "offset_StgUpdateFrame_updatee"
+  offset_StgUpdateFrame_updatee :: Int
 
 foreign import ccall unsafe "sizeof_StgWeak" sizeof_StgWeak :: Int
 
-foreign import ccall unsafe "offset_StgWeak_cfinalizers" offset_StgWeak_cfinalizers
-  :: Int
+foreign import ccall unsafe "offset_StgWeak_cfinalizers"
+  offset_StgWeak_cfinalizers :: Int
 
 foreign import ccall unsafe "offset_StgWeak_key" offset_StgWeak_key :: Int
 
 foreign import ccall unsafe "offset_StgWeak_value" offset_StgWeak_value :: Int
 
-foreign import ccall unsafe "offset_StgWeak_finalizer" offset_StgWeak_finalizer
-  :: Int
+foreign import ccall unsafe "offset_StgWeak_finalizer"
+  offset_StgWeak_finalizer :: Int
 
 foreign import ccall unsafe "offset_StgWeak_link" offset_StgWeak_link :: Int
 
@@ -486,36 +486,36 @@ foreign import ccall unsafe "blocked_NotBlocked" blocked_NotBlocked :: Int
 
 foreign import ccall unsafe "blocked_BlockedOnMVar" blocked_BlockedOnMVar :: Int
 
-foreign import ccall unsafe "blocked_BlockedOnMVarRead" blocked_BlockedOnMVarRead
-  :: Int
+foreign import ccall unsafe "blocked_BlockedOnMVarRead"
+  blocked_BlockedOnMVarRead :: Int
 
-foreign import ccall unsafe "blocked_BlockedOnBlackHole" blocked_BlockedOnBlackHole
-  :: Int
+foreign import ccall unsafe "blocked_BlockedOnBlackHole"
+  blocked_BlockedOnBlackHole :: Int
 
 foreign import ccall unsafe "blocked_BlockedOnRead" blocked_BlockedOnRead :: Int
 
-foreign import ccall unsafe "blocked_BlockedOnWrite" blocked_BlockedOnWrite
-  :: Int
+foreign import ccall unsafe "blocked_BlockedOnWrite"
+  blocked_BlockedOnWrite :: Int
 
-foreign import ccall unsafe "blocked_BlockedOnDelay" blocked_BlockedOnDelay
-  :: Int
+foreign import ccall unsafe "blocked_BlockedOnDelay"
+  blocked_BlockedOnDelay :: Int
 
 foreign import ccall unsafe "blocked_BlockedOnSTM" blocked_BlockedOnSTM :: Int
 
-foreign import ccall unsafe "blocked_BlockedOnDoProc" blocked_BlockedOnDoProc
-  :: Int
+foreign import ccall unsafe "blocked_BlockedOnDoProc"
+  blocked_BlockedOnDoProc :: Int
 
-foreign import ccall unsafe "blocked_BlockedOnCCall" blocked_BlockedOnCCall
-  :: Int
+foreign import ccall unsafe "blocked_BlockedOnCCall"
+  blocked_BlockedOnCCall :: Int
 
-foreign import ccall unsafe "blocked_BlockedOnCCall_Interruptible" blocked_BlockedOnCCall_Interruptible
-  :: Int
+foreign import ccall unsafe "blocked_BlockedOnCCall_Interruptible"
+  blocked_BlockedOnCCall_Interruptible :: Int
 
-foreign import ccall unsafe "blocked_BlockedOnMsgThrowTo" blocked_BlockedOnMsgThrowTo
-  :: Int
+foreign import ccall unsafe "blocked_BlockedOnMsgThrowTo"
+  blocked_BlockedOnMsgThrowTo :: Int
 
-foreign import ccall unsafe "blocked_ThreadMigrating" blocked_ThreadMigrating
-  :: Int
+foreign import ccall unsafe "blocked_ThreadMigrating"
+  blocked_ThreadMigrating :: Int
 
 foreign import ccall unsafe "ret_HeapOverflow" ret_HeapOverflow :: Int
 
@@ -529,11 +529,11 @@ foreign import ccall unsafe "ret_ThreadFinished" ret_ThreadFinished :: Int
 
 foreign import ccall unsafe "sched_SCHED_RUNNING" sched_SCHED_RUNNING :: Int
 
-foreign import ccall unsafe "sched_SCHED_INTERRUPTING" sched_SCHED_INTERRUPTING
-  :: Int
+foreign import ccall unsafe "sched_SCHED_INTERRUPTING"
+  sched_SCHED_INTERRUPTING :: Int
 
-foreign import ccall unsafe "sched_SCHED_SHUTTING_DOWN" sched_SCHED_SHUTTING_DOWN
-  :: Int
+foreign import ccall unsafe "sched_SCHED_SHUTTING_DOWN"
+  sched_SCHED_SHUTTING_DOWN :: Int
 
 foreign import ccall unsafe "scheduler_NoStatus" scheduler_NoStatus :: Int
 
@@ -543,15 +543,15 @@ foreign import ccall unsafe "scheduler_Killed" scheduler_Killed :: Int
 
 foreign import ccall unsafe "scheduler_Interrupted" scheduler_Interrupted :: Int
 
-foreign import ccall unsafe "scheduler_HeapExhausted" scheduler_HeapExhausted
-  :: Int
+foreign import ccall unsafe "scheduler_HeapExhausted"
+  scheduler_HeapExhausted :: Int
 
 foreign import ccall unsafe "sizeof_bool" sizeof_bool :: Int
 
 foreign import ccall unsafe "sizeof_int" sizeof_int :: Int
 
-foreign import ccall unsafe "sizeof_SchedulerStatus" sizeof_SchedulerStatus
-  :: Int
+foreign import ccall unsafe "sizeof_SchedulerStatus"
+  sizeof_SchedulerStatus :: Int
 
 foreign import ccall unsafe "tso_LOCKED" tso_LOCKED :: Int
 
@@ -559,8 +559,8 @@ foreign import ccall unsafe "tso_BLOCKEX" tso_BLOCKEX :: Int
 
 foreign import ccall unsafe "tso_INTERRUPTIBLE" tso_INTERRUPTIBLE :: Int
 
-foreign import ccall unsafe "tso_STOPPED_ON_BREAKPOINT" tso_STOPPED_ON_BREAKPOINT
-  :: Int
+foreign import ccall unsafe "tso_STOPPED_ON_BREAKPOINT"
+  tso_STOPPED_ON_BREAKPOINT :: Int
 
 foreign import ccall unsafe "tso_MARKED" tso_MARKED :: Int
 
@@ -570,8 +570,8 @@ foreign import ccall unsafe "tso_ALLOC_LIMIT" tso_ALLOC_LIMIT :: Int
 
 foreign import ccall unsafe "sizeof_StgStableName" sizeof_StgStableName :: Int
 
-foreign import ccall unsafe "offset_StgStableName_header" offset_StgStableName_header
-  :: Int
+foreign import ccall unsafe "offset_StgStableName_header"
+  offset_StgStableName_header :: Int
 
-foreign import ccall unsafe "offset_StgStableName_sn" offset_StgStableName_sn
-  :: Int
+foreign import ccall unsafe "offset_StgStableName_sn"
+  offset_StgStableName_sn :: Int

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/FakeGHC.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/FakeGHC.hs
@@ -2,9 +2,10 @@
 {-# LANGUAGE StrictData #-}
 
 module Language.Haskell.GHC.Toolkit.FakeGHC
-  ( FakeGHCOptions(..)
-  , fakeGHCMain
-  ) where
+  ( FakeGHCOptions (..),
+    fakeGHCMain,
+  )
+where
 
 import Control.Monad
 import Data.Foldable
@@ -15,36 +16,42 @@ import qualified Plugins as GHC
 import System.Environment.Blank
 import System.Process
 
-data FakeGHCOptions = FakeGHCOptions
-  { ghc, ghcLibDir :: FilePath
-  , frontendPlugin :: GHC.FrontendPlugin
-  }
+data FakeGHCOptions
+  = FakeGHCOptions
+      { ghc, ghcLibDir :: FilePath,
+        frontendPlugin :: GHC.FrontendPlugin
+      }
 
 fakeGHCMain :: FakeGHCOptions -> IO ()
 fakeGHCMain FakeGHCOptions {..} = do
   ks <-
-    filter (\k -> ("GHC_" `isPrefixOf` k) || "HASKELL_" `isPrefixOf` k) .
-    map fst <$>
-    getEnvironment
+    filter (\k -> ("GHC_" `isPrefixOf` k) || "HASKELL_" `isPrefixOf` k)
+      . map fst
+      <$> getEnvironment
   for_ ks unsetEnv
   args0 <- getArgs
   let (minusB_args, args1) = partition ("-B" `isPrefixOf`) args0
-      new_ghc_libdir =
-        case minusB_args of
-          [minusB_arg] -> drop 2 minusB_arg
-          _ -> ghcLibDir
+      new_ghc_libdir = case minusB_args of
+        [minusB_arg] -> drop 2 minusB_arg
+        _ -> ghcLibDir
   case partition (== "--make") args1 of
     ([], _) -> callProcess ghc $ ("-B" <> new_ghc_libdir) : args1
     (_, args2) ->
-      GHC.defaultErrorHandler GHC.defaultFatalMessager GHC.defaultFlushOut $
-      GHC.runGhc (Just new_ghc_libdir) $ do
-        dflags0 <- GHC.getSessionDynFlags
-        (dflags1, fileish_args, _) <-
-          GHC.parseDynamicFlags dflags0 (map GHC.noLoc args2)
-        void $
-          GHC.setSessionDynFlags
-            dflags1 {GHC.ghcMode = GHC.CompManager, GHC.hscTarget = GHC.HscAsm}
-        GHC.frontend
-          frontendPlugin
-          []
-          [(GHC.unLoc m, Nothing) | m <- fileish_args]
+      GHC.defaultErrorHandler GHC.defaultFatalMessager GHC.defaultFlushOut
+        $ GHC.runGhc (Just new_ghc_libdir)
+        $ do
+          dflags0 <- GHC.getSessionDynFlags
+          (dflags1, fileish_args, _) <-
+            GHC.parseDynamicFlags
+              dflags0
+              (map GHC.noLoc args2)
+          void $
+            GHC.setSessionDynFlags
+              dflags1
+                { GHC.ghcMode = GHC.CompManager,
+                  GHC.hscTarget = GHC.HscAsm
+                }
+          GHC.frontend
+            frontendPlugin
+            []
+            [(GHC.unLoc m, Nothing) | m <- fileish_args]

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/GenPaths.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/GenPaths.hs
@@ -2,9 +2,10 @@
 {-# LANGUAGE StrictData #-}
 
 module Language.Haskell.GHC.Toolkit.GenPaths
-  ( GenPathsOptions(..)
-  , genPaths
-  ) where
+  ( GenPathsOptions (..),
+    genPaths,
+  )
+where
 
 import qualified Data.Map as M
 import Distribution.ModuleName
@@ -18,67 +19,73 @@ import Distribution.Types.PackageDescription
 import System.Directory
 import System.FilePath
 
-newtype GenPathsOptions = GenPathsOptions
-  { targetModuleName :: String
-  }
+newtype GenPathsOptions
+  = GenPathsOptions
+      { targetModuleName :: String
+      }
 
 genPaths :: GenPathsOptions -> UserHooks -> UserHooks
 genPaths GenPathsOptions {..} h =
   h
-    { confHook =
-        \t f -> do
-          lbi@LocalBuildInfo {localPkgDescr = pkg_descr@PackageDescription {library = Just lib@Library {libBuildInfo = lib_bi}}} <-
-            confHook h t f
-          let [clbi] = componentNameMap lbi M.! CLibName
-              mod_path = autogenComponentModulesDir lbi clbi
-              mod_name = fromString targetModuleName
-              ghc_libdir = compilerProperties (compiler lbi) M.! "LibDir"
-          createDirectoryIfMissing True mod_path
-          writeFile (mod_path </> targetModuleName <.> "hs") $
-            "module " ++
-            targetModuleName ++
-            " where\n\n" ++
-            concat
+    { confHook = \t f -> do
+        lbi@LocalBuildInfo {localPkgDescr = pkg_descr@PackageDescription {library = Just lib@Library {libBuildInfo = lib_bi}}} <-
+          confHook h t f
+        let [clbi] = componentNameMap lbi M.! CLibName
+            mod_path = autogenComponentModulesDir lbi clbi
+            mod_name = fromString targetModuleName
+            ghc_libdir = compilerProperties (compiler lbi) M.! "LibDir"
+        createDirectoryIfMissing True mod_path
+        writeFile (mod_path </> targetModuleName <.> "hs") $
+          "module "
+            ++ targetModuleName
+            ++ " where\n\n"
+            ++ concat
               [ let Just conf_prog = lookupProgram prog (withPrograms lbi)
-                 in prog_name ++
-                    " :: FilePath\n" ++
-                    prog_name ++ " = " ++ show (programPath conf_prog) ++ "\n\n"
-              | (prog_name, prog) <-
-                  [("ghc", ghcProgram), ("ghcPkg", ghcPkgProgram)]
-              ] ++
-            "ghcLibDir :: FilePath\nghcLibDir = " ++
-            show ghc_libdir ++
-            "\n\n" ++
-            concat
-              [ k ++
-              " :: FilePath\n" ++
-              k ++
-              " = " ++
-              show
-                (d $
-                 absoluteComponentInstallDirs
-                   pkg_descr
-                   lbi
-                   (componentUnitId clbi)
-                   NoCopyDest) ++
-              "\n\n"
-              | (k, d) <- [("binDir", bindir), ("dataDir", datadir)]
+                 in prog_name
+                      ++ " :: FilePath\n"
+                      ++ prog_name
+                      ++ " = "
+                      ++ show (programPath conf_prog)
+                      ++ "\n\n"
+                | (prog_name, prog) <-
+                    [("ghc", ghcProgram), ("ghcPkg", ghcPkgProgram)]
               ]
-          pure
-            lbi
-              { localPkgDescr =
-                  pkg_descr
-                    { library =
-                        Just
-                          lib
-                            { libBuildInfo =
-                                lib_bi
-                                  { otherModules =
-                                      mod_name : otherModules lib_bi
-                                  , autogenModules =
-                                      mod_name : autogenModules lib_bi
-                                  }
-                            }
-                    }
-              }
+            ++ "ghcLibDir :: FilePath\nghcLibDir = "
+            ++ show ghc_libdir
+            ++ "\n\n"
+            ++ concat
+              [ k
+                  ++ " :: FilePath\n"
+                  ++ k
+                  ++ " = "
+                  ++ show
+                    ( d $
+                        absoluteComponentInstallDirs
+                          pkg_descr
+                          lbi
+                          (componentUnitId clbi)
+                          NoCopyDest
+                    )
+                  ++ "\n\n"
+                | (k, d) <- [("binDir", bindir), ("dataDir", datadir)]
+              ]
+        pure
+          lbi
+            { localPkgDescr =
+                pkg_descr
+                  { library =
+                      Just
+                        lib
+                          { libBuildInfo =
+                              lib_bi
+                                { otherModules =
+                                    mod_name
+                                      : otherModules lib_bi,
+                                  autogenModules =
+                                    mod_name
+                                      : autogenModules lib_bi
+                                }
+                          }
+                  }
+            }
     }

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Orphans/Show.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Orphans/Show.hs
@@ -5,8 +5,8 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Language.Haskell.GHC.Toolkit.Orphans.Show
-  ( setDynFlagsRef
-    )
+  ( setDynFlagsRef,
+  )
 where
 
 import CLabel
@@ -38,19 +38,17 @@ setDynFlagsRef = liftIO . atomicWriteIORef dynFlagsRef
 fakeShow :: Outputable a => String -> a -> String
 fakeShow tag val = unsafePerformIO $ do
   dflags <- readIORef dynFlagsRef
-  pure
-    $ "("
-    ++ tag
-    ++ " "
-    ++ show (showSDoc dflags $ pprCode AsmStyle $ ppr val)
-    ++ ")"
+  pure $
+    "("
+      ++ tag
+      ++ " "
+      ++ show (showSDoc dflags $ pprCode AsmStyle $ ppr val)
+      ++ ")"
 
 instance Outputable SDoc where
-
   ppr = id
 
 instance Show SDoc where
-
   show = fakeShow "SDoc"
 
 deriving instance Show ForeignStubs
@@ -60,7 +58,6 @@ deriving instance Show InstalledUnitId
 deriving instance Show HpcInfo
 
 instance Show ModBreaks where
-
   show = const "ModBreaks"
 
 deriving instance Show SptEntry
@@ -74,11 +71,9 @@ deriving instance Show b => Show (Bind b)
 deriving instance Show FunctionOrData
 
 instance Show Var where
-
   show = fakeShow "Var"
 
 instance Show TyCon where
-
   show = fakeShow "TyCon"
 
 deriving instance Show ArgFlag
@@ -90,7 +85,6 @@ deriving instance Show Role
 deriving instance Show CoAxBranch
 
 instance Show (Branches br) where
-
   show = show . fromBranches
 
 deriving instance Show (CoAxiom br)
@@ -102,7 +96,6 @@ deriving instance Show CoAxiomRule
 deriving instance Show LeftOrRight
 
 instance Show a => Show (IORef a) where
-
   show = show . unsafePerformIO . readIORef
 
 deriving instance Show CoercionHole
@@ -119,7 +112,6 @@ deriving instance Show LitNumType
 deriving instance Show Literal
 
 instance Show DataCon where
-
   show = fakeShow "DataCon"
 
 deriving instance Show PrimOpVecCat
@@ -146,13 +138,11 @@ deriving instance
   (Show bndr, Show occ) => Show (GenStgExpr bndr occ)
 
 instance Show CostCentreStack where
-
   show = fakeShow "CostCentreStack"
 
 deriving instance Show UpdateFlag
 
 instance Show StgBinderInfo where
-
   show binder_info
     | satCallsOnly binder_info = "SatCallsOnly"
     | otherwise = "NoStgBinderInfo"
@@ -167,11 +157,9 @@ deriving instance
   (Show bndr, Show occ) => Show (GenStgTopBinding bndr occ)
 
 instance Show Name where
-
   show = fakeShow "Name"
 
 instance Show CLabel where
-
   show = fakeShow "CLabel"
 
 deriving instance Show Section
@@ -185,19 +173,16 @@ deriving instance Show CmmStatics
 deriving instance Show t => Show (MaybeO ex t)
 
 instance Show (n O O) => Show (Block n O O) where
-
   show = show . blockToList
 
 instance (Show (n C O), Show (n O O), Show (n O C)) => Show (Block n C C) where
-
   show (BlockCC h b t) =
     "BlockCC (" ++ show h ++ ") (" ++ show b ++ ") (" ++ show t ++ ")"
 
 instance
-  (Show (block n C C), Show (n C O), Show (n O O), Show (n O C))
-  => Show (Graph' block n C C)
+  (Show (block n C C), Show (n C O), Show (n O O), Show (n O C)) =>
+  Show (Graph' block n C C)
   where
-
   show (GMany NothingO lm NothingO) = show $ bodyList lm
 
 deriving instance
@@ -206,16 +191,13 @@ deriving instance
 deriving instance Show CmmTickScope
 
 instance Show ModuleName where
-
   show = show . moduleNameString
 
 instance Show Module where
-
   show (Module u m) =
     "Module \"" ++ unitIdString u ++ "\" \"" ++ moduleNameString m ++ "\""
 
 instance Show CostCentreIndex where
-
   show = show . unCostCentreIndex
 
 deriving instance Show CCFlavour
@@ -225,7 +207,6 @@ deriving instance Show CostCentre
 deriving instance Show id => Show (Tickish id)
 
 instance Show CmmType where
-
   show = fakeShow "CmmType"
 
 deriving instance Show LocalReg
@@ -260,7 +241,6 @@ deriving instance Show SMRep
 deriving instance Show ProfilingInfo
 
 instance Show StgHalfWord where
-
   show = show . fromStgHalfWord
 
 deriving instance Show CmmInfoTable
@@ -270,5 +250,4 @@ deriving instance Show CmmStackInfo
 deriving instance Show CmmTopInfo
 
 instance Show a => Show (UniqDSet a) where
-
   showsPrec p = showsPrec p . uniqDSetToList

--- a/npm-utils/Setup.hs
+++ b/npm-utils/Setup.hs
@@ -11,15 +11,14 @@ main :: IO ()
 main =
   defaultMainWithHooks
     simpleUserHooks
-      { confHook =
-          \t@(g_pkg_descr, _) c -> do
-            lbi <- confHook simpleUserHooks t c
-            let pkg_descr = packageDescription g_pkg_descr
-                npm_utils_installdirs =
-                  absoluteInstallDirs pkg_descr lbi NoCopyDest
-                npm_utils_datadir = datadir npm_utils_installdirs
-            createDirectoryIfMissing True npm_utils_datadir
-            withCurrentDirectory npm_utils_datadir $
-              callCommand "npm install parcel-bundler"
-            pure lbi
+      { confHook = \t@(g_pkg_descr, _) c -> do
+          lbi <- confHook simpleUserHooks t c
+          let pkg_descr = packageDescription g_pkg_descr
+              npm_utils_installdirs =
+                absoluteInstallDirs pkg_descr lbi NoCopyDest
+              npm_utils_datadir = datadir npm_utils_installdirs
+          createDirectoryIfMissing True npm_utils_datadir
+          withCurrentDirectory npm_utils_datadir $
+            callCommand "npm install parcel-bundler"
+          pure lbi
       }

--- a/npm-utils/src/NPM/Parcel.hs
+++ b/npm-utils/src/NPM/Parcel.hs
@@ -1,6 +1,7 @@
 module NPM.Parcel
-  ( parcel
-  ) where
+  ( parcel,
+  )
+where
 
 import qualified Paths_npm_utils
 import System.FilePath
@@ -8,7 +9,6 @@ import System.IO.Unsafe
 
 {-# NOINLINE parcel #-}
 parcel :: FilePath
-parcel =
-  unsafePerformIO $ do
-    datadir <- Paths_npm_utils.getDataDir
-    pure $ datadir </> "node_modules" </> ".bin" </> "parcel"
+parcel = unsafePerformIO $ do
+  datadir <- Paths_npm_utils.getDataDir
+  pure $ datadir </> "node_modules" </> ".bin" </> "parcel"

--- a/utils/format.hs
+++ b/utils/format.hs
@@ -16,19 +16,16 @@ main = do
   fs' <- listFilesRecursive bp
   q <- newMVar $ filter ("-ast" `isSuffixOf`) fs'
   n <- read <$> getEnv "FORMAT_N"
-  replicateConcurrently_ n $
-    fix $ \w -> do
-      mf <-
-        modifyMVar q $ \case
-          f:r -> pure (r, Just f)
-          [] -> pure ([], Nothing)
-      case mf of
-        Just f -> do
-          s' <- readFile f
-          writeFile (f <.> "pretty") $
-            case parseValue s' of
-              Just v -> valToStr v
-              _ -> s'
-          removeFile f
-          w
-        _ -> pure ()
+  replicateConcurrently_ n $ fix $ \w -> do
+    mf <- modifyMVar q $ \case
+      f : r -> pure (r, Just f)
+      [] -> pure ([], Nothing)
+    case mf of
+      Just f -> do
+        s' <- readFile f
+        writeFile (f <.> "pretty") $ case parseValue s' of
+          Just v -> valToStr v
+          _ -> s'
+        removeFile f
+        w
+      _ -> pure ()

--- a/wabt/Setup.hs
+++ b/wabt/Setup.hs
@@ -14,55 +14,54 @@ main :: IO ()
 main =
   defaultMainWithHooks
     simpleUserHooks
-      { hookedPrograms = [simpleProgram "cmake"]
-      , confHook =
-          \t c -> do
-            lbi <- confHook simpleUserHooks t c
-            let verbosity = fromFlag $ configVerbosity $ configFlags lbi
-                hs_wabt_builddir = buildDir lbi
-                hs_wabt_build_bindir = hs_wabt_builddir </> "wabt"
-                run prog args cwd =
-                  runProgramInvocation
-                    verbosity
-                    (programInvocation conf_prog args)
-                      {progInvokeCwd = Just cwd, progInvokeInput = Nothing}
-                  where
-                    Just conf_prog =
-                      lookupProgram (simpleProgram prog) (withPrograms lbi)
-            tmpdir <- getTemporaryDirectory
-            withTempDirectory verbosity tmpdir "HSwabt" $ \wabt_buildroot -> do
-              copyDirectoryRecursive verbosity "wabt" wabt_buildroot
-              let wabt_builddir = wabt_buildroot </> "build"
-              createDirectory wabt_builddir
-              run
-                "cmake"
-                [ "-DBUILD_TESTS=OFF"
-                , "-DCMAKE_BUILD_TYPE=Release"
-                , "-G"
-                , "Unix Makefiles"
-                , wabt_buildroot
-                ]
-                wabt_builddir
-              run "cmake" ["--build", wabt_builddir] wabt_builddir
-              createDirectoryIfMissing True hs_wabt_build_bindir
-              bins <- listDirectory $ wabt_buildroot </> "bin"
-              for_ bins $ \b ->
-                copyFileWithMetadata
-                  (wabt_buildroot </> "bin" </> b)
-                  (hs_wabt_build_bindir </> b)
-            pure lbi
-      , copyHook =
-          \pkg_descr lbi h flags -> do
-            copyHook simpleUserHooks pkg_descr lbi h flags
-            let hs_wabt_builddir = buildDir lbi
-                hs_wabt_build_bindir = hs_wabt_builddir </> "wabt"
-                uid = localUnitId lbi
-                copydest = fromFlag (copyDest flags)
-                installDirs =
-                  absoluteComponentInstallDirs pkg_descr lbi uid copydest
-                binDir = bindir installDirs
-            createDirectoryIfMissing True binDir
-            bins <- listDirectory hs_wabt_build_bindir
+      { hookedPrograms = [simpleProgram "cmake"],
+        confHook = \t c -> do
+          lbi <- confHook simpleUserHooks t c
+          let verbosity = fromFlag $ configVerbosity $ configFlags lbi
+              hs_wabt_builddir = buildDir lbi
+              hs_wabt_build_bindir = hs_wabt_builddir </> "wabt"
+              run prog args cwd =
+                runProgramInvocation
+                  verbosity
+                  (programInvocation conf_prog args)
+                    { progInvokeCwd = Just cwd,
+                      progInvokeInput = Nothing
+                    }
+                where
+                  Just conf_prog =
+                    lookupProgram (simpleProgram prog) (withPrograms lbi)
+          tmpdir <- getTemporaryDirectory
+          withTempDirectory verbosity tmpdir "HSwabt" $ \wabt_buildroot -> do
+            copyDirectoryRecursive verbosity "wabt" wabt_buildroot
+            let wabt_builddir = wabt_buildroot </> "build"
+            createDirectory wabt_builddir
+            run
+              "cmake"
+              [ "-DBUILD_TESTS=OFF",
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-G",
+                "Unix Makefiles",
+                wabt_buildroot
+              ]
+              wabt_builddir
+            run "cmake" ["--build", wabt_builddir] wabt_builddir
+            createDirectoryIfMissing True hs_wabt_build_bindir
+            bins <- listDirectory $ wabt_buildroot </> "bin"
             for_ bins $ \b ->
-              copyFileWithMetadata (hs_wabt_build_bindir </> b) (binDir </> b)
+              copyFileWithMetadata
+                (wabt_buildroot </> "bin" </> b)
+                (hs_wabt_build_bindir </> b)
+          pure lbi,
+        copyHook = \pkg_descr lbi h flags -> do
+          copyHook simpleUserHooks pkg_descr lbi h flags
+          let hs_wabt_builddir = buildDir lbi
+              hs_wabt_build_bindir = hs_wabt_builddir </> "wabt"
+              uid = localUnitId lbi
+              copydest = fromFlag (copyDest flags)
+              installDirs = absoluteComponentInstallDirs pkg_descr lbi uid copydest
+              binDir = bindir installDirs
+          createDirectoryIfMissing True binDir
+          bins <- listDirectory hs_wabt_build_bindir
+          for_ bins $ \b ->
+            copyFileWithMetadata (hs_wabt_build_bindir </> b) (binDir </> b)
       }

--- a/wasm-toolkit/test/Language/WebAssembly/WireFormat/Orphans.hs
+++ b/wasm-toolkit/test/Language/WebAssembly/WireFormat/Orphans.hs
@@ -4,9 +4,10 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Language.WebAssembly.WireFormat.Orphans
-  ( genModule
-  , shrinkModule
-  ) where
+  ( genModule,
+    shrinkModule,
+  )
+where
 
 import qualified Data.ByteString.Short as SBS
 import Data.Coerce
@@ -22,21 +23,27 @@ genSBS :: Gen SBS.ShortByteString
 genSBS = SBS.pack <$> listOf chooseAny
 
 instance Arbitrary SBS.ShortByteString where
+
   arbitrary = genSBS
+
   shrink = map SBS.pack . shrink . SBS.unpack
 
 genName :: Gen Name
 genName = coerce genSBS
 
 instance Arbitrary Name where
+
   arbitrary = genName
+
   shrink = genericShrink
 
 genValueType :: Gen ValueType
 genValueType = Test.QuickCheck.Gen.elements [I32, I64, F32, F64]
 
 instance Arbitrary ValueType where
+
   arbitrary = genValueType
+
   shrink = genericShrink
 
 genResultType :: Gen [ValueType]
@@ -48,56 +55,72 @@ genFunctionType :: Gen FunctionType
 genFunctionType = FunctionType <$> listOf genValueType <*> genResultType
 
 instance Arbitrary FunctionType where
+
   arbitrary = genFunctionType
+
   shrink = genericShrink
 
 genLimits :: Gen Limits
 genLimits = Limits <$> chooseAny <*> genMaybe chooseAny
 
 instance Arbitrary Limits where
+
   arbitrary = genLimits
+
   shrink = genericShrink
 
 genMemoryType :: Gen MemoryType
 genMemoryType = coerce genLimits
 
 instance Arbitrary MemoryType where
+
   arbitrary = genMemoryType
+
   shrink = genericShrink
 
 genElementType :: Gen ElementType
 genElementType = pure AnyFunc
 
 instance Arbitrary ElementType where
+
   arbitrary = genElementType
+
   shrink = genericShrink
 
 genTableType :: Gen TableType
 genTableType = TableType <$> genElementType <*> genLimits
 
 instance Arbitrary TableType where
+
   arbitrary = genTableType
+
   shrink = genericShrink
 
 genMutability :: Gen Mutability
 genMutability = Test.QuickCheck.Gen.elements [Const, Var]
 
 instance Arbitrary Mutability where
+
   arbitrary = genMutability
+
   shrink = genericShrink
 
 genGlobalType :: Gen GlobalType
 genGlobalType = GlobalType <$> genValueType <*> genMutability
 
 instance Arbitrary GlobalType where
+
   arbitrary = genGlobalType
+
   shrink = genericShrink
 
 genMemoryArgument :: Gen MemoryArgument
 genMemoryArgument = MemoryArgument <$> chooseAny <*> chooseAny
 
 instance Arbitrary MemoryArgument where
+
   arbitrary = genMemoryArgument
+
   shrink = genericShrink
 
 genInstructions :: Gen [Instruction]
@@ -106,307 +129,342 @@ genInstructions = listOf genInstruction
 genInstruction :: Gen Instruction
 genInstruction =
   frequency
-    [ ( 64
-      , oneof
-          [ pure Unreachable
-          , pure Nop
-          , Branch <$> genLabelIndex
-          , BranchIf <$> genLabelIndex
-          , BranchTable <$> listOf genLabelIndex <*> genLabelIndex
-          , pure Return
-          , Call <$> genFunctionIndex
-          , CallIndirect <$> genFunctionTypeIndex
-          , pure Drop
-          , pure Select
-          , GetLocal <$> genLocalIndex
-          , SetLocal <$> genLocalIndex
-          , TeeLocal <$> genLocalIndex
-          , GetGlobal <$> genGlobalIndex
-          , SetGlobal <$> genGlobalIndex
-          , I32Load <$> genMemoryArgument
-          , I64Load <$> genMemoryArgument
-          , F32Load <$> genMemoryArgument
-          , F64Load <$> genMemoryArgument
-          , I32Load8Signed <$> genMemoryArgument
-          , I32Load8Unsigned <$> genMemoryArgument
-          , I32Load16Signed <$> genMemoryArgument
-          , I32Load16Unsigned <$> genMemoryArgument
-          , I64Load8Signed <$> genMemoryArgument
-          , I64Load8Unsigned <$> genMemoryArgument
-          , I64Load16Signed <$> genMemoryArgument
-          , I64Load16Unsigned <$> genMemoryArgument
-          , I64Load32Signed <$> genMemoryArgument
-          , I64Load32Unsigned <$> genMemoryArgument
-          , I32Store <$> genMemoryArgument
-          , I64Store <$> genMemoryArgument
-          , F32Store <$> genMemoryArgument
-          , F64Store <$> genMemoryArgument
-          , I32Store8 <$> genMemoryArgument
-          , I32Store16 <$> genMemoryArgument
-          , I64Store8 <$> genMemoryArgument
-          , I64Store16 <$> genMemoryArgument
-          , I64Store32 <$> genMemoryArgument
-          , pure MemorySize
-          , pure MemoryGrow
-          , pure I32Eqz
-          , pure I64Eqz
-          , pure I32Clz
-          , pure I32Ctz
-          , pure I32Popcnt
-          , pure I64Clz
-          , pure I64Ctz
-          , pure I64Popcnt
-          , pure F32Abs
-          , pure F32Neg
-          , pure F32Ceil
-          , pure F32Floor
-          , pure F32Trunc
-          , pure F32Nearest
-          , pure F32Sqrt
-          , pure F64Abs
-          , pure F64Neg
-          , pure F64Ceil
-          , pure F64Floor
-          , pure F64Trunc
-          , pure F64Nearest
-          , pure F64Sqrt
-          , pure I32WrapFromI64
-          , pure I32TruncSFromF32
-          , pure I32TruncUFromF32
-          , pure I32TruncSFromF64
-          , pure I32TruncUFromF64
-          , pure I64ExtendSFromI32
-          , pure I64ExtendUFromI32
-          , pure I64TruncSFromF32
-          , pure I64TruncUFromF32
-          , pure I64TruncSFromF64
-          , pure I64TruncUFromF64
-          , pure F32ConvertSFromI32
-          , pure F32ConvertUFromI32
-          , pure F32ConvertSFromI64
-          , pure F32ConvertUFromI64
-          , pure F32DemoteFromF64
-          , pure F64ConvertSFromI32
-          , pure F64ConvertUFromI32
-          , pure F64ConvertSFromI64
-          , pure F64ConvertUFromI64
-          , pure F64PromoteFromF32
-          , pure I32ReinterpretFromF32
-          , pure I64ReinterpretFromF64
-          , pure F32ReinterpretFromI32
-          , pure F64ReinterpretFromI64
-          , pure I32Eq
-          , pure I32Ne
-          , pure I32LtS
-          , pure I32LtU
-          , pure I32GtS
-          , pure I32GtU
-          , pure I32LeS
-          , pure I32LeU
-          , pure I32GeS
-          , pure I32GeU
-          , pure I64Eq
-          , pure I64Ne
-          , pure I64LtS
-          , pure I64LtU
-          , pure I64GtS
-          , pure I64GtU
-          , pure I64LeS
-          , pure I64LeU
-          , pure I64GeS
-          , pure I64GeU
-          , pure F32Eq
-          , pure F32Ne
-          , pure F32Lt
-          , pure F32Gt
-          , pure F32Le
-          , pure F32Ge
-          , pure F64Eq
-          , pure F64Ne
-          , pure F64Lt
-          , pure F64Gt
-          , pure F64Le
-          , pure F64Ge
-          , pure I32Add
-          , pure I32Sub
-          , pure I32Mul
-          , pure I32DivS
-          , pure I32DivU
-          , pure I32RemS
-          , pure I32RemU
-          , pure I32And
-          , pure I32Or
-          , pure I32Xor
-          , pure I32Shl
-          , pure I32ShrS
-          , pure I32ShrU
-          , pure I32RotL
-          , pure I32RotR
-          , pure I64Add
-          , pure I64Sub
-          , pure I64Mul
-          , pure I64DivS
-          , pure I64DivU
-          , pure I64RemS
-          , pure I64RemU
-          , pure I64And
-          , pure I64Or
-          , pure I64Xor
-          , pure I64Shl
-          , pure I64ShrS
-          , pure I64ShrU
-          , pure I64RotL
-          , pure I64RotR
-          , pure F32Add
-          , pure F32Sub
-          , pure F32Mul
-          , pure F32Div
-          , pure F32Min
-          , pure F32Max
-          , pure F32Copysign
-          , pure F64Add
-          , pure F64Sub
-          , pure F64Mul
-          , pure F64Div
-          , pure F64Min
-          , pure F64Max
-          , pure F64Copysign
-          ])
-    , ( 1
-      , oneof
-          [ Block <$> genResultType <*> genInstructions
-          , Loop <$> genResultType <*> genInstructions
-          , If <$> genResultType <*> genInstructions <*>
-            genMaybe genInstructions
-          ])
+    [ ( 64,
+        oneof
+          [ pure Unreachable,
+            pure Nop,
+            Branch <$> genLabelIndex,
+            BranchIf <$> genLabelIndex,
+            BranchTable <$> listOf genLabelIndex <*> genLabelIndex,
+            pure Return,
+            Call <$> genFunctionIndex,
+            CallIndirect <$> genFunctionTypeIndex,
+            pure Drop,
+            pure Select,
+            GetLocal <$> genLocalIndex,
+            SetLocal <$> genLocalIndex,
+            TeeLocal <$> genLocalIndex,
+            GetGlobal <$> genGlobalIndex,
+            SetGlobal <$> genGlobalIndex,
+            I32Load <$> genMemoryArgument,
+            I64Load <$> genMemoryArgument,
+            F32Load <$> genMemoryArgument,
+            F64Load <$> genMemoryArgument,
+            I32Load8Signed <$> genMemoryArgument,
+            I32Load8Unsigned <$> genMemoryArgument,
+            I32Load16Signed <$> genMemoryArgument,
+            I32Load16Unsigned <$> genMemoryArgument,
+            I64Load8Signed <$> genMemoryArgument,
+            I64Load8Unsigned <$> genMemoryArgument,
+            I64Load16Signed <$> genMemoryArgument,
+            I64Load16Unsigned <$> genMemoryArgument,
+            I64Load32Signed <$> genMemoryArgument,
+            I64Load32Unsigned <$> genMemoryArgument,
+            I32Store <$> genMemoryArgument,
+            I64Store <$> genMemoryArgument,
+            F32Store <$> genMemoryArgument,
+            F64Store <$> genMemoryArgument,
+            I32Store8 <$> genMemoryArgument,
+            I32Store16 <$> genMemoryArgument,
+            I64Store8 <$> genMemoryArgument,
+            I64Store16 <$> genMemoryArgument,
+            I64Store32 <$> genMemoryArgument,
+            pure MemorySize,
+            pure MemoryGrow,
+            pure I32Eqz,
+            pure I64Eqz,
+            pure I32Clz,
+            pure I32Ctz,
+            pure I32Popcnt,
+            pure I64Clz,
+            pure I64Ctz,
+            pure I64Popcnt,
+            pure F32Abs,
+            pure F32Neg,
+            pure F32Ceil,
+            pure F32Floor,
+            pure F32Trunc,
+            pure F32Nearest,
+            pure F32Sqrt,
+            pure F64Abs,
+            pure F64Neg,
+            pure F64Ceil,
+            pure F64Floor,
+            pure F64Trunc,
+            pure F64Nearest,
+            pure F64Sqrt,
+            pure I32WrapFromI64,
+            pure I32TruncSFromF32,
+            pure I32TruncUFromF32,
+            pure I32TruncSFromF64,
+            pure I32TruncUFromF64,
+            pure I64ExtendSFromI32,
+            pure I64ExtendUFromI32,
+            pure I64TruncSFromF32,
+            pure I64TruncUFromF32,
+            pure I64TruncSFromF64,
+            pure I64TruncUFromF64,
+            pure F32ConvertSFromI32,
+            pure F32ConvertUFromI32,
+            pure F32ConvertSFromI64,
+            pure F32ConvertUFromI64,
+            pure F32DemoteFromF64,
+            pure F64ConvertSFromI32,
+            pure F64ConvertUFromI32,
+            pure F64ConvertSFromI64,
+            pure F64ConvertUFromI64,
+            pure F64PromoteFromF32,
+            pure I32ReinterpretFromF32,
+            pure I64ReinterpretFromF64,
+            pure F32ReinterpretFromI32,
+            pure F64ReinterpretFromI64,
+            pure I32Eq,
+            pure I32Ne,
+            pure I32LtS,
+            pure I32LtU,
+            pure I32GtS,
+            pure I32GtU,
+            pure I32LeS,
+            pure I32LeU,
+            pure I32GeS,
+            pure I32GeU,
+            pure I64Eq,
+            pure I64Ne,
+            pure I64LtS,
+            pure I64LtU,
+            pure I64GtS,
+            pure I64GtU,
+            pure I64LeS,
+            pure I64LeU,
+            pure I64GeS,
+            pure I64GeU,
+            pure F32Eq,
+            pure F32Ne,
+            pure F32Lt,
+            pure F32Gt,
+            pure F32Le,
+            pure F32Ge,
+            pure F64Eq,
+            pure F64Ne,
+            pure F64Lt,
+            pure F64Gt,
+            pure F64Le,
+            pure F64Ge,
+            pure I32Add,
+            pure I32Sub,
+            pure I32Mul,
+            pure I32DivS,
+            pure I32DivU,
+            pure I32RemS,
+            pure I32RemU,
+            pure I32And,
+            pure I32Or,
+            pure I32Xor,
+            pure I32Shl,
+            pure I32ShrS,
+            pure I32ShrU,
+            pure I32RotL,
+            pure I32RotR,
+            pure I64Add,
+            pure I64Sub,
+            pure I64Mul,
+            pure I64DivS,
+            pure I64DivU,
+            pure I64RemS,
+            pure I64RemU,
+            pure I64And,
+            pure I64Or,
+            pure I64Xor,
+            pure I64Shl,
+            pure I64ShrS,
+            pure I64ShrU,
+            pure I64RotL,
+            pure I64RotR,
+            pure F32Add,
+            pure F32Sub,
+            pure F32Mul,
+            pure F32Div,
+            pure F32Min,
+            pure F32Max,
+            pure F32Copysign,
+            pure F64Add,
+            pure F64Sub,
+            pure F64Mul,
+            pure F64Div,
+            pure F64Min,
+            pure F64Max,
+            pure F64Copysign
+          ]
+      ),
+      ( 1,
+        oneof
+          [ Block <$> genResultType <*> genInstructions,
+            Loop <$> genResultType <*> genInstructions,
+            If <$> genResultType <*> genInstructions <*> genMaybe genInstructions
+          ]
+      )
     ]
 
 instance Arbitrary Instruction where
+
   arbitrary = genInstruction
+
   shrink = genericShrink
 
 genExpression :: Gen Expression
 genExpression = Expression <$> listOf genInstruction
 
 instance Arbitrary Expression where
+
   arbitrary = genExpression
+
   shrink = genericShrink
 
 genCustom :: Gen Custom
 genCustom = Custom <$> genName <*> genSBS
 
 instance Arbitrary Custom where
+
   arbitrary = genCustom
+
   shrink = genericShrink
 
 genFunctionTypeIndex :: Gen FunctionTypeIndex
 genFunctionTypeIndex = coerce (chooseAny @Word32)
 
 instance Arbitrary FunctionTypeIndex where
+
   arbitrary = genFunctionTypeIndex
+
   shrink = genericShrink
 
 genFunctionIndex :: Gen FunctionIndex
 genFunctionIndex = coerce (chooseAny @Word32)
 
 instance Arbitrary FunctionIndex where
+
   arbitrary = genFunctionIndex
+
   shrink = genericShrink
 
 genTableIndex :: Gen TableIndex
 genTableIndex = coerce (chooseAny @Word32)
 
 instance Arbitrary TableIndex where
+
   arbitrary = genTableIndex
+
   shrink = genericShrink
 
 genMemoryIndex :: Gen MemoryIndex
 genMemoryIndex = coerce (chooseAny @Word32)
 
 instance Arbitrary MemoryIndex where
+
   arbitrary = genMemoryIndex
+
   shrink = genericShrink
 
 genGlobalIndex :: Gen GlobalIndex
 genGlobalIndex = coerce (chooseAny @Word32)
 
 instance Arbitrary GlobalIndex where
+
   arbitrary = genGlobalIndex
+
   shrink = genericShrink
 
 genLocalIndex :: Gen LocalIndex
 genLocalIndex = coerce (chooseAny @Word32)
 
 instance Arbitrary LocalIndex where
+
   arbitrary = genLocalIndex
+
   shrink = genericShrink
 
 genLabelIndex :: Gen LabelIndex
 genLabelIndex = coerce (chooseAny @Word32)
 
 instance Arbitrary LabelIndex where
+
   arbitrary = genLabelIndex
+
   shrink = genericShrink
 
 genImportDescription :: Gen ImportDescription
 genImportDescription =
   oneof
-    [ ImportFunction <$> genFunctionTypeIndex
-    , ImportTable <$> genTableType
-    , ImportMemory <$> genMemoryType
-    , ImportGlobal <$> genGlobalType
+    [ ImportFunction <$> genFunctionTypeIndex,
+      ImportTable <$> genTableType,
+      ImportMemory <$> genMemoryType,
+      ImportGlobal <$> genGlobalType
     ]
 
 instance Arbitrary ImportDescription where
+
   arbitrary = genImportDescription
+
   shrink = genericShrink
 
 genImport :: Gen Import
 genImport = Import <$> genName <*> genName <*> genImportDescription
 
 instance Arbitrary Import where
+
   arbitrary = genImport
+
   shrink = genericShrink
 
 genTable :: Gen Table
 genTable = coerce genTableType
 
 instance Arbitrary Table where
+
   arbitrary = genTable
+
   shrink = genericShrink
 
 genMemory :: Gen Memory
 genMemory = coerce genMemoryType
 
 instance Arbitrary Memory where
+
   arbitrary = genMemory
+
   shrink = genericShrink
 
 genGlobal :: Gen Global
 genGlobal = Global <$> genGlobalType <*> genExpression
 
 instance Arbitrary Global where
+
   arbitrary = genGlobal
+
   shrink = genericShrink
 
 genExportDescription :: Gen ExportDescription
 genExportDescription =
   oneof
-    [ ExportFunction <$> genFunctionIndex
-    , ExportTable <$> genTableIndex
-    , ExportMemory <$> genMemoryIndex
-    , ExportGlobal <$> genGlobalIndex
+    [ ExportFunction <$> genFunctionIndex,
+      ExportTable <$> genTableIndex,
+      ExportMemory <$> genMemoryIndex,
+      ExportGlobal <$> genGlobalIndex
     ]
 
 instance Arbitrary ExportDescription where
+
   arbitrary = genExportDescription
+
   shrink = genericShrink
 
 genExport :: Gen Export
 genExport = Export <$> genName <*> genExportDescription
 
 instance Arbitrary Export where
+
   arbitrary = genExport
+
   shrink = genericShrink
 
 genElement :: Gen Element
@@ -414,28 +472,36 @@ genElement =
   Element <$> genTableIndex <*> genExpression <*> listOf genFunctionIndex
 
 instance Arbitrary Element where
+
   arbitrary = genElement
+
   shrink = genericShrink
 
 genLocals :: Gen Locals
 genLocals = Locals <$> chooseAny <*> genValueType
 
 instance Arbitrary Locals where
+
   arbitrary = genLocals
+
   shrink = genericShrink
 
 genFunction :: Gen Function
 genFunction = Function <$> listOf genLocals <*> genExpression
 
 instance Arbitrary Function where
+
   arbitrary = genFunction
+
   shrink = genericShrink
 
 genDataSegment :: Gen DataSegment
 genDataSegment = DataSegment <$> genMemoryIndex <*> genExpression <*> genSBS
 
 instance Arbitrary DataSegment where
+
   arbitrary = genDataSegment
+
   shrink = genericShrink
 
 genLinkingSymbolFlags :: Gen LinkingSymbolFlags
@@ -443,7 +509,9 @@ genLinkingSymbolFlags =
   LinkingSymbolFlags <$> chooseAny <*> chooseAny <*> chooseAny <*> chooseAny
 
 instance Arbitrary LinkingSymbolFlags where
+
   arbitrary = genLinkingSymbolFlags
+
   shrink = genericShrink
 
 genLinkingSymbolInfo :: Gen LinkingSymbolInfo
@@ -452,57 +520,66 @@ genLinkingSymbolInfo = do
   oneof
     [ if linkingWasmSymUndefined
         then LinkingFunctionSymbolInfo _sym_flags <$> chooseAny <*> pure Nothing
-        else LinkingFunctionSymbolInfo _sym_flags <$> chooseAny <*>
-             fmap Just genName
-    , if linkingWasmSymUndefined
-        then LinkingDataSymbolInfo _sym_flags <$> genName <*> pure Nothing <*>
-             pure Nothing <*>
-             pure Nothing
-        else LinkingDataSymbolInfo _sym_flags <$> genName <*>
-             fmap Just chooseAny <*>
-             fmap Just chooseAny <*>
-             fmap Just chooseAny
-    , if linkingWasmSymUndefined
+        else LinkingFunctionSymbolInfo _sym_flags <$> chooseAny <*> fmap Just genName,
+      if linkingWasmSymUndefined
+        then
+          LinkingDataSymbolInfo _sym_flags
+            <$> genName
+            <*> pure Nothing
+            <*> pure Nothing
+            <*> pure Nothing
+        else
+          LinkingDataSymbolInfo _sym_flags
+            <$> genName
+            <*> fmap Just chooseAny
+            <*> fmap Just chooseAny
+            <*> fmap Just chooseAny,
+      if linkingWasmSymUndefined
         then LinkingGlobalSymbolInfo _sym_flags <$> chooseAny <*> pure Nothing
-        else LinkingGlobalSymbolInfo _sym_flags <$> chooseAny <*>
-             fmap Just genName
-    , LinkingSectionSymbolInfo _sym_flags <$> chooseAny
+        else LinkingGlobalSymbolInfo _sym_flags <$> chooseAny <*> fmap Just genName,
+      LinkingSectionSymbolInfo _sym_flags <$> chooseAny
     ]
 
 instance Arbitrary LinkingSymbolInfo where
+
   arbitrary = genLinkingSymbolInfo
+
   shrink = genericShrink
 
 genLinkingSubSection :: Gen LinkingSubSection
 genLinkingSubSection =
   oneof
-    [ LinkingWasmSegmentInfo <$> genSBS
-    , LinkingWasmInitFuncs <$> genSBS
-    , LinkingWasmComdatInfo <$> genSBS
-    , LinkingWasmSymbolTable <$> genSBS
+    [ LinkingWasmSegmentInfo <$> genSBS,
+      LinkingWasmInitFuncs <$> genSBS,
+      LinkingWasmComdatInfo <$> genSBS,
+      LinkingWasmSymbolTable <$> genSBS
     ]
 
 instance Arbitrary LinkingSubSection where
+
   arbitrary = genLinkingSubSection
+
   shrink = genericShrink
 
 genRelocationType :: Gen RelocationType
 genRelocationType =
   Test.QuickCheck.Gen.elements
-    [ RWebAssemblyFunctionIndexLEB
-    , RWebAssemblyTableIndexSLEB
-    , RWebAssemblyTableIndexI32
-    , RWebAssemblyMemoryAddrLEB
-    , RWebAssemblyMemoryAddrSLEB
-    , RWebAssemblyMemoryAddrI32
-    , RWebAssemblyTypeIndexLEB
-    , RWebAssemblyGlobalIndexLEB
-    , RWebAssemblyFunctionOffsetI32
-    , RWebAssemblySectionOffsetI32
+    [ RWebAssemblyFunctionIndexLEB,
+      RWebAssemblyTableIndexSLEB,
+      RWebAssemblyTableIndexI32,
+      RWebAssemblyMemoryAddrLEB,
+      RWebAssemblyMemoryAddrSLEB,
+      RWebAssemblyMemoryAddrI32,
+      RWebAssemblyTypeIndexLEB,
+      RWebAssemblyGlobalIndexLEB,
+      RWebAssemblyFunctionOffsetI32,
+      RWebAssemblySectionOffsetI32
     ]
 
 instance Arbitrary RelocationType where
+
   arbitrary = genRelocationType
+
   shrink = genericShrink
 
 genRelocationEntry :: Gen RelocationEntry
@@ -511,102 +588,100 @@ genRelocationEntry = do
   _reloc_offset <- chooseAny
   _reloc_index <- chooseAny
   _reloc_addend <-
-    if _reloc_type `elem`
-       [ RWebAssemblyMemoryAddrLEB
-       , RWebAssemblyMemoryAddrSLEB
-       , RWebAssemblyMemoryAddrI32
-       , RWebAssemblyFunctionOffsetI32
-       , RWebAssemblySectionOffsetI32
-       ]
+    if _reloc_type
+      `elem` [ RWebAssemblyMemoryAddrLEB,
+               RWebAssemblyMemoryAddrSLEB,
+               RWebAssemblyMemoryAddrI32,
+               RWebAssemblyFunctionOffsetI32,
+               RWebAssemblySectionOffsetI32
+             ]
       then Just <$> chooseAny
       else pure Nothing
   pure $ RelocationEntry _reloc_type _reloc_offset _reloc_index _reloc_addend
 
 instance Arbitrary RelocationEntry where
+
   arbitrary = genRelocationEntry
+
   shrink = genericShrink
 
 genSection :: Gen Section
 genSection =
   oneof
-    [ LinkingSection <$> chooseAny <*> listOf genLinkingSubSection
-    , RelocationSection <$> genName <*> chooseAny <*> listOf genRelocationEntry
-    , CustomSection <$> genCustom
-    , TypeSection <$> listOf genFunctionType
-    , ImportSection <$> listOf genImport
-    , FunctionSection <$> listOf genFunctionTypeIndex
-    , TableSection <$> listOf genTable
-    , MemorySection <$> listOf genMemory
-    , GlobalSection <$> listOf genGlobal
-    , ExportSection <$> listOf genExport
-    , StartSection <$> genFunctionIndex
-    , ElementSection <$> listOf genElement
-    , CodeSection <$> listOf genFunction
-    , DataSection <$> listOf genDataSegment
+    [ LinkingSection <$> chooseAny <*> listOf genLinkingSubSection,
+      RelocationSection <$> genName <*> chooseAny <*> listOf genRelocationEntry,
+      CustomSection <$> genCustom,
+      TypeSection <$> listOf genFunctionType,
+      ImportSection <$> listOf genImport,
+      FunctionSection <$> listOf genFunctionTypeIndex,
+      TableSection <$> listOf genTable,
+      MemorySection <$> listOf genMemory,
+      GlobalSection <$> listOf genGlobal,
+      ExportSection <$> listOf genExport,
+      StartSection <$> genFunctionIndex,
+      ElementSection <$> listOf genElement,
+      CodeSection <$> listOf genFunction,
+      DataSection <$> listOf genDataSegment
     ]
 
 instance Arbitrary Section where
+
   arbitrary = genSection
+
   shrink = genericShrink
 
 genModule :: Gen Module
 genModule = Module <$> listOf genSection
 
-isExportSection, isElementSection, isCodeSection, isDataSection ::
-     Section -> Bool
-isExportSection sec =
-  case sec of
-    ExportSection {} -> True
-    _ -> False
-
-isElementSection sec =
-  case sec of
-    ElementSection {} -> True
-    _ -> False
-
-isCodeSection sec =
-  case sec of
-    CodeSection {} -> True
-    _ -> False
-
-isDataSection sec =
-  case sec of
-    DataSection {} -> True
-    _ -> False
+isExportSection,
+  isElementSection,
+  isCodeSection,
+  isDataSection ::
+    Section -> Bool
+isExportSection sec = case sec of
+  ExportSection {} -> True
+  _ -> False
+isElementSection sec = case sec of
+  ElementSection {} -> True
+  _ -> False
+isCodeSection sec = case sec of
+  CodeSection {} -> True
+  _ -> False
+isDataSection sec = case sec of
+  DataSection {} -> True
+  _ -> False
 
 shrinkedFunction :: Function
 shrinkedFunction =
   Function {functionLocals = [], functionBody = coerce [Unreachable]}
 
 updateList :: Int -> a -> [a] -> [a]
-updateList i a l = l0 <> (a : l1)
-  where
-    (l0, _:l1) = splitAt i l
+updateList i a l = l0 <> (a : l1) where (l0, _ : l1) = splitAt i l
 
 shrinkCodeSection :: [Function] -> [[Function]]
 shrinkCodeSection _sec =
   concat
     [ if _sec !! i == shrinkedFunction
-      then []
-      else [updateList i shrinkedFunction _sec]
-    | i <- [0 .. length _sec - 1]
+        then []
+        else [updateList i shrinkedFunction _sec]
+      | i <- [0 .. length _sec - 1]
     ]
 
 shrinkModule :: Module -> [Module]
 shrinkModule m =
-  _drop_sec isExportSection <> _drop_sec isElementSection <>
-  _results_by_code_sec <>
-  _drop_sec isDataSection
+  _drop_sec isExportSection
+    <> _drop_sec isElementSection
+    <> _results_by_code_sec
+    <> _drop_sec isDataSection
   where
-    _drop_sec f =
-      case break f (coerce m) of
-        (_, []) -> []
-        (_pre_secs, _:_post_secs) -> [coerce $ _pre_secs <> _post_secs]
-    _results_by_code_sec =
-      case break isCodeSection (coerce m) of
-        (_, []) -> []
-        (_pre_code_secs, _code_sec:_post_code_secs) ->
-          [ coerce $
-          _pre_code_secs <> (CodeSection _shrinked_code_sec : _post_code_secs)
+    _drop_sec f = case break f (coerce m) of
+      (_, []) -> []
+      (_pre_secs, _ : _post_secs) -> [coerce $ _pre_secs <> _post_secs]
+    _results_by_code_sec = case break isCodeSection (coerce m) of
+      (_, []) -> []
+      (_pre_code_secs, _code_sec : _post_code_secs) ->
+        [ coerce $
+            _pre_code_secs
+              <> (CodeSection _shrinked_code_sec : _post_code_secs)
           | _shrinked_code_sec <- shrinkCodeSection $ functions' _code_sec
-          ]
+        ]

--- a/wasm-toolkit/test/NodeCompile.hs
+++ b/wasm-toolkit/test/NodeCompile.hs
@@ -1,6 +1,7 @@
 module NodeCompile
-  ( testNodeCompileWithShrink
-  ) where
+  ( testNodeCompileWithShrink,
+  )
+where
 
 import Control.Exception
 import Data.Binary.Put
@@ -15,42 +16,40 @@ import Test.QuickCheck
 import Test.QuickCheck.Monadic
 
 testNodeCompile :: Module -> Property
-testNodeCompile m =
-  monadicIO $ do
-    _result <-
-      run $ do
-        tmpdir <- getTemporaryDirectory
-        bracket
-          (openBinaryTempFile tmpdir "wasm-toolkit-test.wasm")
-          (\(p, _) -> removeFile p)
-          (\(p, h) -> do
-             LBS.hPut h $ runPut $ putModule m
-             hClose h
-             (_exit_code, _stdout, _stderr) <-
-               readProcessWithExitCode
-                 "node"
-                 ["test" </> "node-compile.js", p]
-                 ""
-             case _exit_code of
-               ExitSuccess -> pure Nothing
-               _ -> do
-                 (p_err, h_err) <-
-                   openTempFile tmpdir "wasm-toolkit-test-dump.txt"
-                 hPutStr h_err $ show m
-                 hClose h_err
-                 pure $ Just (_exit_code, _stdout, _stderr, p_err))
-    case _result of
-      Just (_exit_code, _stdout, _stderr, p_err) ->
-        fail $
-        "Compiling serialized module via Node.js failed.\nExit code: " <>
-        show _exit_code <>
-        "\nStdout: " <>
-        _stdout <>
-        "\nStderr: " <>
-        _stderr <>
-        "\nModule dump path: " <>
-        p_err
-      _ -> pure ()
+testNodeCompile m = monadicIO $ do
+  _result <- run $ do
+    tmpdir <- getTemporaryDirectory
+    bracket
+      (openBinaryTempFile tmpdir "wasm-toolkit-test.wasm")
+      (\(p, _) -> removeFile p)
+      ( \(p, h) -> do
+          LBS.hPut h $ runPut $ putModule m
+          hClose h
+          (_exit_code, _stdout, _stderr) <-
+            readProcessWithExitCode
+              "node"
+              ["test" </> "node-compile.js", p]
+              ""
+          case _exit_code of
+            ExitSuccess -> pure Nothing
+            _ -> do
+              (p_err, h_err) <- openTempFile tmpdir "wasm-toolkit-test-dump.txt"
+              hPutStr h_err $ show m
+              hClose h_err
+              pure $ Just (_exit_code, _stdout, _stderr, p_err)
+      )
+  case _result of
+    Just (_exit_code, _stdout, _stderr, p_err) ->
+      fail $
+        "Compiling serialized module via Node.js failed.\nExit code: "
+          <> show _exit_code
+          <> "\nStdout: "
+          <> _stdout
+          <> "\nStderr: "
+          <> _stderr
+          <> "\nModule dump path: "
+          <> p_err
+    _ -> pure ()
 
 testNodeCompileWithShrink :: (Module -> [Module]) -> Module -> Property
 testNodeCompileWithShrink s m = shrinking s m testNodeCompile

--- a/wasm-toolkit/test/wasm-toolkit-codec.hs
+++ b/wasm-toolkit/test/wasm-toolkit-codec.hs
@@ -11,53 +11,57 @@ import Test.QuickCheck
 import Test.QuickCheck.Gen
 
 testCodecGen ::
-     (Eq a, Show a) => Gen a -> (a -> [a]) -> Get a -> (a -> Put) -> Property
-testCodecGen gen s g p =
-  forAllShrink gen s $ \x ->
-    let buf = runPut $ p x
-     in case runGetOrFail g buf of
-          Right (rest, _, r)
-            | r /= x || not (LBS.null rest) ->
-              counterexample
-                ("testCodeGen: failed to parse.\nBefore: " <> show x <>
-                 "\nBuffer: " <>
-                 show buf <>
-                 "\nAfter: " <>
-                 show r <>
-                 "\nResidule: " <>
-                 show rest)
-                False
-            | otherwise -> property True
-          _ ->
+  (Eq a, Show a) => Gen a -> (a -> [a]) -> Get a -> (a -> Put) -> Property
+testCodecGen gen s g p = forAllShrink gen s $ \x ->
+  let buf = runPut $ p x
+   in case runGetOrFail g buf of
+        Right (rest, _, r)
+          | r /= x || not (LBS.null rest) ->
             counterexample
-              ("testCodecGen: failed to parse.\nBefore: " <> show x <>
-               "\nBuffer: " <>
-               show buf)
+              ( "testCodeGen: failed to parse.\nBefore: "
+                  <> show x
+                  <> "\nBuffer: "
+                  <> show buf
+                  <> "\nAfter: "
+                  <> show r
+                  <> "\nResidule: "
+                  <> show rest
+              )
               False
+          | otherwise -> property True
+        _ ->
+          counterexample
+            ( "testCodecGen: failed to parse.\nBefore: "
+                <> show x
+                <> "\nBuffer: "
+                <> show buf
+            )
+            False
 
 testCodecFile ::
-     (Eq a, Show a)
-  => LBS.ByteString
-  -> (a -> [a])
-  -> Get a
-  -> (a -> Put)
-  -> Property
-testCodecFile buf s g p =
-  case runGetOrFail g buf of
-    Right (rest, _, x)
-      | LBS.null rest -> testCodecGen (pure x) s g p
-      | otherwise ->
-        counterexample
-          ("testCodecFile: failed to parse.\nBuffer: " <> show buf <>
-           "\nResult: " <>
-           show x <>
-           "\nResidule: " <>
-           show rest)
-          False
-    _ ->
+  (Eq a, Show a) =>
+  LBS.ByteString ->
+  (a -> [a]) ->
+  Get a ->
+  (a -> Put) ->
+  Property
+testCodecFile buf s g p = case runGetOrFail g buf of
+  Right (rest, _, x)
+    | LBS.null rest -> testCodecGen (pure x) s g p
+    | otherwise ->
       counterexample
-        ("testCodecFile: failed to parse.\nBuffer: " <> show buf)
+        ( "testCodecFile: failed to parse.\nBuffer: "
+            <> show buf
+            <> "\nResult: "
+            <> show x
+            <> "\nResidule: "
+            <> show rest
+        )
         False
+  _ ->
+    counterexample
+      ("testCodecFile: failed to parse.\nBuffer: " <> show buf)
+      False
 
 testCodecModule :: FilePath -> IO Property
 testCodecModule p = do
@@ -67,46 +71,46 @@ testCodecModule p = do
 testLEB128Static :: Property
 testLEB128Static =
   conjoin
-    [ testCodecGen (pure 0) (const []) getVU32 putVU32
-    , testCodecGen (pure maxBound) (const []) getVU32 putVU32
-    , testCodecGen (pure minBound) (const []) getVS32 putVS32
-    , testCodecGen (pure (-1)) (const []) getVS32 putVS32
-    , testCodecGen (pure 0) (const []) getVS32 putVS32
-    , testCodecGen (pure maxBound) (const []) getVS32 putVS32
-    , testCodecGen (pure minBound) (const []) getVS64 putVS64
-    , testCodecGen (pure (-1)) (const []) getVS64 putVS64
-    , testCodecGen (pure 0) (const []) getVS64 putVS64
-    , testCodecGen (pure maxBound) (const []) getVS64 putVS64
-    , testCodecGen (pure 0xFFFFFFFFFFFFFFF8) (const []) getVS64 putVS64
+    [ testCodecGen (pure 0) (const []) getVU32 putVU32,
+      testCodecGen (pure maxBound) (const []) getVU32 putVU32,
+      testCodecGen (pure minBound) (const []) getVS32 putVS32,
+      testCodecGen (pure (-1)) (const []) getVS32 putVS32,
+      testCodecGen (pure 0) (const []) getVS32 putVS32,
+      testCodecGen (pure maxBound) (const []) getVS32 putVS32,
+      testCodecGen (pure minBound) (const []) getVS64 putVS64,
+      testCodecGen (pure (-1)) (const []) getVS64 putVS64,
+      testCodecGen (pure 0) (const []) getVS64 putVS64,
+      testCodecGen (pure maxBound) (const []) getVS64 putVS64,
+      testCodecGen (pure 0xFFFFFFFFFFFFFFF8) (const []) getVS64 putVS64
     ]
 
 testLEB128Dynamic :: Property
 testLEB128Dynamic =
   conjoin
-    [ testCodecGen chooseAny (const []) getVU32 putVU32
-    , testCodecGen chooseAny (const []) getVS32 putVS32
-    , testCodecGen chooseAny (const []) getVS64 putVS64
-    , testCodecGen chooseAny (const []) getF32 putF32
-    , testCodecGen chooseAny (const []) getF64 putF64
+    [ testCodecGen chooseAny (const []) getVU32 putVU32,
+      testCodecGen chooseAny (const []) getVS32 putVS32,
+      testCodecGen chooseAny (const []) getVS64 putVS64,
+      testCodecGen chooseAny (const []) getF32 putF32,
+      testCodecGen chooseAny (const []) getF64 putF64
     ]
 
 main :: IO ()
 main = do
   quickCheck testLEB128Static
   for_
-    [ "test/array.wasm"
-    , "test/clang-fib.wasm"
-    , "test/fib.wasm"
-    , "test/jsffi.wasm"
-    , "test/rtsapi.wasm"
-    , "test/stableptr.wasm"
-    ] $
-    testCodecModule >=> quickCheck
+    [ "test/array.wasm",
+      "test/clang-fib.wasm",
+      "test/fib.wasm",
+      "test/jsffi.wasm",
+      "test/rtsapi.wasm",
+      "test/stableptr.wasm"
+    ]
+    $ testCodecModule
+      >=> quickCheck
   r <-
-    quickCheckResult $
-    withMaxSuccess 576460752303423488 $
-    conjoin
-      [ testLEB128Dynamic
-      , testCodecGen genModule genericShrink getModule putModule
-      ]
+    quickCheckResult $ withMaxSuccess 576460752303423488 $
+      conjoin
+        [ testLEB128Dynamic,
+          testCodecGen genModule genericShrink getModule putModule
+        ]
   writeFile "test/wasm-toolkit-codec.txt" $ show r


### PR DESCRIPTION
We appoint `ormolu` as our official Haskell formatter, and apply it onto the current codebase.