### PR TITLE
Implement missing utf8 codec cbits for text

### DIFF
--- a/asterius/rts/rts.text.mjs
+++ b/asterius/rts/rts.text.mjs
@@ -23,4 +23,35 @@ export class TextCBits {
     }
     return 0;
   }
+
+  _hs_text_decode_utf8(dest, destoffp, src, srcend) {
+    const dec = new TextDecoder("utf-8", { fatal: true }),
+      s = dec.decode(
+        this.memory.i8View.subarray(Memory.unTag(src), Memory.unTag(srcend))
+      );
+    for (let i = 0; i < s.length; ++i)
+      this.memory.i16Store(dest + i * 2, s.charCodeAt(i));
+    this.memory.i64Store(destoffp, s.length);
+    return srcend;
+  }
+
+  _hs_text_encode_utf8(destp, src, srcoff, srclen) {
+    const dec = new TextDecoder("utf-16le", { fatal: true }),
+      s = dec.decode(
+        this.memory.i8View.subarray(
+          Memory.unTag(src + srcoff * 2),
+          Memory.unTag(src + srcoff * 2 + srclen * 2)
+        )
+      ),
+      dest = Number(this.memory.i64Load(destp)),
+      enc = new TextEncoder(),
+      l = enc.encodeInto(
+        s,
+        this.memory.i8View.subarray(
+          Memory.unTag(dest),
+          Memory.unTag(dest + srclen * 3)
+        )
+      ).written;
+    this.memory.i64Store(destp, dest + l);
+  }
 }

--- a/asterius/rts/rts.text.mjs
+++ b/asterius/rts/rts.text.mjs
@@ -45,6 +45,13 @@ export class TextCBits {
       ),
       dest = Number(this.memory.i64Load(destp)),
       enc = new TextEncoder(),
+      // `Data.Text.Encoding.encodeUtf8` allocates a `ByteArray#` of size
+      // `srclen * 3` to ensure enough space for a single-pass encoding from
+      // UTF-16 to UTF-8. See the comment near
+      // `https://github.com/haskell/text/blob/2176eb38b5238e763e8076b0d0db8c2f2014ab8b/Data/Text/Encoding.hs#L432`
+      // and the "Buffer Sizing" section of
+      // `https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encodeInto`
+      // for details.
       l = enc.encodeInto(
         s,
         this.memory.i8View.subarray(

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -761,7 +761,9 @@ textCBits =
         )
     )
     [ ("_hs_text_memcpy", [I64, I64, I64, I64, I64], []),
-      ("_hs_text_memcmp", [I64, I64, I64, I64, I64], [I64])
+      ("_hs_text_memcmp", [I64, I64, I64, I64, I64], [I64]),
+      ("_hs_text_decode_utf8", [I64, I64, I64, I64], [I64]),
+      ("_hs_text_encode_utf8", [I64, I64, I64, I64], [])
     ]
 
 floatCBits :: [(AsteriusEntitySymbol, (FunctionImport, Function))]


### PR DESCRIPTION
Related: #357 #347 

This PR uses W3C `TextDecoder` and `TextEncoder` to implement UTF-8 codec functions: `_hs_text_decode_utf8` and `_hs_text_encode_utf8`, which are required by `Data.Text.Encoding` and `aeson` related code.

The behavior of `_hs_text_decode_utf8` diverges with original c version with illegal input; in which case a runtime error is thrown in js and can't be handled in hs. It's possible to implement correct "stop at first illegal code point" behavior by bisecting the source buffer and feeding to `TextDecoder`, but IMHO that's more work and should be fixed in future PRs.