### PR TITLE
Hack to support kmettverse packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
             apt install -y nodejs
             mkdir -p /root/.local/bin
             curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C /root/.local/bin '*/stack'
-            curl -L https://downloads.haskell.org/~cabal/cabal-install-latest/cabal-install-3.0.0.0-x86_64-unknown-linux.tar.xz | tar xJ -C /root/.local/bin 'cabal'
+            curl -L https://downloads.haskell.org/~cabal/cabal-install-2.4.1.0/cabal-install-2.4.1.0-x86_64-unknown-linux.tar.xz | tar xJ -C ~/.local/bin 'cabal'
       - checkout
 
       - run:
@@ -194,7 +194,7 @@ jobs:
           name: Test ahc-cabal
           command: |
             ahc-cabal new-update
-            ahc-cabal new-install --installdir . \
+            ahc-cabal new-install --symlink-bindir . \
               hello \
               lens
             ahc-dist --input-exe hello --run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
           name: Test ahc-cabal
           command: |
             ahc-cabal new-update
-            ahc-cabal new-install --symlink-bindir . \
+            ahc-cabal new-install -j1 --symlink-bindir . \
               hello \
               lens
             ahc-dist --input-exe hello --run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,9 @@ jobs:
           name: Test ahc-cabal
           command: |
             ahc-cabal new-update
-            ahc-cabal new-install --installdir . hello
+            ahc-cabal new-install --installdir . \
+              hello \
+              lens
             ahc-dist --input-exe hello --run
 
   asterius-test-ghc-testsuite:

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN \
   apt install -y nodejs && \
   mkdir -p /root/.local/bin && \
   curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C /root/.local/bin '*/stack' && \
-  curl -L https://downloads.haskell.org/~cabal/cabal-install-latest/cabal-install-3.0.0.0-x86_64-unknown-linux.tar.xz | tar xJ -C /root/.local/bin 'cabal' && \
+  curl -L https://downloads.haskell.org/~cabal/cabal-install-2.4.1.0/cabal-install-2.4.1.0-x86_64-unknown-linux.tar.xz | tar xJ -C ~/.local/bin 'cabal' && \
   stack --no-terminal install asterius && \
   stack --no-terminal exec ahc-boot && \
   export ASTERIUS_LIB_DIR=$(stack path --local-install-root)/share/x86_64-linux-ghc-8.6.5/asterius-0.0.1/.boot/asterius_lib && \

--- a/asterius/app/ahc-cabal.hs
+++ b/asterius/app/ahc-cabal.hs
@@ -64,8 +64,6 @@ main = do
         "-a",
         "library-stripping: False",
         "-a",
-        "package-env: -",
-        "-a",
         "profiling: False",
         "-a",
         "relocatable: False",


### PR DESCRIPTION
This PR doubles the dose of hack introduced in #344. When we attempt to compile the custom `Setup.hs` script with the host ghc, it may fail (e.g. lacking certain `custom-deps`), in which case we resort to compiling & using a `Setup.hs` that implements `build-type: Simple` behavior.

This hack is even grosser, but it fixes the building of the kmettverse packages (up to `lens` at least). Because kmettverse packages has a constant pattern of using `Setup.hs` with `cabal-doctest` for doctests, and since we aren't running tests anyway, the packages build fine with the default `build-type: Simple` script.