### PR TITLE
To collect sometimes, to allocate always

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ jobs:
             stack --no-terminal test asterius:sizeof_md5context
             stack --no-terminal test asterius:largenum
             stack --no-terminal test asterius:bytearray --test-arguments="--yolo"
+            stack --no-terminal test asterius:bytearray --test-arguments="--gc-threshold=128"
             stack --no-terminal test asterius:fib --test-arguments="--no-gc-sections"
             stack --no-terminal test asterius:fib --test-arguments="--binaryen --no-gc-sections"
 

--- a/asterius/rts/rts.gc.mjs
+++ b/asterius/rts/rts.gc.mjs
@@ -20,7 +20,8 @@ export class GC {
     export_stableptrs,
     symbol_table,
     reentrancy_guard,
-    yolo
+    yolo,
+    gc_threshold
   ) {
     this.memory = memory;
     this.heapAlloc = heapalloc;
@@ -32,6 +33,7 @@ export class GC {
     this.symbolTable = symbol_table;
     this.reentrancyGuard = reentrancy_guard;
     this.yolo = yolo;
+    this.gcThreshold = gc_threshold;
     this.closureIndirects = new Map();
     this.liveMBlocks = new Set();
     this.deadMBlocks = new Set();
@@ -684,7 +686,7 @@ export class GC {
    * Perform GC, using scheduler TSOs as roots
    */
   performGC() {
-    if (this.yolo) {
+    if (this.yolo || this.heapAlloc.liveSize() < this.gcThreshold) {
       this.updateNursery();
       return;
     }

--- a/asterius/rts/rts.heapalloc.mjs
+++ b/asterius/rts/rts.heapalloc.mjs
@@ -134,4 +134,12 @@ export class HeapAlloc {
       );
     }
   }
+
+  liveSize() {
+    let acc = 0;
+    for (const bd of this.mgroups) {
+      acc += this.memory.i16Load(bd + rtsConstants.offset_bdescr_node);
+    }
+    return acc;
+  }
 }

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -87,7 +87,8 @@ export async function newAsteriusInstance(req) {
       req.exportStablePtrs,
       req.symbolTable,
       __asterius_reentrancy_guard,
-      req.yolo
+      req.yolo,
+      req.gcThreshold
     ),
     __asterius_exception_helper = new ExceptionHelper(
       __asterius_memory,

--- a/asterius/src/Asterius/JSRun/NonMain.hs
+++ b/asterius/src/Asterius/JSRun/NonMain.hs
@@ -70,7 +70,8 @@ distNonMain p extra_syms = ahcDistMain
       yolo = False,
       extraGHCFlags = ["-no-hs-main"],
       Asterius.Main.exportFunctions = [],
-      extraRootSymbols = extra_syms
+      extraRootSymbols = extra_syms,
+      gcThreshold = 64
     }
 
 newAsteriusInstanceNonMain ::

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -67,7 +67,8 @@ data Task
         outputBaseName :: String,
         tailCalls, gcSections, fullSymTable, bundle, binaryen, debug, outputLinkReport, outputIR, run, verboseErr, yolo :: Bool,
         extraGHCFlags :: [String],
-        exportFunctions, extraRootSymbols :: [AsteriusEntitySymbol]
+        exportFunctions, extraRootSymbols :: [AsteriusEntitySymbol],
+        gcThreshold :: Int
       }
   deriving (Show)
 
@@ -121,7 +122,8 @@ parseTask args = case err_msgs of
           str_opt "export-function" $
             \s t -> t {exportFunctions = fromString s : exportFunctions t},
           str_opt "extra-root-symbol" $
-            \s t -> t {extraRootSymbols = fromString s : extraRootSymbols t}
+            \s t -> t {extraRootSymbols = fromString s : extraRootSymbols t},
+          str_opt "gc-threshold" $ \s t -> t {gcThreshold = read s}
         ]
         args
     task =
@@ -148,7 +150,8 @@ parseTask args = case err_msgs of
             yolo = False,
             extraGHCFlags = [],
             exportFunctions = [],
-            extraRootSymbols = []
+            extraRootSymbols = [],
+            gcThreshold = 64
           }
         task_trans_list
 
@@ -221,6 +224,8 @@ genReq Task {..} LinkReport {..} =
       intDec staticMBlocks,
       ", yolo: ",
       if yolo then "true" else "false",
+      ", gcThreshold: ",
+      intHex gcThreshold,
       "}",
       ";\n"
     ]


### PR DESCRIPTION
A rework of #378.

We now have a `--gc-threshold` option for `ahc-link` & `ahc-dist`. When a heap overflow occurs and `performGC` is entered, it queries the current state of `HeapAlloc` and calculates the total live mblock number. If it's below the "gc threshold" value (which defaults to 64), then it skips GC logic like the yolo mode. This should avoid a lot of GC invocations as shown in the flame graph in #374, working around our lack of generational collection.