### PR TITLE
Mitigate Integer use-after-free issue

### DIFF
--- a/asterius/rts/rts.stableptr.mjs
+++ b/asterius/rts/rts.stableptr.mjs
@@ -54,7 +54,15 @@ export class StablePtrManager {
   }
 
   preserveJSVals(sps) {
-    for (const sp of Array.from(this.spt.keys()))
-      if (sp & 1 && !sps.has(sp)) this.freeJSVal(sp);
+    // The logic to free JSVals not spotted on the Haskell heap during GC has
+    // been commented out for now, due to a use-after-free issue related to
+    // Integers (see #320).
+
+    // Disabling GC for JSVal is the easiest mitigation for the issue. When a
+    // new generation Integer library replaces the current integer-simple
+    // library, we'll recover the logic here.
+
+    // for (const sp of Array.from(this.spt.keys()))
+    //   if (sp & 1 && !sps.has(sp)) this.freeJSVal(sp);
   }
 }


### PR DESCRIPTION
Related: #320 

We temporarily disable `JSVal` GC to mitigate the `Integer` use-after-free issue for the time being. @hsyl20's new generation `Integer` library will soon save us from this mess, so imho we better not spend a lot more time to rewrite `integer-simple` to fix it :)