### PR TITLE
Add the unlit executable

### DIFF
--- a/asterius/app/fs.c
+++ b/asterius/app/fs.c
@@ -1,0 +1,291 @@
+/* -----------------------------------------------------------------------------
+ *
+ * (c) Tamar Christina 2018
+ *
+ * Windows I/O routines for file opening.
+ *
+ * NOTE: Only modify this file in utils/fs/ and rerun configure. Do not edit
+ *       this file in any other directory as it will be overwritten.
+ *
+ * ---------------------------------------------------------------------------*/
+#include "fs.h"
+#include <stdio.h>
+
+#if defined(_WIN32)
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include <windows.h>
+#include <io.h>
+#include <fcntl.h>
+#include <wchar.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <share.h>
+
+/* This function converts Windows paths between namespaces. More specifically
+   It converts an explorer style path into a NT or Win32 namespace.
+   This has several caveats but they are caviats that are native to Windows and
+   not POSIX. See
+   https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247.aspx.
+   Anything else such as raw device paths we leave untouched.  The main benefit
+   of doing any of this is that we can break the MAX_PATH restriction and also
+   access raw handles that we couldn't before.  */
+static wchar_t* __hs_create_device_name (const wchar_t* filename) {
+  const wchar_t* win32_dev_namespace  = L"\\\\.\\";
+  const wchar_t* win32_file_namespace = L"\\\\?\\";
+  const wchar_t* nt_device_namespace  = L"\\Device\\";
+  const wchar_t* unc_prefix           = L"UNC\\";
+  const wchar_t* network_share        = L"\\\\";
+
+  wchar_t* result = _wcsdup (filename);
+  wchar_t ns[10] = {0};
+
+  /* If the file is already in a native namespace don't change it.  */
+  if (   wcsncmp (win32_dev_namespace , filename, 4) == 0
+      || wcsncmp (win32_file_namespace, filename, 4) == 0
+      || wcsncmp (nt_device_namespace , filename, 8) == 0)
+    return result;
+
+  /* Since we're using the lower level APIs we must normalize slashes now.  The
+     Win32 API layer will no longer convert '/' into '\\' for us.  */
+  for (size_t i = 0; i < wcslen (result); i++)
+    {
+      if (result[i] == L'/')
+        result[i] = L'\\';
+    }
+
+  /* Now resolve any . and .. in the path or subsequent API calls may fail since
+     Win32 will no longer resolve them.  */
+  DWORD nResult = GetFullPathNameW (result, 0, NULL, NULL) + 1;
+  wchar_t *temp = _wcsdup (result);
+  result = malloc (nResult * sizeof (wchar_t));
+  if (GetFullPathNameW (temp, nResult, result, NULL) == 0)
+    {
+      goto cleanup;
+    }
+
+  free (temp);
+
+  if (wcsncmp (network_share, result, 2) == 0)
+    {
+      if (swprintf (ns, 10, L"%ls%ls", win32_file_namespace, unc_prefix) <= 0)
+        {
+          goto cleanup;
+        }
+    }
+  else if (swprintf (ns, 10, L"%ls", win32_file_namespace) <= 0)
+    {
+      goto cleanup;
+    }
+
+  /* Create new string.  */
+  int bLen = wcslen (result) + wcslen (ns) + 1;
+  temp = _wcsdup (result);
+  result = malloc (bLen * sizeof (wchar_t));
+  if (swprintf (result, bLen, L"%ls%ls", ns, temp) <= 0)
+    {
+      goto cleanup;
+    }
+
+  free (temp);
+
+  return result;
+
+cleanup:
+  free (temp);
+  free (result);
+  return NULL;
+}
+
+#define HAS_FLAG(a,b) ((a & b) == b)
+
+int FS(swopen) (const wchar_t* filename, int oflag, int shflag, int pmode)
+{
+  /* Construct access mode.  */
+  DWORD dwDesiredAccess = 0;
+  if (HAS_FLAG (oflag, _O_RDONLY))
+    dwDesiredAccess |= GENERIC_READ | FILE_READ_DATA | FILE_READ_ATTRIBUTES;
+  if (HAS_FLAG (oflag, _O_RDWR))
+    dwDesiredAccess |= GENERIC_WRITE | GENERIC_READ | FILE_READ_DATA |
+                       FILE_WRITE_DATA | FILE_READ_ATTRIBUTES |
+                       FILE_WRITE_ATTRIBUTES;
+  if (HAS_FLAG (oflag,  _O_WRONLY))
+    dwDesiredAccess|= GENERIC_WRITE | FILE_WRITE_DATA | FILE_WRITE_ATTRIBUTES;
+
+  /* Construct shared mode.  */
+  DWORD dwShareMode = FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE;
+  if (HAS_FLAG (shflag, _SH_DENYRW))
+    dwShareMode &= ~(FILE_SHARE_READ | FILE_SHARE_WRITE);
+  if (HAS_FLAG (shflag, _SH_DENYWR))
+    dwShareMode &= ~FILE_SHARE_WRITE;
+  if (HAS_FLAG (shflag, _SH_DENYRD))
+    dwShareMode &= ~FILE_SHARE_READ;
+  if (HAS_FLAG (pmode, _S_IWRITE))
+    dwShareMode |= FILE_SHARE_READ | FILE_SHARE_WRITE;
+  if (HAS_FLAG (pmode, _S_IREAD))
+    dwShareMode |= FILE_SHARE_READ;
+
+  /* Override access mode with pmode if creating file.  */
+  if (HAS_FLAG (oflag, _O_CREAT))
+    {
+      if (HAS_FLAG (pmode, _S_IWRITE))
+        dwDesiredAccess |= FILE_GENERIC_WRITE;
+      if (HAS_FLAG (pmode, _S_IREAD))
+        dwDesiredAccess |= FILE_GENERIC_READ;
+    }
+
+  /* Create file disposition.  */
+  DWORD dwCreationDisposition = OPEN_EXISTING;
+  if (HAS_FLAG (oflag, _O_CREAT))
+    dwCreationDisposition = OPEN_ALWAYS;
+  if (HAS_FLAG (oflag, (_O_CREAT | _O_EXCL)))
+    dwCreationDisposition = CREATE_NEW;
+  if (HAS_FLAG (oflag, _O_TRUNC) && !HAS_FLAG (oflag, _O_CREAT))
+    dwCreationDisposition = TRUNCATE_EXISTING;
+
+  /* Set file access attributes.  */
+  DWORD dwFlagsAndAttributes = FILE_ATTRIBUTE_NORMAL;
+  if (HAS_FLAG (oflag, _O_RDONLY))
+    dwFlagsAndAttributes |= 0; /* No special attribute.  */
+  if (HAS_FLAG (oflag, (_O_CREAT | _O_TEMPORARY)))
+    dwFlagsAndAttributes |= FILE_FLAG_DELETE_ON_CLOSE;
+  if (HAS_FLAG (oflag, (_O_CREAT | _O_SHORT_LIVED)))
+    dwFlagsAndAttributes |= FILE_ATTRIBUTE_TEMPORARY;
+  if (HAS_FLAG (oflag, _O_RANDOM))
+    dwFlagsAndAttributes |= FILE_FLAG_RANDOM_ACCESS;
+  if (HAS_FLAG (oflag, _O_SEQUENTIAL))
+    dwFlagsAndAttributes |= FILE_FLAG_SEQUENTIAL_SCAN;
+  /* Flag is only valid on it's own.  */
+  if (dwFlagsAndAttributes != FILE_ATTRIBUTE_NORMAL)
+    dwFlagsAndAttributes &= ~FILE_ATTRIBUTE_NORMAL;
+
+  /* Set security attributes.  */
+  SECURITY_ATTRIBUTES securityAttributes;
+  ZeroMemory (&securityAttributes, sizeof(SECURITY_ATTRIBUTES));
+  securityAttributes.bInheritHandle       = !(oflag & _O_NOINHERIT);
+  securityAttributes.lpSecurityDescriptor = NULL;
+  securityAttributes.nLength              = sizeof(SECURITY_ATTRIBUTES);
+
+  wchar_t* _filename = __hs_create_device_name (filename);
+  if (!_filename)
+    return -1;
+
+  HANDLE hResult
+    = CreateFileW (_filename, dwDesiredAccess, dwShareMode, &securityAttributes,
+                   dwCreationDisposition, dwFlagsAndAttributes, NULL);
+  free (_filename);
+  if (INVALID_HANDLE_VALUE == hResult)
+    return -1;
+
+  /* Now we have a Windows handle, we have to convert it to an FD and apply
+     the remaining flags.  */
+  const int flag_mask = _O_APPEND | _O_RDONLY | _O_TEXT | _O_WTEXT;
+  int fd = _open_osfhandle ((intptr_t)hResult, oflag & flag_mask);
+  if (-1 == fd)
+    return -1;
+
+  /* Finally we can change the mode to the requested one.  */
+  const int mode_mask = _O_TEXT | _O_BINARY | _O_U16TEXT | _O_U8TEXT | _O_WTEXT;
+  if ((oflag & mode_mask) && (-1 == _setmode (fd, oflag & mode_mask)))
+    return -1;
+
+  return fd;
+}
+
+FILE *FS(fwopen) (const wchar_t* filename, const wchar_t* mode)
+{
+  int shflag = 0;
+  int pmode  = 0;
+  int oflag  = 0;
+
+  int len = wcslen (mode);
+  int i;
+  #define IS_EXT(X) ((i < (len - 1)) && mode[i] == X)
+
+  for (i = 0; i < len; i++)
+    {
+      switch (mode[i])
+        {
+          case L'a':
+            if (IS_EXT (L'+'))
+              oflag |= _O_RDWR | _O_CREAT | _O_APPEND;
+            else
+              oflag |= _O_WRONLY | _O_CREAT | _O_APPEND;
+            break;
+          case L'r':
+            if (IS_EXT (L'+'))
+              oflag |= _O_RDWR;
+            else
+              oflag |= _O_RDONLY;
+            break;
+          case L'w':
+            if (IS_EXT (L'+'))
+              oflag |= _O_RDWR | _O_CREAT | _O_TRUNC;
+            else
+              oflag |= _O_WRONLY | _O_CREAT | _O_TRUNC;
+            break;
+          case L'b':
+            oflag |= _O_BINARY;
+            break;
+          case L't':
+            oflag |= _O_TEXT;
+            break;
+          case L'c':
+          case L'n':
+            oflag |= 0;
+            break;
+          case L'S':
+            oflag |= _O_SEQUENTIAL;
+            break;
+          case L'R':
+            oflag |= _O_RANDOM;
+            break;
+          case L'T':
+            oflag |= _O_SHORT_LIVED;
+            break;
+          case L'D':
+            oflag |= _O_TEMPORARY;
+            break;
+          default:
+            if (wcsncmp (mode, L"ccs=UNICODE", 11) == 0)
+              oflag |= _O_WTEXT;
+            else if (wcsncmp (mode, L"ccs=UTF-8", 9) == 0)
+              oflag |= _O_U8TEXT;
+            else if (wcsncmp (mode, L"ccs=UTF-16LE", 12) == 0)
+              oflag |= _O_U16TEXT;
+            else continue;
+        }
+    }
+  #undef IS_EXT
+
+  int fd = FS(swopen) (filename, oflag, shflag, pmode);
+  FILE* file = _wfdopen (fd, mode);
+  return file;
+}
+
+FILE *FS(fopen) (const char* filename, const char* mode)
+{
+  size_t len = mbstowcs (NULL, filename, 0);
+  wchar_t *w_filename = malloc (sizeof (wchar_t) * (len + 1));
+  mbstowcs (w_filename, filename, len);
+  w_filename[len] = L'\0';
+
+  len = mbstowcs (NULL, mode, 0);
+  wchar_t *w_mode = malloc (sizeof (wchar_t) * (len + 1));
+  mbstowcs (w_mode, mode, len);
+  w_mode[len] = L'\0';
+
+  FILE *result = FS(fwopen) (w_filename, w_mode);
+  free (w_filename);
+  free (w_mode);
+  return result;
+}
+#else
+FILE *FS(fopen) (const char* filename, const char* mode)
+{
+  return fopen (filename, mode);
+}
+#endif

--- a/asterius/app/fs.h
+++ b/asterius/app/fs.h
@@ -1,0 +1,36 @@
+/* -----------------------------------------------------------------------------
+ *
+ * (c) Tamar Christina 2018
+ *
+ * Windows I/O routines for file opening.
+ *
+ * NOTE: Only modify this file in utils/fs/ and rerun configure. Do not edit
+ *       this file in any other directory as it will be overwritten.
+ *
+ * ---------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <stdio.h>
+
+#if !defined(FS_NAMESPACE)
+#define FS_NAMESPACE hs
+#endif
+
+/* Play some dirty tricks to get CPP to expand correctly.  */
+#define FS_FULL(ns, name) __##ns##_##name
+#define prefix FS_NAMESPACE
+#define FS_L(p, n) FS_FULL(p, n)
+#define FS(name) FS_L(prefix, name)
+
+#if defined(_WIN32)
+#include <wchar.h>
+
+int FS(swopen) (const wchar_t* filename, int oflag,
+                int shflag, int pmode);
+FILE *FS(fwopen) (const wchar_t* filename, const wchar_t* mode);
+FILE *FS(fopen) (const char* filename, const char* mode);
+#else
+
+FILE *FS(fopen) (const char* filename, const char* mode);
+#endif

--- a/asterius/app/unlit.c
+++ b/asterius/app/unlit.c
@@ -1,0 +1,402 @@
+/* unlit.c                                   Wed Dec  5 17:16:24 GMT 1990
+ *
+ * Literate script filter.  In contrast with the format used by most
+ * programming languages, a literate script is a program in which
+ * comments are given the leading role, whilst program text must be
+ * explicitly flagged as such by placing a `>' character in the first
+ * column on each line.  It is hoped that this style of programming will
+ * encourage the writing of accurate and clearly documented programs
+ * in which the writer may include motivating arguments, examples
+ * and explanations.
+ *
+ * Unlit is a filter that can be used to strip all of the comment lines
+ * out of a literate script file.  The command format for unlit is:
+ *              unlit [-n] [-q] ifile ofile
+ * where ifile and ofile are the names of the input (literate script) and
+ * output (raw program) files respectively.  Either of these names may
+ * be `-' representing the standard input or the standard output resp.
+ * A number of rules are used in an attempt to guard against the most
+ * common errors that are made when writing literate scripts:
+ * 1) Empty script files are not permitted.  A file in which no lines
+ *    begin with `>' usually indicates a file in which the programmer
+ *    has forgotten about the literate script convention.
+ * 2) A line containing part of program definition (i.e. preceeded by `>')
+ *    cannot be used immediately before or after a comment line unless
+ *    the comment line is blank.  This error usually indicates that
+ *    the `>' character has been omitted from a line in a section of
+ *    program spread over a number of lines.
+ * Using the -q (quiet) flag suppresses the signalling of these error
+ * conditions.  The default behaviour can be selected explicitly using
+ * the -n (noisy) option so that any potential errors in the script file
+ * are reported.
+ *
+ * The original idea for the use of literate scripts is due to Richard
+ * Bird of the programming Research Group, Oxford and was initially
+ * adopted for use in the implementation of the functional programming
+ * language Orwell used for teaching in Oxford.  This idea has subsequently
+ * been borrowed in a number of other language implementations.
+ *
+ * Modified to understand \begin{code} ... \end{code} used in Glasgow.  -- LA
+ * And \begin{pseudocode} ... \end{pseudocode}.  -- LA
+ */
+
+#include "fs.h"
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+
+#define NULLSTR        ((char *)0)
+#define DEFNCHAR       '>'
+#define MISSINGBLANK   "unlit: Program line next to comment"
+#define EMPTYSCRIPT    "unlit: No definitions in file (perhaps you forgot the '>'s?)"
+#define USAGE          "usage: unlit [-q] [-n] [-c] [-#] [-P] [-h label] file1 file2\n"
+#define CANNOTOPEN     "unlit: cannot open \"%s\"\n"
+#define CANNOTWRITE    "unlit: error writing \"%s\"\n"
+#define CANNOTWRITESTDOUT "unlit: error writing standard output\n"
+#define DISTINCTNAMES  "unlit: input and output filenames must differ\n"
+#define MISSINGENDCODE "unlit: missing \\end{code}\n"
+#define SPURIOUSENDCODE "unlit: spurious \\end{code}\n"
+
+#define BEGINCODE "\\begin{code}"
+#define LENBEGINCODE 12
+#define ENDCODE "\\end{code}"
+#define LENENDCODE 10
+#if defined(PSEUDOCODE)
+/* According to Will Partain, the inventor of pseudocode, this gone now. */
+#define MISSINGENDPSEUDOCODE "unlit: missing \\end{pseudocode}\n"
+#define BEGINPSEUDOCODE "\\begin{pseudocode}"
+#define LENBEGINPSEUDOCODE 18
+#define ENDPSEUDOCODE "\\end{pseudocode}"
+#define LENENDPSEUDOCODE 16
+#endif
+
+typedef enum { START, BLANK, TEXT, DEFN, BEGIN, END, /*PSEUDO,*/ ENDFILE, HASH, SHEBANG } line;
+#define isWhitespace(c)  (c==' '  || c=='\t' || c=='\r')
+#define isLineTerm(c)    (c=='\n' || c==EOF)
+
+static int noisy  = 1;   /* 0 => keep quiet about errors, 1 => report errors */
+static int errors = 0;   /* count the number of errors reported              */
+static int crunchnl = 0; /* don't print \n for removed lines                 */
+static int leavecpp = 1; /* leave preprocessor lines */
+static int ignore_shebang = 1; /* Leave out shebang (#!) lines */
+static int no_line_pragma = 0; /* Leave out initial line pragma */
+
+static char* prefix_str = NULL; /* Prefix output with a string */
+
+static char *ofilename = NULL;
+
+/* complain(file,line,what)
+ *
+ * print error message `what' for `file' at `line'.  The error is suppressed
+ * if noisy is not set.
+ */
+
+static void complain(char *file, int lin, char *what)
+{
+    if (noisy) {
+        if (file)
+            fprintf(stderr, "%s ", file);
+        fprintf(stderr,"line %d: %s\n",lin,what);
+        errors++;
+    }
+}
+
+static void writeerror(void)
+{
+    if (!strcmp(ofilename,"-")) {
+	fprintf(stderr, CANNOTWRITESTDOUT);
+    } else {
+	fprintf(stderr, CANNOTWRITE, ofilename);
+    }
+    exit(1);
+}
+
+static void myputc(char c, FILE *ostream)
+{
+    if (putc(c,ostream) == EOF) {
+	writeerror();
+    }
+}
+
+#define TABPOS 8
+
+/* As getc, but does TAB expansion */
+static int egetc(FILE *istream)
+{
+    static int spleft = 0;
+    static int linepos = 0;
+    int c;
+
+    if (spleft > 0) {
+	spleft--;
+	linepos++;
+	return ' ';
+    }
+    c = getc(istream);
+    if (c == EOF)
+	return c;
+    else if (c == '\n' || c == '\f') {
+	linepos = 0;
+	return c;
+    } else if (c == '\t') {
+	spleft = TABPOS - linepos % TABPOS;
+	spleft--;
+	linepos++;
+	return ' ';
+    } else {
+	linepos++;
+	return c;
+    }
+
+}
+
+/* readline(istream, ostream)
+ *
+ * Read a line from the input stream `istream', and return a value
+ * indicating whether that line was:
+ *     BLANK (whitespace only),
+ *     DEFN  (first character is DEFNCHAR),
+ *     TEXT  (a line of text)
+ *     BEGIN (a \begin{code} line)
+ *     PSEUDO (a \begin{pseodocode} line)
+ *     HASH  (a preprocessor line)
+ *     END   (a (spurious) \end{code} line)
+ * or  ENDFILE (indicating an EOF).
+ * Lines of type DEFN are copied to the output stream `ostream'
+ * (without the leading DEFNCHAR).  BLANK and TEXT lines are
+ * replaced by empty (i.e. blank lines) in the output stream, so
+ * that error messages refering to line numbers in the output file
+ * can also be used to locate the corresponding line in the input
+ * stream.
+ */
+
+static line readline(FILE *istream, FILE *ostream) {
+    int c, c1;
+    char buf[100];
+    int i;
+
+    c = egetc(istream);
+
+    if (c==EOF)
+        return ENDFILE;
+
+    if ( c == '#' ) {
+      if ( ignore_shebang ) {
+         c1 = egetc(istream);
+         if ( c1 == '!' ) {
+           while (c=egetc(istream), !isLineTerm(c)) ;
+           return SHEBANG;
+	 }
+	 myputc(c, ostream);
+	 c=c1;
+      }
+      if ( leavecpp ) {
+	myputc(c, ostream);
+        while (c=egetc(istream), !isLineTerm(c))
+            myputc(c,ostream);
+        myputc('\n',ostream);
+        return HASH;
+      }
+    }
+
+    if (c==DEFNCHAR) {
+	myputc(' ',ostream);
+        while (c=egetc(istream), !isLineTerm(c))
+            myputc(c,ostream);
+        myputc('\n',ostream);
+        return DEFN;
+    }
+
+    if (!crunchnl)
+	myputc('\n',ostream);
+
+    while (isWhitespace(c))
+        c=egetc(istream);
+    if (isLineTerm(c))
+        return BLANK;
+
+    i = 0;
+    buf[i++] = c;
+    while (c=egetc(istream), !isLineTerm(c))
+        if (i < sizeof buf - 1)
+	    buf[i++] = c;
+    while(i > 0 && isspace(buf[i-1]))
+	i--;
+    buf[i] = 0;
+    if (strcmp(buf, BEGINCODE) == 0)
+	return BEGIN;
+    if (strcmp(buf, ENDCODE) == 0)
+	return END;
+#if defined(PSEUDOCODE)
+    else if (strcmp(buf, BEGINPSEUDOCODE) == 0)
+	return PSEUDO;
+#endif
+    else
+	return TEXT;
+}
+
+
+/* unlit(file,istream,ostream)
+ *
+ * Copy the file named `file', accessed using the input stream `istream'
+ * to the output stream `ostream', removing any comments and checking
+ * for bad use of literate script features:
+ *  - there should be at least one BLANK line between a DEFN and TEXT
+ *  - there should be at least one DEFN line in a script.
+ */
+
+static void unlit(char *file, FILE *istream, FILE *ostream)
+{
+    line last, this=START;
+    int  linesread=0;
+    int  defnsread=0;
+
+    do {
+        last = this;
+        this = readline(istream, ostream);
+        linesread++;
+        if (this==DEFN)
+            defnsread++;
+        if (last==DEFN && this==TEXT)
+            complain(file, linesread-1, MISSINGBLANK);
+        if (last==TEXT && this==DEFN)
+            complain(file, linesread, MISSINGBLANK);
+        if (this==END)
+            complain(file, linesread, SPURIOUSENDCODE);
+	if (this == BEGIN) {
+	    /* start of code, copy to end */
+	    char lineb[1000];
+	    for(;;) {
+		if (fgets(lineb, sizeof lineb, istream) == NULL) {
+		    complain(file, linesread, MISSINGENDCODE);
+		    exit(1);
+		}
+		linesread++;
+		if (strncmp(lineb,ENDCODE,LENENDCODE) == 0) {
+		    myputc('\n', ostream);
+		    break;
+		}
+		fputs(lineb, ostream);
+	    }
+	    defnsread++;
+	}
+#if defined(PSEUDOCODE)
+	if (this == PSEUDO) {
+	    char lineb[1000];
+	    for(;;) {
+		if (fgets(lineb, sizeof lineb, istream) == NULL) {
+		    complain(file, linesread, MISSINGENDPSEUDOCODE);
+		    exit(1);
+		}
+		linesread++;
+		myputc('\n', ostream);
+		if (strncmp(lineb,ENDPSEUDOCODE,LENENDPSEUDOCODE) == 0) {
+		    break;
+		}
+	    }
+	}
+#endif
+	if (this == SHEBANG) {
+	    myputc('\n', ostream);
+	}
+    } while(this!=ENDFILE);
+
+    if (defnsread==0)
+        complain(file,linesread,EMPTYSCRIPT);
+}
+
+/* main(argc, argv)
+ *
+ * Main program.  Processes command line arguments, looking for leading:
+ *  -q  quiet mode - do not complain about bad literate script files
+ *  -n  noisy mode - complain about bad literate script files.
+ *  -r  remove cpp droppings in output.
+ *  -P  don't output any CPP line pragmas.
+ * Expects two additional arguments, a file name for the input and a file
+ * name for the output file.  These two names must normally be distinct.
+ * An exception is made for the special name "-" which can be used in either
+ * position to specify the standard input or the standard output respectively.
+ */
+
+int main(int argc,char **argv)
+{
+    FILE *istream, *ostream;
+    char *file;
+
+    for (argc--, argv++; argc > 0; argc--, argv++)
+        if (strcmp(*argv,"-n")==0)
+            noisy = 1;
+        else if (strcmp(*argv,"-q")==0)
+            noisy = 0;
+        else if (strcmp(*argv,"-c")==0)
+	    crunchnl = 1;
+        else if (strcmp(*argv,"-P")==0)
+	    no_line_pragma = 1;
+        else if (strcmp(*argv,"-h")==0) {
+	  if (argc > 1) {
+	    argc--; argv++;
+	    if (prefix_str)
+	      free(prefix_str);
+	    prefix_str = (char*)malloc(sizeof(char)*(1+strlen(*argv)));
+	    if (prefix_str)
+	      strcpy(prefix_str, *argv);
+	  }
+        } else if (strcmp(*argv,"-#")==0)
+	    ignore_shebang = 0;
+        else
+            break;
+
+    if (argc!=2) {
+        fprintf(stderr, USAGE);
+        exit(1);
+    }
+
+    if (strcmp(argv[0],argv[1])==0 && strcmp(argv[0],"-")!=0) {
+        fprintf(stderr, DISTINCTNAMES);
+        exit(1);
+    }
+
+    file = argv[0];
+    if (strcmp(argv[0], "-")==0) {
+        istream = stdin;
+        file    = "stdin";
+    }
+    else
+        if ((istream=__hs_fopen(argv[0], "r")) == NULL) {
+            fprintf(stderr, CANNOTOPEN, argv[0]);
+            exit(1);
+        }
+
+    ofilename=argv[1];
+    if (strcmp(argv[1], "-")==0)
+        ostream = stdout;
+    else
+        if ((ostream=__hs_fopen(argv[1], "w")) == NULL)  {
+            fprintf(stderr, CANNOTOPEN, argv[1]);
+            exit(1);
+        }
+
+    /* Prefix the output with line pragmas */
+    if (!no_line_pragma && prefix_str) {
+      /* Both GHC and CPP understand the #line pragma.
+       * We used to throw in both a #line and a {-# LINE #-} pragma
+       * here, but CPP doesn't understand {-# LINE #-} so it thought
+       * the line numbers were off by one.  We could put the {-# LINE
+       * #-} before the #line, but there's no point since GHC
+       * understands #line anyhow.  --SDM 8/2003
+       */
+      fprintf(ostream, "#line 1 \"%s\"\n", prefix_str);
+    }
+
+    unlit(file, istream, ostream);
+
+    if (istream != stdin) fclose(istream);
+    if (ostream != stdout) {
+	if (fclose(ostream) == EOF) {
+	    writeerror();
+	}
+    }
+
+    exit(errors==0 ? 0 : 1);
+}

--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -155,6 +155,10 @@ executables:
     dependencies:
       - asterius
 
+  unlit:
+    source-dirs: app
+    main: unlit.c
+
   genconstants:
     source-dirs: app
     main: genconstants.hs

--- a/asterius/src/Asterius/BuildInfo.hs
+++ b/asterius/src/Asterius/BuildInfo.hs
@@ -6,6 +6,7 @@ module Asterius.BuildInfo
     ahcPkg,
     ahcLd,
     ahcDist,
+    unlit,
     dataDir,
   )
 where
@@ -14,8 +15,9 @@ import BuildInfo_asterius
 import System.Directory
 import System.FilePath
 
-ahc, ahcPkg, ahcLd, ahcDist :: FilePath
+ahc, ahcPkg, ahcLd, ahcDist, unlit :: FilePath
 ahc = binDir </> "ahc" <.> exeExtension
 ahcPkg = binDir </> "ahc-pkg" <.> exeExtension
 ahcLd = binDir </> "ahc-ld" <.> exeExtension
 ahcDist = binDir </> "ahc-dist" <.> exeExtension
+unlit = binDir </> "unlit" <.> exeExtension

--- a/asterius/src/Asterius/FrontendPlugin.hs
+++ b/asterius/src/Asterius/FrontendPlugin.hs
@@ -53,7 +53,8 @@ frontendPlugin = makeFrontendPlugin $ do
       $ dflags
         { GHC.settings =
             (GHC.settings dflags)
-              { GHC.sPgm_l = (ahcLd, []),
+              { GHC.sPgm_L = unlit,
+                GHC.sPgm_l = (ahcLd, []),
                 GHC.sPgm_i = "false"
               }
         }


### PR DESCRIPTION
When trying to build `cubicbezier` (which is a transitive dependency of `diagrams`), `ahc` complains about the lack of the `unlit` executable. I have no idea why `unlit` is required since:

* `Cabal` implements the unlit logic as pure Haskell and should use that when preprocessing literate sources
* `unlit` isn't present in the bindir of a vanilla `ghc` installation

But anyway. This PR adds the `unlit` source code copied from `utils` of `ghc` and hard-wire the installed `unlit` path as the unlit program. Combined with #381, we are able to build `diagrams` along with all its dependencies.