### PR TITLE
Fix CI on the `master` branch

### DIFF
--- a/asterius/test/nomain.hs
+++ b/asterius/test/nomain.hs
@@ -17,8 +17,7 @@ main = do
       "--output-ir",
       "--full-sym-table",
       "--ghc-option=-no-hs-main",
-      "--extra-root-symbol=NoMain_x_closure",
-      "--no-gc-sections"
+      "--extra-root-symbol=NoMain_x_closure"
     ]
       <> args
   m <- decodeFile "test/nomain/NoMain.unlinked.bin"

--- a/lts.sh
+++ b/lts.sh
@@ -42,13 +42,10 @@ ahc-cabal v1-install -j --keep-going --minimize-conflict-set --prefix=$ASTERIUS_
   genvalidity-time \
   genvalidity-uuid \
   graphite \
-  gravatar \
   groundhog-th \
   haddock-library \
-  HandsomeSoup \
   HaTeX \
   haxl \
-  http-client-tls \
   hxt-css \
   hxt-tagsoup \
   integration \


### PR DESCRIPTION
Changeset:

* We used to have `--no-gc-sections` for the `nomain` test, so to stress test the linker & runtime by collecting everything into the resulting wasm. Since #348 the global pkgdb has grown quite a bit so `--no-gc-sections` would generate wasm files which are too large to be loaded. Maybe we should remove this flag but that belongs to a future PR.
* We chop off some more packages in the docker image build script to further reduce timeout possibility.