### PR TITLE
Move DCE logic to a proper pass

### DIFF
--- a/asterius/src/Asterius/Passes/GCSections.hs
+++ b/asterius/src/Asterius/Passes/GCSections.hs
@@ -1,0 +1,109 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Asterius.Passes.GCSections
+  ( gcSections,
+  )
+where
+
+import Asterius.Types
+import Data.Data
+  ( Data,
+    gmapQl,
+  )
+import qualified Data.Map.Lazy as LM
+import qualified Data.Set as S
+import Data.String
+import Type.Reflection
+
+gcSections ::
+  Bool ->
+  AsteriusModule ->
+  S.Set AsteriusEntitySymbol ->
+  [AsteriusEntitySymbol] ->
+  AsteriusModule
+gcSections verbose_err store_mod root_syms export_funcs =
+  final_m
+    { ffiMarshalState = ffi_this
+    }
+  where
+    ffi_all = ffiMarshalState store_mod
+    ffi_this =
+      ffi_all
+        { ffiImportDecls = flip LM.filterWithKey (ffiImportDecls ffi_all) $ \k _ ->
+            (k <> "_wrapper") `LM.member` functionMap final_m,
+          ffiExportDecls = ffi_exports
+        }
+    ffi_exports =
+      ffiExportDecls (ffiMarshalState store_mod)
+        `LM.restrictKeys` S.fromList export_funcs
+    root_syms' =
+      S.fromList [ffiExportClosure | FFIExportDecl {..} <- LM.elems ffi_exports]
+        <> root_syms
+    (_, _, final_m) = go (root_syms', S.empty, mempty)
+    go i@(i_staging_syms, _, _)
+      | S.null i_staging_syms = i
+      | otherwise = go $ iter i
+    iter (i_staging_syms, i_acc_syms, i_m) = (o_staging_syms, o_acc_syms, o_m)
+      where
+        o_acc_syms = i_staging_syms <> i_acc_syms
+        (i_child_syms, o_m) =
+          S.foldr'
+            ( \i_staging_sym (i_child_syms_acc, o_m_acc) ->
+                case LM.lookup i_staging_sym (staticsMap store_mod) of
+                  Just ss ->
+                    ( collectAsteriusEntitySymbols ss <> i_child_syms_acc,
+                      o_m_acc
+                        { staticsMap = LM.insert i_staging_sym ss (staticsMap o_m_acc)
+                        }
+                    )
+                  _ -> case LM.lookup i_staging_sym (functionMap store_mod) of
+                    Just func ->
+                      ( collectAsteriusEntitySymbols func <> i_child_syms_acc,
+                        o_m_acc
+                          { functionMap =
+                              LM.insert
+                                i_staging_sym
+                                func
+                                (functionMap o_m_acc)
+                          }
+                      )
+                    _
+                      | verbose_err ->
+                        ( i_child_syms_acc,
+                          o_m_acc
+                            { staticsMap =
+                                LM.insert
+                                  ("__asterius_barf_" <> i_staging_sym)
+                                  AsteriusStatics
+                                    { staticsType = ConstBytes,
+                                      asteriusStatics =
+                                        [ Serialized $
+                                            entityName i_staging_sym
+                                              <> ( case LM.lookup
+                                                     i_staging_sym
+                                                     (staticsErrorMap store_mod) of
+                                                     Just err -> fromString (": " <> show err)
+                                                     _ -> mempty
+                                                 )
+                                              <> "\0"
+                                        ]
+                                    }
+                                  (staticsMap o_m_acc)
+                            }
+                        )
+                      | otherwise ->
+                        (i_child_syms_acc, o_m_acc)
+            )
+            (S.empty, i_m)
+            i_staging_syms
+        o_staging_syms = i_child_syms `S.difference` o_acc_syms
+
+collectAsteriusEntitySymbols :: Data a => a -> S.Set AsteriusEntitySymbol
+collectAsteriusEntitySymbols t
+  | Just HRefl <- eqTypeRep (typeOf t) (typeRep @AsteriusEntitySymbol) =
+    S.singleton t
+  | otherwise =
+    gmapQl (<>) S.empty collectAsteriusEntitySymbols t

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StrictData #-}
 
@@ -19,27 +17,16 @@ import Asterius.JSFFI
 import Asterius.MemoryTrap
 import Asterius.Passes.DataSymbolTable
 import Asterius.Passes.FunctionSymbolTable
+import Asterius.Passes.GCSections
 import Asterius.Types
 import Data.Binary
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Short as SBS
-import Data.Data
-  ( Data,
-    gmapQl,
-  )
 import qualified Data.Map.Lazy as LM
 import qualified Data.Set as S
-import Data.String
 import Foreign
 import GHC.Generics
 import Language.Haskell.GHC.Toolkit.Constants
-import Type.Reflection
-  ( (:~~:) (..),
-    TypeRep,
-    eqTypeRep,
-    typeOf,
-    typeRep,
-  )
 import Unsafe.Coerce
 import Prelude hiding (IO)
 
@@ -48,13 +35,6 @@ unresolvedGlobalRegType gr = case gr of
   FloatReg _ -> F32
   DoubleReg _ -> F64
   _ -> I64
-
-collectAsteriusEntitySymbols ::
-  Data a => a -> S.Set AsteriusEntitySymbol -> S.Set AsteriusEntitySymbol
-collectAsteriusEntitySymbols t acc =
-  case eqTypeRep (typeOf t) (typeRep :: TypeRep AsteriusEntitySymbol) of
-    Just HRefl -> S.insert t acc
-    _ -> gmapQl (.) id collectAsteriusEntitySymbols t acc
 
 data LinkReport
   = LinkReport
@@ -88,92 +68,6 @@ instance Monoid LinkReport where
       staticMBlocks = 0,
       bundledFFIMarshalState = mempty
     }
-
-mergeSymbols ::
-  Bool ->
-  Bool ->
-  Bool ->
-  AsteriusModule ->
-  S.Set AsteriusEntitySymbol ->
-  [AsteriusEntitySymbol] ->
-  (AsteriusModule, LinkReport)
-mergeSymbols _ gc_sections verbose_err store_mod root_syms export_funcs
-  | not gc_sections = (store_mod, mempty {bundledFFIMarshalState = ffi_all})
-  | otherwise = (final_m, mempty {bundledFFIMarshalState = ffi_this})
-  where
-    ffi_all = ffiMarshalState store_mod
-    ffi_this =
-      ffi_all
-        { ffiImportDecls = flip LM.filterWithKey (ffiImportDecls ffi_all) $ \k _ ->
-            (k <> "_wrapper") `LM.member` functionMap final_m,
-          ffiExportDecls = ffi_exports
-        }
-    ffi_exports
-      | not gc_sections = ffiExportDecls (ffiMarshalState store_mod)
-      | otherwise =
-        ffiExportDecls (ffiMarshalState store_mod)
-          `LM.restrictKeys` S.fromList export_funcs
-    root_syms' =
-      S.fromList [ffiExportClosure | FFIExportDecl {..} <- LM.elems ffi_exports]
-        <> root_syms
-    (_, _, final_m) = go (root_syms', S.empty, mempty)
-    go i@(i_staging_syms, _, _)
-      | S.null i_staging_syms = i
-      | otherwise = go $ iter i
-    iter (i_staging_syms, i_acc_syms, i_m) = (o_staging_syms, o_acc_syms, o_m)
-      where
-        o_acc_syms = i_staging_syms <> i_acc_syms
-        (i_child_syms, o_m) =
-          S.foldr'
-            ( \i_staging_sym (i_child_syms_acc, o_m_acc) ->
-                case LM.lookup i_staging_sym (staticsMap store_mod) of
-                  Just ss ->
-                    ( collectAsteriusEntitySymbols ss i_child_syms_acc,
-                      o_m_acc
-                        { staticsMap = LM.insert i_staging_sym ss (staticsMap o_m_acc)
-                        }
-                    )
-                  _ -> case LM.lookup i_staging_sym (functionMap store_mod) of
-                    Just func ->
-                      ( collectAsteriusEntitySymbols func i_child_syms_acc,
-                        o_m_acc
-                          { functionMap =
-                              LM.insert
-                                i_staging_sym
-                                func
-                                (functionMap o_m_acc)
-                          }
-                      )
-                    _
-                      | verbose_err ->
-                        ( i_child_syms_acc,
-                          o_m_acc
-                            { staticsMap =
-                                LM.insert
-                                  ("__asterius_barf_" <> i_staging_sym)
-                                  AsteriusStatics
-                                    { staticsType = ConstBytes,
-                                      asteriusStatics =
-                                        [ Serialized $
-                                            entityName i_staging_sym
-                                              <> ( case LM.lookup
-                                                     i_staging_sym
-                                                     (staticsErrorMap store_mod) of
-                                                     Just err -> fromString (": " <> show err)
-                                                     _ -> mempty
-                                                 )
-                                              <> "\0"
-                                        ]
-                                    }
-                                  (staticsMap o_m_acc)
-                            }
-                        )
-                      | otherwise ->
-                        (i_child_syms_acc, o_m_acc)
-            )
-            (S.empty, i_m)
-            i_staging_syms
-        o_staging_syms = i_child_syms `S.difference` o_acc_syms
 
 makeInfoTableSet ::
   AsteriusModule -> LM.Map AsteriusEntitySymbol Int64 -> [Int64]
@@ -256,17 +150,19 @@ linkStart ::
 linkStart debug gc_sections binaryen verbose_err store root_syms export_funcs =
   ( merged_m,
     result_m,
-    report
+    mempty
       { staticsSymbolMap = ss_sym_map,
         functionSymbolMap = func_sym_map,
         infoTableSet = makeInfoTableSet merged_m ss_sym_map,
         Asterius.Resolve.tableSlots = tbl_slots,
-        staticMBlocks = static_mbs
+        staticMBlocks = static_mbs,
+        bundledFFIMarshalState = bundled_ffi_state
       }
   )
   where
-    (merged_m0, !report) =
-      mergeSymbols debug gc_sections verbose_err store root_syms export_funcs
+    merged_m0
+      | gc_sections = gcSections verbose_err store root_syms export_funcs
+      | otherwise = store
     merged_m1
       | debug = addMemoryTrap merged_m0
       | otherwise = merged_m0
@@ -284,11 +180,12 @@ linkStart debug gc_sections binaryen verbose_err store root_syms export_funcs =
                 )
                 $ staticsMap merged_m1
           }
+    bundled_ffi_state = ffiMarshalState merged_m
     (!result_m, !ss_sym_map, !func_sym_map, !tbl_slots, !static_mbs) =
       resolveAsteriusModule
         debug
         binaryen
-        (bundledFFIMarshalState report)
+        bundled_ffi_state
         merged_m
         (1 .|. functionTag `shiftL` 32)
         (dataTag `shiftL` 32)


### PR DESCRIPTION
Previously we piled quite a lot of linker logic into `Asterius.Resolve`; this PR moves out the dead code elimination logic out of `Asterius.Resolve` to a separate optional pass. This is a part of efforts to clean up the linker mess and prepare a cleaner foundation for incremental linker work.