### PR TITLE
Fix the request object name in default entry script to `req`

### DIFF
--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -217,18 +217,14 @@ genDefEntry task =
       "import module from \"./",
       out_base,
       ".wasm.mjs\";\n",
-      "import ",
-      out_base,
-      " from \"./",
+      "import req from \"./",
       out_base,
       ".req.mjs\";\n",
       case target task of
         Node -> "process.on(\"unhandledRejection\", err => { throw err; });\n"
         Browser -> mempty,
       mconcat
-        [ "module.then(m => rts.newAsteriusInstance(Object.assign(",
-          out_base,
-          ", {module: m}))).then(async i => {\n",
+        [ "module.then(m => rts.newAsteriusInstance(Object.assign(req, {module: m}))).then(async i => {\n",
           "try {\n",
           "i.exports.hs_init();\n",
           "await i.exports.main();\n",


### PR DESCRIPTION
Closes #364.

We used to emit `import foo from "./foo.req.mjs"` in `foo.mjs` for `foo.hs` main modules, but when the module name contains slashes, `foo-bar` isn't a valid js identifier and this results in runtime syntax errors.