### PR TITLE
Enhance runtime performance

### DIFF
--- a/asterius/rts/rts.constants.mjs
+++ b/asterius/rts/rts.constants.mjs
@@ -1,6 +1,7 @@
 export const dataTag = 0x1ffff7;
 export const functionTag = 0x1fffed;
 export const mblock_size = 0x100000;
+export const mblock_size_log2 = 0x14;
 export const block_size = 0x1000;
 export const blocks_per_mblock = 0xfc;
 export const offset_timespec_tv_sec = 0x0;

--- a/asterius/rts/rts.gc.mjs
+++ b/asterius/rts/rts.gc.mjs
@@ -6,8 +6,8 @@ import { stg_arg_bitmaps } from "./rts.autoapply.mjs";
 
 function bdescr(c) {
   return Number(
-    ((BigInt(c) >> BigInt(Math.log2(rtsConstants.mblock_size))) <<
-      BigInt(Math.log2(rtsConstants.mblock_size))) |
+    ((BigInt(c) >> BigInt(rtsConstants.mblock_size_log2)) <<
+      BigInt(rtsConstants.mblock_size_log2)) |
       BigInt(rtsConstants.offset_first_bdescr)
   );
 }

--- a/asterius/rts/rts.memory.mjs
+++ b/asterius/rts/rts.memory.mjs
@@ -29,7 +29,7 @@ export class Memory {
   }
 
   static unTag(p) {
-    return Number(BigInt(p) & BigInt(0xffffffff));
+    return Number(p) & 0xffffffff;
   }
 
   static getTag(p) {
@@ -49,7 +49,7 @@ export class Memory {
   }
 
   static getDynTag(p) {
-    return Number(BigInt(p) & BigInt(7));
+    return Number(p) & 7;
   }
 
   static setDynTag(p, t) {
@@ -171,7 +171,7 @@ export class Memory {
   heapAlloced(p) {
     return (
       Memory.unTag(p) >=
-      this.staticMBlocks << Math.log2(rtsConstants.mblock_size)
+      this.staticMBlocks << rtsConstants.mblock_size_log2
     );
   }
 
@@ -194,7 +194,7 @@ export class Memory {
 
   freeMBlocks(p, n) {
     const mblock_no =
-      BigInt(Memory.unTag(p)) >> BigInt(Math.log2(rtsConstants.mblock_size));
+      BigInt(Memory.unTag(p)) >> BigInt(rtsConstants.mblock_size_log2);
     this.liveBitset &= ~(mask(n) << mblock_no);
   }
 

--- a/asterius/rts/rts.memorytrap.mjs
+++ b/asterius/rts/rts.memorytrap.mjs
@@ -17,7 +17,7 @@ export class MemoryTrap {
   trap(sym, p) {
     const tag = Memory.getTag(p),
       untagged = BigInt(Memory.unTag(p)),
-      mblock_no = untagged >> BigInt(Math.log2(rtsConstants.mblock_size)),
+      mblock_no = untagged >> BigInt(rtsConstants.mblock_size_log2),
       mblock_live = Boolean((this.memory.liveBitset >> mblock_no) & BigInt(1));
     if (tag != rtsConstants.dataTag || !mblock_live) {
       const err = new WebAssembly.RuntimeError(

--- a/asterius/src/Asterius/JSGen/Constants.hs
+++ b/asterius/src/Asterius/JSGen/Constants.hs
@@ -9,6 +9,7 @@ import Asterius.Internals.ByteString
 import Asterius.Internals.MagicNumber
 import Data.ByteString.Builder
 import Language.Haskell.GHC.Toolkit.Constants
+import Data.Bits
 
 rtsConstants :: Builder
 rtsConstants =
@@ -19,6 +20,8 @@ rtsConstants =
       intHex functionTag,
       ";\nexport const mblock_size = ",
       intHex mblock_size,
+      ";\nexport const mblock_size_log2 = ",
+      intHex (countTrailingZeros mblock_size),
       ";\nexport const block_size = ",
       intHex block_size,
       ";\nexport const blocks_per_mblock = ",


### PR DESCRIPTION
Diagrams example showed that pointer manipulation in JS rts takes a lot of time. This MR makes `unTag`, `getDynTag` and `bdescr` faster.