### PR TITLE
Fix & test ahc-cabal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,13 +41,14 @@ jobs:
             apt install -y nodejs
             mkdir -p /root/.local/bin
             curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C /root/.local/bin '*/stack'
+            curl -L https://downloads.haskell.org/~cabal/cabal-install-latest/cabal-install-3.0.0.0-x86_64-unknown-linux.tar.xz | tar xJ -C /root/.local/bin 'cabal'
       - checkout
 
       - run:
           name: Boot
           command: |
             git submodule update --init --recursive
-            stack --no-terminal -j2 build --test --no-run-tests
+            stack --no-terminal -j2 install --test --no-run-tests asterius
             stack --no-terminal exec ahc-boot
 
       - persist_to_workspace:
@@ -145,6 +146,55 @@ jobs:
             stack --no-terminal test asterius:nomain --test-arguments="--tail-calls"
 
             stack --no-terminal test asterius:th
+
+  asterius-test-cabal:
+    docker:
+      - image: debian:unstable
+    environment:
+      - DEBIAN_FRONTEND: noninteractive
+      - LANG: C.UTF-8
+      - PATH: /root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apt update
+            apt full-upgrade -y
+            apt install -y \
+              automake \
+              cmake \
+              curl \
+              g++ \
+              git \
+              gnupg \
+              libdw-dev \
+              libffi-dev \
+              libgmp-dev \
+              libncurses-dev \
+              libnuma-dev \
+              make \
+              openssh-client \
+              python-minimal \
+              python3-minimal \
+              xz-utils \
+              zlib1g-dev
+            curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+            echo "deb https://deb.nodesource.com/node_13.x sid main" > /etc/apt/sources.list.d/nodesource.list
+            apt update
+            apt install -y nodejs
+      - checkout
+      - run:
+          name: Initialize submodules
+          command: |
+            git submodule update --init --recursive
+      - attach_workspace:
+          at: /root
+      - run:
+          name: Test ahc-cabal
+          command: |
+            ahc-cabal new-update
+            ahc-cabal new-install --installdir . hello
+            ahc-dist --input-exe hello --run
 
   asterius-test-ghc-testsuite:
     docker:
@@ -479,6 +529,9 @@ workflows:
     jobs:
       - asterius-boot
       - asterius-test:
+          requires:
+            - asterius-boot
+      - asterius-test-cabal:
           requires:
             - asterius-boot
       - asterius-test-ghc-testsuite:

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN \
   apt install -y nodejs && \
   mkdir -p /root/.local/bin && \
   curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C /root/.local/bin '*/stack' && \
+  curl -L https://downloads.haskell.org/~cabal/cabal-install-latest/cabal-install-3.0.0.0-x86_64-unknown-linux.tar.xz | tar xJ -C /root/.local/bin 'cabal' && \
   stack --no-terminal install asterius && \
   stack --no-terminal exec ahc-boot && \
   apt purge -y \

--- a/asterius/app/ahc-cabal.hs
+++ b/asterius/app/ahc-cabal.hs
@@ -1,65 +1,79 @@
 import Asterius.BuildInfo
+import Control.Monad
 import Data.List
+import Distribution.Simple.Utils
+import Distribution.Verbosity
+import System.Directory
 import System.Environment.Blank
-import System.Process
+import System.FilePath
+import System.Process (callProcess)
 
 main :: IO ()
 main = do
-  args <- getArgs
-  let extra_prog_args =
-        [ "--with-ghc=" <> ahc,
-          "--with-ghc-pkg=" <> ahcPkg,
-          "--ghc-option=-fexternal-interpreter",
-          "--ghc-option=-pgml" <> ahcLd
-        ]
-      extra_args =
-        [ "--disable-shared",
-          "--disable-executable-dynamic",
-          "--disable-profiling",
-          "--disable-debug-info",
-          "--disable-library-for-ghci",
-          "--disable-split-sections",
-          "--disable-split-objs",
-          "--disable-executable-stripping",
-          "--disable-library-stripping",
-          "--disable-tests",
-          "--disable-coverage",
-          "--disable-benchmarks",
-          "--disable-relocatable"
-        ]
-          <> extra_prog_args
-      (global_flags, command_flags) = span ("-" `isPrefixOf`) args
-      new_command_flags = case command_flags of
-        command : flags
-          | command
-              `elem` [ "new-build",
-                       "new-configure",
-                       "v2-build",
-                       "v2-configure",
-                       "v1-configure",
-                       "v1-reconfigure",
-                       "v1-install"
-                     ] ->
-            command : (extra_args <> flags)
-          | command `elem` ["v1-build"] ->
-            command : (extra_prog_args <> flags)
-          | command
-              `elem` [ "update",
-                       "help",
-                       "info",
-                       "list",
-                       "fetch",
-                       "user-config",
-                       "get",
-                       "init",
-                       "sandbox",
-                       "new-update",
-                       "v2-update",
-                       "v1-sandbox"
-                     ] ->
-            command_flags
-          | otherwise ->
-            error $ "ahc-cabal: Unsupported command " <> command
-        _ -> command_flags
-      new_args = global_flags <> new_command_flags
-  callProcess "cabal" new_args
+  args0 <- getArgs
+  env <- getEnvironment
+  unsetEnv "CABAL_CONFIG"
+  (args1, old_cabal_config_path) <-
+    case findIndex ("--config-file" `isPrefixOf`) args0 of
+      Just i
+        | arg == "--config-file" ->
+          pure
+            (take i args0 <> drop (i + 2) args0, args0 !! (i + 1))
+        | otherwise -> pure (take i args0 <> drop (i + 1) args0, drop 14 arg)
+        where
+          arg = args0 !! i
+      _ -> case lookup "CABAL_CONFIG" env of
+        Just v -> pure (args0, v)
+        _ -> do
+          home <- getHomeDirectory
+          let cabal_prefix_path = home </> ".cabal"
+              cabal_config_path = cabal_prefix_path </> "config"
+          createDirectoryIfMissing True cabal_prefix_path
+          cabal_config_exist <- doesFileExist cabal_config_path
+          unless cabal_config_exist $
+            callProcess
+              "cabal"
+              ["--config-file", cabal_config_path, "user-config", "init"]
+          pure (args0, cabal_config_path)
+  tmp <- getTemporaryDirectory
+  withTempDirectory silent tmp "ahc-cabal" $ \tmpdir -> do
+    let new_cabal_config_path = tmpdir </> "config"
+    copyFile old_cabal_config_path new_cabal_config_path
+    callProcess
+      "cabal"
+      [ "--config-file",
+        new_cabal_config_path,
+        "user-config",
+        "update",
+        "-a",
+        "benchmarks: False",
+        "-a",
+        "coverage: False",
+        "-a",
+        "debug-info: False",
+        "-a",
+        "executable-dynamic: False",
+        "-a",
+        "executable-stripping: False",
+        "-a",
+        "library-for-ghci: False",
+        "-a",
+        "library-stripping: False",
+        "-a",
+        "profiling: False",
+        "-a",
+        "relocatable: False",
+        "-a",
+        "shared: False",
+        "-a",
+        "split-objs: False",
+        "-a",
+        "split-sections: False",
+        "-a",
+        "tests: False",
+        "-a",
+        "with-compiler: " <> ahc,
+        "-a",
+        "with-hc-pkg: " <> ahcPkg
+      ]
+    callProcess "cabal" (["--config-file", new_cabal_config_path] <> args1)

--- a/asterius/app/ahc-ld.hs
+++ b/asterius/app/ahc-ld.hs
@@ -33,8 +33,14 @@ parseLinkTask args = do
           str_args "--export-function="
     }
   where
-    Just (stripPrefix "--prog-name=" -> Just prog_name) =
-      find ("--prog-name=" `isPrefixOf`) args
+    prog_name
+      | Just (stripPrefix "--prog-name=" -> Just v) <-
+          find
+            ("--prog-name=" `isPrefixOf`)
+            args =
+        v
+      | otherwise =
+        ""
     link_output = args !! succ output_i
     Just output_i = elemIndex "-o" args
     link_objs = filter ((== "o.") . take 2 . reverse) args

--- a/asterius/src/Asterius/FrontendPlugin.hs
+++ b/asterius/src/Asterius/FrontendPlugin.hs
@@ -5,6 +5,7 @@ module Asterius.FrontendPlugin
   )
 where
 
+import Asterius.BuildInfo
 import Asterius.CodeGen
 import Asterius.Foreign
 import Asterius.GHCi.Internals
@@ -49,7 +50,13 @@ frontendPlugin = makeFrontendPlugin $ do
     dflags <- GHC.getSessionDynFlags
     void
       $ GHC.setSessionDynFlags
-      $ dflags {GHC.settings = (GHC.settings dflags) {GHC.sPgm_i = "false"}}
+      $ dflags
+        { GHC.settings =
+            (GHC.settings dflags)
+              { GHC.sPgm_l = (ahcLd, []),
+                GHC.sPgm_i = "false"
+              }
+        }
         `GHC.gopt_set` GHC.Opt_ExternalInterpreter
   when is_debug $ do
     dflags <- GHC.getSessionDynFlags


### PR DESCRIPTION
Whatever not tested on CI should be assumed broken. And at least not the case anymore for `ahc-cabal`..

Changes:

* Previously, `ahc-cabal` works by intercepting command-line arguments, adding a bunch of asterius-specific stuff and passing to `cabal`; it requires quite a bit of knowledge about how `cabal` arguments are parsed, and only work for a certain set of "common" commands. Now we take an alternative approach: obtain the cabal config file path, create and supply a temporary config file which is patched with `cabal user-config update`. This is simpler and works for all cabal commands.
* The frontend plugin of `ahc` now always hard-code the `ahc-ld` as the linker, so no need for passing `-pgml` from the command line
* The `ahc-ld` executable used to expect a `--prog-name` switch which is only generated by `ahc-link`, not `ahc` itself. We now default to an empty program name when the switch is absent.
* On CI we test a minimal `ahc-cabal` case: build and run `hello` from hackage.
* `cabal` is installed in the docker image. So `ahc-cabal` should work in the image.

TLDR: these problems are fixed:

* `ahc` fails to build executable due to the `ahc-ld` bug
* `ahc-cabal` fails to build executable targets due to the bug above
* `ahc-cabal` doesn't work for V1 build commands
* `ahc-cabal` doesn't work in the docker image