### PR TITLE
Turn off package environment files in `ahc-cabal`

### DIFF
--- a/asterius/app/ahc-cabal.hs
+++ b/asterius/app/ahc-cabal.hs
@@ -64,6 +64,8 @@ main = do
         "-a",
         "library-stripping: False",
         "-a",
+        "package-env: -",
+        "-a",
         "profiling: False",
         "-a",
         "relocatable: False",

--- a/asterius/app/ahc-pkg.hs
+++ b/asterius/app/ahc-pkg.hs
@@ -1,17 +1,19 @@
 import qualified Asterius.BuildInfo as A
+import Data.Foldable
+import Data.List
 import System.Environment.Blank
 import System.FilePath
-import System.Process
+import System.Process (callProcess)
 
 main :: IO ()
 main = do
+  env <- getEnvironment
+  traverse_ unsetEnv
+    $ filter (\k -> ("GHC_" `isPrefixOf` k) || "HASKELL_" `isPrefixOf` k)
+    $ map fst env
   args <- getArgs
-  callProcess A.ghcPkg $ do
-    arg <- args
-    if arg == "--global"
-      then
-        [ "--global",
-          "--global-package-db="
-            <> (A.dataDir </> ".boot" </> "asterius_lib" </> "package.conf.d")
-        ]
-      else pure arg
+  callProcess A.ghcPkg $
+    ( "--global-package-db="
+        <> (A.dataDir </> ".boot" </> "asterius_lib" </> "package.conf.d")
+    )
+      : args


### PR DESCRIPTION
This PR is a result of much frustration brought by "package environment files" which polluted @hsyl20's local environment and prevented `ahc-boot` to properly run. Following instruction in https://gitlab.haskell.org/ghc/ghc/issues/13753, we instruct `ahc-cabal` to set `package-env: -` to disable them. Also, `ahc-pkg` now implements the same hack of `ahc-cabal` and `ahc` to prevent pollution of `GHC*` & `HASKELL*` related env vars, so it should work fine when directly invoked with `stack exec`.