### PR TITLE
Bump various deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   asterius-boot:
     docker:
-      - image: debian:unstable
+      - image: debian:sid
     environment:
       - ASTERIUS_BUILD_OPTIONS: -j2
       - DEBIAN_FRONTEND: noninteractive
@@ -22,9 +22,9 @@ jobs:
               cmake \
               curl \
               g++ \
+              gawk \
               git \
               gnupg \
-              libdw-dev \
               libffi-dev \
               libgmp-dev \
               libncurses-dev \
@@ -68,7 +68,7 @@ jobs:
 
   asterius-test:
     docker:
-      - image: debian:unstable
+      - image: debian:sid
     environment:
       - DEBIAN_FRONTEND: noninteractive
       - GHCRTS: -N2
@@ -85,9 +85,9 @@ jobs:
               cmake \
               curl \
               g++ \
+              gawk \
               git \
               gnupg \
-              libdw-dev \
               libffi-dev \
               libgmp-dev \
               libncurses-dev \
@@ -150,7 +150,7 @@ jobs:
 
   asterius-test-cabal:
     docker:
-      - image: debian:unstable
+      - image: debian:sid
     environment:
       - DEBIAN_FRONTEND: noninteractive
       - LANG: C.UTF-8
@@ -166,9 +166,9 @@ jobs:
               cmake \
               curl \
               g++ \
+              gawk \
               git \
               gnupg \
-              libdw-dev \
               libffi-dev \
               libgmp-dev \
               libncurses-dev \
@@ -199,7 +199,7 @@ jobs:
 
   asterius-test-ghc-testsuite:
     docker:
-      - image: debian:unstable
+      - image: debian:sid
     environment:
       - DEBIAN_FRONTEND: noninteractive
       - GHCRTS: -N2
@@ -217,9 +217,9 @@ jobs:
               cmake \
               curl \
               g++ \
+              gawk \
               git \
               gnupg \
-              libdw-dev \
               libffi-dev \
               libgmp-dev \
               libncurses-dev \
@@ -263,7 +263,7 @@ jobs:
 
   asterius-test-ghc-testsuite-yolo:
     docker:
-      - image: debian:unstable
+      - image: debian:sid
     environment:
       - ASTERIUS_GHC_TESTSUITE_OPTIONS: --yolo
       - DEBIAN_FRONTEND: noninteractive
@@ -282,9 +282,9 @@ jobs:
               cmake \
               curl \
               g++ \
+              gawk \
               git \
               gnupg \
-              libdw-dev \
               libffi-dev \
               libgmp-dev \
               libncurses-dev \
@@ -328,7 +328,7 @@ jobs:
 
   asterius-test-ghc-testsuite-debug:
     docker:
-      - image: debian:unstable
+      - image: debian:sid
     environment:
       - ASTERIUS_GHC_TESTSUITE_OPTIONS: --debug
       - DEBIAN_FRONTEND: noninteractive
@@ -347,9 +347,9 @@ jobs:
               cmake \
               curl \
               g++ \
+              gawk \
               git \
               gnupg \
-              libdw-dev \
               libffi-dev \
               libgmp-dev \
               libncurses-dev \
@@ -393,7 +393,7 @@ jobs:
 
   asterius-test-ghc-testsuite-debug-yolo:
     docker:
-      - image: debian:unstable
+      - image: debian:sid
     environment:
       - ASTERIUS_GHC_TESTSUITE_OPTIONS: --debug --yolo
       - DEBIAN_FRONTEND: noninteractive
@@ -412,9 +412,9 @@ jobs:
               cmake \
               curl \
               g++ \
+              gawk \
               git \
               gnupg \
-              libdw-dev \
               libffi-dev \
               libgmp-dev \
               libncurses-dev \
@@ -458,7 +458,7 @@ jobs:
 
   asterius-build-docs:
     docker:
-      - image: debian:unstable
+      - image: debian:sid
     environment:
       DEBIAN_FRONTEND: noninteractive
       LANG: C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:unstable
+FROM debian:sid
 
 COPY asterius /root/asterius/asterius
 COPY binaryen /root/asterius/binaryen
@@ -25,9 +25,9 @@ RUN \
     cmake \
     curl \
     g++ \
+    gawk \
     gcc \
     gnupg \
-    libdw-dev \
     libffi-dev \
     libgmp-dev \
     libncurses-dev \
@@ -57,6 +57,7 @@ RUN \
     g++ \
     gnupg \
     make \
+    mawk \
     python3-minimal \
     xz-utils && \
   apt autoremove --purge -y && \

--- a/npm-utils/Setup.hs
+++ b/npm-utils/Setup.hs
@@ -19,6 +19,6 @@ main =
               npm_utils_datadir = datadir npm_utils_installdirs
           createDirectoryIfMissing True npm_utils_datadir
           withCurrentDirectory npm_utils_datadir $
-            callCommand "npm install parcel-bundler"
+            callCommand "npm install parcel-bundler@1.12.4"
           pure lbi
       }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.14
+resolver: lts-14.16
 packages:
   - asterius
   - binaryen
@@ -15,17 +15,17 @@ setup-info:
   ghc:
     linux64-custom-asterius-tinfo6:
       8.6.5:
-        url: https://6823-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.6.5-x86_64-unknown-linux.tar.xz
-        sha256: faa780dd143058b17ba4856708219440488ac0209b056ebfd2ff2c2134c34f82
+        url: https://8136-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.6.5-x86_64-unknown-linux.tar.xz
+        sha256: bb8bbb3dc0fce4fa5c0c141d2eda780df61d3ee1f0ad37ceb9ad4ec0ee701b2c
     linux64-custom-asterius:
       8.6.5:
-        url: https://6827-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.6.5-x86_64-unknown-linux.tar.xz
-        sha256: 69d4a536e61ea05d4cfa1c92d43a9a0af066fb5f500889bd9f42b370114fa3c5
+        url: https://8134-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.6.5-x86_64-unknown-linux.tar.xz
+        sha256: a91a7a481865a3a23af3b8eabd97d839427348cfbfbeb7f9f8e68af821c06614
     linux64-custom-asterius-musl:
       8.6.5:
-        url: https://6825-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.6.5-x86_64-alpine-linux.tar.xz
-        sha256: 5eb622b5209f6e5db4c87c35c32b52e77ccfcc49b7955f167d441028d53f9f94
+        url: https://8135-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.6.5-x86_64-alpine-linux.tar.xz
+        sha256: 2718f8a539188268a091d86676d400ec77b5b1fa925ea654187d50f0854082b2
     macosx-custom-asterius:
       8.6.5:
-        url: https://6826-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.6.5-x86_64-apple-darwin.tar.xz
-        sha256: 64246ab4e6435843c7f71a4ee00647823f2d898d9cb726f657645c7b0c7a7ad6
+        url: https://8137-111412813-gh.circle-artifacts.com/0/tmp/ghc-bindist/ghc-8.6.5-x86_64-apple-darwin.tar.xz
+        sha256: f7c5784fd81374565bd23014c503eeca7199f8eb388c2f95186eae75d22aca0a


### PR DESCRIPTION
Notable changes:

* The bindists are no longer configured with `--enable-dwarf-unwind`, since we don't use them for the host libraries. The runtime environment doesn't require `libdw` anymore.
* The macos bindist is built with xcode 11.2.1 and macos catalina. `coreutils` from `brew` is removed from `$PATH` when building, maybe this will help with fixing darwin support.
* `inline-js` is bumped to contain upstream improvements.
* The stackage snapshot version is bumped to `lts-14.16`.
* We now fix the `parcel-bundler` version when installing `npm-utils`.

We're leaving out `binaryen` and `wabt` in this bump. They'll be updated when appropriate.