### PR TITLE
Quick fix of `decodeUtf8With` for lazy `Text`

### DIFF
--- a/asterius/boot.sh
+++ b/asterius/boot.sh
@@ -139,7 +139,7 @@ $ASTERIUS_TMP_DIR/Setup-simple install --builddir=$ASTERIUS_TMP_DIR/dist/ghci $A
 cd ..
 
 cd text
-$ASTERIUS_TMP_DIR/Setup-simple configure --prefix=$ASTERIUS_LIB_DIR --package-db=clear --package-db=global --builddir=$ASTERIUS_TMP_DIR/dist/text --with-ghc=$ASTERIUS_AHC --with-ghc-pkg=$ASTERIUS_AHCPKG $ASTERIUS_CONFIGURE_OPTIONS
+$ASTERIUS_TMP_DIR/Setup-simple configure --prefix=$ASTERIUS_LIB_DIR --package-db=clear --package-db=global --builddir=$ASTERIUS_TMP_DIR/dist/text --with-ghc=$ASTERIUS_AHC --with-ghc-pkg=$ASTERIUS_AHCPKG --ghc-option=-DASTERIUS $ASTERIUS_CONFIGURE_OPTIONS
 $ASTERIUS_TMP_DIR/Setup-simple build --builddir=$ASTERIUS_TMP_DIR/dist/text $ASTERIUS_BUILD_OPTIONS
 $ASTERIUS_TMP_DIR/Setup-simple install --builddir=$ASTERIUS_TMP_DIR/dist/text $ASTERIUS_INSTALL_OPTIONS
 cd ..

--- a/ghc-toolkit/boot-libs/text/Data/Text/Lazy/Encoding.hs
+++ b/ghc-toolkit/boot-libs/text/Data/Text/Lazy/Encoding.hs
@@ -93,6 +93,9 @@ decodeLatin1 = foldr (chunk . TE.decodeLatin1) empty . B.toChunks
 
 -- | Decode a 'ByteString' containing UTF-8 encoded text.
 decodeUtf8With :: OnDecodeError -> B.ByteString -> Text
+#if defined(ASTERIUS)
+decodeUtf8With onErr lbs = Chunk (TE.decodeUtf8With onErr (B.toStrict lbs)) Empty
+#else
 decodeUtf8With onErr (B.Chunk b0 bs0) =
     case TE.streamDecodeUtf8With onErr b0 of
       TE.Some t l f -> chunk t (go f l bs0)
@@ -107,6 +110,7 @@ decodeUtf8With onErr (B.Chunk b0 bs0) =
                       Just c  -> Chunk (T.singleton c) Empty
     desc = "Data.Text.Lazy.Encoding.decodeUtf8With: Invalid UTF-8 stream"
 decodeUtf8With _ _ = empty
+#endif
 
 -- | Decode a 'ByteString' containing UTF-8 encoded text that is known
 -- to be valid.


### PR DESCRIPTION
`decodeUtf8With` for lazy `Text` uses a streaming UTF-8 parser in cbits which is too troublesome to port right now. So we implement a not so efficient workaround here: we patch `text` and call the already working `decodeUtf8` function for strict `Text`, then convert it back. This shall close #357 and unblock #315.

In the longer run, since patching `text` is unavoidable, we shall simply get rid of `ccall` interfaces for `text` parsers, and introduce stateful parsing with `TextDecoder`; combined with bisection on input buffer, it should also be possible to stop at first illegal codepoint and enable proper error handling on the haskell side.