### PR TITLE
Migrate 128-bit FNV-1a logic to be used by base and hashable

### DIFF
--- a/asterius/rts/rts.fnv.mjs
+++ b/asterius/rts/rts.fnv.mjs
@@ -1,0 +1,30 @@
+// We implement the 128-bit FNV-1a hash function:
+// https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+// Original work by @bollu. This module is used in two cases:
+// 1. Pseudo-MD5 hashing for Fingerprints in base
+// 2. FNV hashing for hashable. The 128-bits hash result is truncated to 64-bits
+
+const fnv_offset = BigInt("144066263297769815596495629667062367629"),
+  fnv_prime = BigInt("309485009821345068724781371"),
+  fnv_mask = (BigInt(1) << BigInt(128)) - BigInt(1);
+
+export class FNV {
+  constructor(memory) {
+    this.memory = memory;
+    Object.freeze(this);
+  }
+
+  init() {
+    return fnv_offset;
+  }
+
+  update(hash, bufp, len) {
+    for (let i = 0; i < len; ++i) {
+      hash ^= BigInt(this.memory.i8Load(bufp + i));
+      hash *= fnv_prime;
+      // only keep 128 bits, overflow is overflown.
+      hash &= fnv_mask;
+    }
+    return hash;
+  }
+}

--- a/asterius/rts/rts.md5.mjs
+++ b/asterius/rts/rts.md5.mjs
@@ -9,14 +9,14 @@ export class MD5 {
 
   // void MD5Init(struct MD5Context *context);
   __hsbase_MD5Init(ctxp) {
-    this.memory.i128Store(ctxp, fnv.init());
+    this.memory.i128Store(ctxp, this.fnv.init());
   }
 
   // void MD5Update(struct MD5Context *context, byte const *buf, int len);
   __hsbase_MD5Update(ctxp, bufp, len) {
     this.memory.i128Store(
       ctxp,
-      fnv.update(this.memory.i128Load(ctxp), bufp, len)
+      this.fnv.update(this.memory.i128Load(ctxp), bufp, len)
     );
   }
 

--- a/asterius/rts/rts.md5.mjs
+++ b/asterius/rts/rts.md5.mjs
@@ -1,41 +1,23 @@
-import { Memory } from "./rts.memory.mjs";
+import { FNV } from "./rts.fnv.mjs";
 
 export class MD5 {
-  // We implement the 128-bit FNV-1a hash function:
-  // https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
-  // This is easier, and it is unclear whether GHC
-  // needs cryptographic hash functions. We assume that GHC does not ever
-  // depend on the fact that the hash function _must be MD5_.
-
-  // used by GHC/Fingerprint.hs
-  // C implementation header: libraries/base/include/md5.h
-  // C implementation source: libraries/base/cbits/md5.c
   constructor(memory) {
+    this.fnv = new FNV(memory);
     this.memory = memory;
-    Object.seal(this);
+    Object.freeze(this);
   }
 
   // void MD5Init(struct MD5Context *context);
   __hsbase_MD5Init(ctxp) {
-    const offset = BigInt("144066263297769815596495629667062367629");
-    this.memory.i128Store(ctxp, offset);
+    this.memory.i128Store(ctxp, fnv.init());
   }
 
   // void MD5Update(struct MD5Context *context, byte const *buf, int len);
   __hsbase_MD5Update(ctxp, bufp, len) {
-    const prime = BigInt("309485009821345068724781371");
-
-    let i = 0;
-    let hash = this.memory.i128Load(ctxp);
-    while (i < len) {
-      let c = BigInt(this.memory.i8View[Memory.unTag(bufp) + i]);
-      hash = hash * prime;
-      hash = hash ^ c;
-      // only keep 128 bits, overflow is overflown.
-      hash = hash & ((BigInt(1) << BigInt(128)) - BigInt(1));
-      i++;
-    }
-    this.memory.i128Store(ctxp, hash);
+    this.memory.i128Store(
+      ctxp,
+      fnv.update(this.memory.i128Load(ctxp), bufp, len)
+    );
   }
 
   // 16 byte = 128 bit.

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -18,6 +18,7 @@ module Asterius.Builtins
   )
 where
 
+import Asterius.Builtins.Hashable
 import Asterius.EDSL
 import Asterius.Internals
 import Asterius.Internals.MagicNumber
@@ -191,6 +192,7 @@ rtsAsteriusModule opts =
     -- the module wrapped by using `generateWrapperModule`.
     <> generateRtsExternalInterfaceModule opts
     <> generateWrapperModule (generateRtsExternalInterfaceModule opts)
+    <> hashableCBits
 
 -- Generate the module consisting of functions which need to be wrapped
 -- for communication with the external runtime.

--- a/asterius/src/Asterius/Builtins/Hashable.hs
+++ b/asterius/src/Asterius/Builtins/Hashable.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Asterius.Builtins.Hashable
+  ( hashableCBits,
+  )
+where
+
+import Asterius.EDSL
+import Asterius.Types
+
+hashableCBits :: AsteriusModule
+hashableCBits = hashableFNVHash <> hashableFNVHashOffset
+
+hashableFNVHash, hashableFNVHashOffset :: AsteriusModule
+hashableFNVHash = runEDSL "hashable_fnv_hash" $ do
+  setReturnTypes [I64]
+  [str, len, salt] <- params [I64, I64, I64]
+  hash <- i64MutLocal
+  putLVal hash salt
+  i <- i64MutLocal
+  putLVal i $ constI64 0
+  whileLoop [] (getLVal i `ltUInt64` len) $ do
+    putLVal hash $
+      ( getLVal hash
+          `xorInt64` extendUInt32 (loadI8 (str `addInt64` getLVal i) 0)
+      )
+        `mulInt64` constI64 16777619
+    putLVal i $ getLVal i `addInt64` constI64 1
+  emit $ getLVal hash
+hashableFNVHashOffset = runEDSL "hashable_fnv_hash_offset" $ do
+  setReturnTypes [I64]
+  [str, offset', len, salt] <- params [I64, I64, I64, I64]
+  call' "hashable_fnv_hash" [str `addInt64` offset', len, salt] I64 >>= emit

--- a/asterius/src/Asterius/EDSL.hs
+++ b/asterius/src/Asterius/EDSL.hs
@@ -78,6 +78,7 @@ module Asterius.EDSL
     geUInt64,
     shlInt64,
     shrUInt64,
+    xorInt64,
     geUInt32,
     addInt32,
     subInt32,
@@ -527,6 +528,7 @@ addInt64,
   geUInt64,
   shlInt64,
   shrUInt64,
+  xorInt64,
   geUInt32,
   addInt32,
   subInt32,
@@ -552,6 +554,7 @@ gtUInt64 = Binary GtUInt64
 geUInt64 = Binary GeUInt64
 shlInt64 = Binary ShlInt64
 shrUInt64 = Binary ShrUInt64
+xorInt64 = Binary XorInt64
 geUInt32 = Binary GeUInt32
 addInt32 = Binary AddInt32
 subInt32 = Binary SubInt32


### PR DESCRIPTION
Related: #358 #146 

We already have 128-bit FNV-1a algorithm implemented in `rts.md5.mjs` as pseudo-MD5 to be used by `GHC.Fingerprint` logic. This PR factors out the hashing logic, and implements interface for both `GHC.Fingerprint` logic and `hashable` logic. `hashable` uses 64-bit hashing, so the resulting 128-bit result shall be truncated before returning.

Side note: maybe we should also use `arithmoi` to write a script for a principled way of generating magic numbers for FNV hashing.