### PR TITLE
Implement "--nursery-size" option for ahc-link & ahc-dist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ jobs:
             stack --no-terminal test asterius:sizeof_md5context
             stack --no-terminal test asterius:largenum
             stack --no-terminal test asterius:bytearray --test-arguments="--yolo"
+            stack --no-terminal test asterius:bytearray --test-arguments="--nursery-size=128"
             stack --no-terminal test asterius:fib --test-arguments="--no-gc-sections"
             stack --no-terminal test asterius:fib --test-arguments="--binaryen --no-gc-sections"
 

--- a/asterius/rts/rts.gc.mjs
+++ b/asterius/rts/rts.gc.mjs
@@ -20,7 +20,8 @@ export class GC {
     export_stableptrs,
     symbol_table,
     reentrancy_guard,
-    yolo
+    yolo,
+    nursery_size
   ) {
     this.memory = memory;
     this.heapAlloc = heapalloc;
@@ -32,6 +33,7 @@ export class GC {
     this.symbolTable = symbol_table;
     this.reentrancyGuard = reentrancy_guard;
     this.yolo = yolo;
+    this.nurserySize = nursery_size;
     this.closureIndirects = new Map();
     this.liveMBlocks = new Set();
     this.deadMBlocks = new Set();
@@ -667,8 +669,13 @@ export class GC {
   updateNursery() {
     const base_reg =
         this.symbolTable.MainCapability + rtsConstants.offset_Capability_r,
-      hp_alloc = Number(
-        this.memory.i64Load(base_reg + rtsConstants.offset_StgRegTable_rHpAlloc)
+      hp_alloc = Math.max(
+        Number(
+          this.memory.i64Load(
+            base_reg + rtsConstants.offset_StgRegTable_rHpAlloc
+          )
+        ),
+        this.nurserySize * rtsConstants.mblock_size
       );
     this.memory.i64Store(
       base_reg + rtsConstants.offset_StgRegTable_rHpAlloc,

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -87,7 +87,8 @@ export async function newAsteriusInstance(req) {
       req.exportStablePtrs,
       req.symbolTable,
       __asterius_reentrancy_guard,
-      req.yolo
+      req.yolo,
+      req.nurserySize
     ),
     __asterius_exception_helper = new ExceptionHelper(
       __asterius_memory,

--- a/asterius/src/Asterius/JSRun/NonMain.hs
+++ b/asterius/src/Asterius/JSRun/NonMain.hs
@@ -70,7 +70,8 @@ distNonMain p extra_syms = ahcDistMain
       yolo = False,
       extraGHCFlags = ["-no-hs-main"],
       Asterius.Main.exportFunctions = [],
-      extraRootSymbols = extra_syms
+      extraRootSymbols = extra_syms,
+      nurserySize = 64
     }
 
 newAsteriusInstanceNonMain ::

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -67,7 +67,8 @@ data Task
         outputBaseName :: String,
         tailCalls, gcSections, fullSymTable, bundle, binaryen, debug, outputLinkReport, outputIR, run, verboseErr, yolo :: Bool,
         extraGHCFlags :: [String],
-        exportFunctions, extraRootSymbols :: [AsteriusEntitySymbol]
+        exportFunctions, extraRootSymbols :: [AsteriusEntitySymbol],
+        nurserySize :: Int
       }
   deriving (Show)
 
@@ -121,7 +122,8 @@ parseTask args = case err_msgs of
           str_opt "export-function" $
             \s t -> t {exportFunctions = fromString s : exportFunctions t},
           str_opt "extra-root-symbol" $
-            \s t -> t {extraRootSymbols = fromString s : extraRootSymbols t}
+            \s t -> t {extraRootSymbols = fromString s : extraRootSymbols t},
+          str_opt "nursery-size" $ \s t -> t {nurserySize = read s}
         ]
         args
     task =
@@ -148,7 +150,8 @@ parseTask args = case err_msgs of
             yolo = False,
             extraGHCFlags = [],
             exportFunctions = [],
-            extraRootSymbols = []
+            extraRootSymbols = [],
+            nurserySize = 64
           }
         task_trans_list
 
@@ -221,6 +224,8 @@ genReq Task {..} LinkReport {..} =
       intDec staticMBlocks,
       ", yolo: ",
       if yolo then "true" else "false",
+      ", nurserySize: ",
+      intHex nurserySize,
       "}",
       ";\n"
     ]


### PR DESCRIPTION
Implements a part of GC mitigations discussed in #374.

We now have a `--nursery-size=` option for `ahc-link` and `ahc-dist`. It specifies the number of mblocks (for now, 1 mblock == 1mb) to be allocated when `updateNursery()` is invoked after heap overflow. The previous behavior is 1 mblock in most cases, we now set the default number to 64, to reduce chances of heap overflow and gc invocation.

It's worth noting that the initial nursery allocated in `hs_init` is unaffected and is still 1 mblock, which means even if the specified nursery size is big enough, at least 1 gc invocation is still required. Correcting  the initial nursery size would require the option to be passed to `ahc-ld`, which doesn't play nicely with `ahc-cabal` users.