### PR TITLE
Fix the Cloudflare Worker example and enable its test in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
             stack --no-terminal test asterius:bytearray
             stack --no-terminal test asterius:bigint
             stack --no-terminal test asterius:todomvc
-            # stack --no-terminal test asterius:cloudflare
+            stack --no-terminal test asterius:cloudflare
             stack --no-terminal test asterius:exception
             stack --no-terminal test asterius:regression60
             stack --no-terminal test asterius:sizeof_md5context

--- a/asterius/test/.gitignore
+++ b/asterius/test/.gitignore
@@ -10,6 +10,8 @@ package.json
 jsffi_stub.h
 
 !/cloudflare/cloudflare.mjs
+!/cloudflare/package.json
+!/cloudflare/test.js
 !/jsffi/index.html
 !/jsffi/jsffi.mjs
 !/rtsapi/rtsapi.mjs

--- a/asterius/test/cloudflare.hs
+++ b/asterius/test/cloudflare.hs
@@ -14,8 +14,7 @@ main = do
       "--input-mjs",
       "test/cloudflare/cloudflare.mjs",
       "--export-function=handleFetch",
-      "--ghc-option=-no-hs-main",
-      "--extra-root-symbol=Worker_x_closure"
+      "--ghc-option=-no-hs-main"
     ]
       <> args
   withCurrentDirectory "test/cloudflare" $ callProcess "npm" [ "run", "test" ]

--- a/asterius/test/cloudflare.hs
+++ b/asterius/test/cloudflare.hs
@@ -11,6 +11,9 @@ main = do
       "--input-hs",
       "test/cloudflare/cloudflare.hs",
       "--input-mjs",
-      "test/cloudflare/cloudflare.mjs"
+      "test/cloudflare/cloudflare.mjs",
+      "--export-function=handleFetch",
+      "--ghc-option=-no-hs-main",
+      "--extra-root-symbol=Worker_x_closure"
     ]
       <> args

--- a/asterius/test/cloudflare.hs
+++ b/asterius/test/cloudflare.hs
@@ -5,6 +5,7 @@ import System.Process
 main :: IO ()
 main = do
   args <- getArgs
+  withCurrentDirectory "test/cloudflare" $ callCommand "npm install"
   callProcess "ahc-link" $
     [ "--bundle",
       "--browser",
@@ -17,3 +18,4 @@ main = do
       "--extra-root-symbol=Worker_x_closure"
     ]
       <> args
+  withCurrentDirectory "test/cloudflare" $ callProcess "npm" [ "run", "test" ]

--- a/asterius/test/cloudflare/cloudflare.hs
+++ b/asterius/test/cloudflare/cloudflare.hs
@@ -15,11 +15,11 @@ handleFetch ev = do
       let payload = js_request_json req
       name <- indexJSObject payload "name"
       if js_is_undefined name then
-        pure $ js_new_response (toJSString "Name not specified") 400
+        js_new_response (toJSString "Name not specified") 400
       else
-        pure $ js_new_response (toJSString $ "Hello " <> (fromJSString . coerce) name) 200
+        js_new_response (toJSString $ "Hello " <> (fromJSString . coerce) name) 200
     _ ->
-      pure $ js_new_response (toJSString "Hello from Haskell") 200
+      js_new_response (toJSString "Hello from Haskell") 200
 
 foreign import javascript "${1} === undefined"
   js_is_undefined :: JSVal -> Bool
@@ -28,4 +28,4 @@ foreign import javascript safe "${1}.json()"
   js_request_json :: JSVal -> JSObject
 
 foreign import javascript "new Response(${1}, {\"status\": ${2}})"
-  js_new_response :: JSString -> Int -> JSObject
+  js_new_response :: JSString -> Int -> IO JSObject

--- a/asterius/test/cloudflare/cloudflare.hs
+++ b/asterius/test/cloudflare/cloudflare.hs
@@ -9,10 +9,23 @@ foreign export javascript "handleFetch" handleFetch :: JSObject -> IO JSObject
 handleFetch :: JSObject -> IO JSObject
 handleFetch ev = do
   req <- indexJSObject ev "request"
-  let req_str = jsonStringify req
-  pure $ js_new_response $ toJSString $ "From Haskell: " <> req_str
+  method <- indexJSObject (coerce req) "method"
+  case (fromJSString . coerce) method of
+    "POST" -> do
+      let payload = js_request_json req
+      name <- indexJSObject payload "name"
+      if js_is_undefined name then
+        pure $ js_new_response (toJSString "Name not specified") 400
+      else
+        pure $ js_new_response (toJSString $ "Hello " <> (fromJSString . coerce) name) 200
+    _ ->
+      pure $ js_new_response (toJSString "Hello from Haskell") 200
 
+foreign import javascript "${1} === undefined"
+  js_is_undefined :: JSVal -> Bool
 
-foreign import javascript "new Response(${1})"
-  js_new_response :: JSString -> JSObject
+foreign import javascript safe "${1}.json()"
+  js_request_json :: JSVal -> JSObject
 
+foreign import javascript "new Response(${1}, {\"status\": ${2}})"
+  js_new_response :: JSString -> Int -> JSObject

--- a/asterius/test/cloudflare/cloudflare.hs
+++ b/asterius/test/cloudflare/cloudflare.hs
@@ -1,26 +1,18 @@
+module Cloudflare where
+
 import Asterius.Types
 import Control.Monad
 import Data.Coerce
 
-handleFetch :: (JSObject -> IO ()) -> IO ()
-handleFetch = coerce makeHaskellCallback1 >=> js_handle_fetch
+foreign export javascript "handleFetch" handleFetch :: JSObject -> IO JSObject
 
-main :: IO ()
-main = handleFetch $ \ev -> do
+handleFetch :: JSObject -> IO JSObject
+handleFetch ev = do
   req <- indexJSObject ev "request"
   let req_str = jsonStringify req
-      resp = js_new_response $ toJSString $ "From Haskell: " <> req_str
-      resp_promise = js_promise_resolve resp
-  js_respond_with ev resp_promise
+  pure $ js_new_response $ toJSString $ "From Haskell: " <> req_str
 
-foreign import javascript "addEventListener('fetch', ${1})"
-  js_handle_fetch :: JSFunction -> IO ()
 
 foreign import javascript "new Response(${1})"
   js_new_response :: JSString -> JSObject
 
-foreign import javascript "Promise.resolve(${1})"
-  js_promise_resolve :: JSObject -> JSObject
-
-foreign import javascript "${1}.respondWith(${2})"
-  js_respond_with :: JSObject -> JSObject -> IO ()

--- a/asterius/test/cloudflare/cloudflare.mjs
+++ b/asterius/test/cloudflare/cloudflare.mjs
@@ -1,5 +1,20 @@
-import cloudflare from "./cloudflare.lib.mjs";
+import * as rts from "./rts.mjs";
+import cloudflare from "./cloudflare.req.mjs";
 
-let i = cloudflare(m);
-i.exports.hs_init();
-i.exports.main();
+const asteriusInstance = new Promise((resolve, reject) => {
+  // Cloudflare Workers makes Wasm bindings available as global variables.
+  // The binding name is configurable by the user when using the API.
+  // It gets hardcoded to 'wasm' when using the Wrangler CLI (as of v1.6.0).
+  rts.newAsteriusInstance(Object.assign(cloudflare, { module: wasm }))
+    .then(i => {
+      i.exports.hs_init();
+      resolve(i);
+    })
+    .catch(e => reject(e));
+});
+
+addEventListener("fetch", event => {
+  event.respondWith(asteriusInstance
+    .then(i => i.exports.handleFetch(event))
+    .catch(e => new Response(e)))
+})

--- a/asterius/test/cloudflare/package.json
+++ b/asterius/test/cloudflare/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "browserslist": [
+    "last 1 Chrome versions"
+  ],
+  "scripts": {
+    "test": "ava --timeout=10s"
+  },
+  "devDependencies": {
+    "@dollarshaveclub/cloudworker": "^0.1.2",
+    "ava": "^1.0.0"
+  }
+}

--- a/asterius/test/cloudflare/test.js
+++ b/asterius/test/cloudflare/test.js
@@ -1,0 +1,52 @@
+"use strict";
+
+const fs = require("fs").promises;
+const path = require("path");
+const Cloudworker = require("@dollarshaveclub/cloudworker");
+const wasm = require("@dollarshaveclub/cloudworker/lib/wasm");
+const test = require("ava");
+
+const scriptPath = path.join(__dirname, "cloudflare.js");
+const wasmPath = path.join(__dirname, "cloudflare.wasm");
+
+test.beforeEach(t => {
+  return Promise
+    .all([fs.readFile(scriptPath, "utf8"), wasm.loadPath(wasmPath)])
+    .then(values => {
+      const [script, wasm] = values;
+      const bindings = {wasm: wasm};
+      t.context.cw = new Cloudworker(script, {bindings});
+    })
+});
+
+test('get: successful response', t => {
+  const req = new Cloudworker.Request(
+    'https://example.com/')
+  return t.context.cw.dispatch(req).then((res) => {
+    t.is(res.status, 200);
+    res.text().then((body) =>{
+      t.is(body, 'Hello from Haskell');
+    })
+  })
+});
+
+test("post: missing name", t => {
+  const req = new Cloudworker.Request(
+    'https://example.com/',
+    {method: "POST", body: '{"hello": "cloudflare"}'})
+  return t.context.cw.dispatch(req).then((res) => {
+    t.is(res.status, 400)
+  })
+});
+
+test('post: successful response', t => {
+  const req = new Cloudworker.Request(
+    'https://example.com/',
+    {method: "POST", body: '{"name": "cloudflare"}'})
+  return t.context.cw.dispatch(req).then((res) => {
+    t.is(res.status, 200);
+    res.text().then((body) =>{
+      t.is(body, "Hello cloudflare");
+    })
+  })
+});

--- a/asterius/test/cloudflare/test.js
+++ b/asterius/test/cloudflare/test.js
@@ -19,11 +19,14 @@ test.beforeEach(t => {
     })
 });
 
-test('get: successful response', async t => {
-  const req = new Cloudworker.Request('https://example.com/');
-  const res = await t.context.cw.dispatch(req);
-  t.is(res.status, 200);
-  t.is(await res.text(), 'Hello from Haskell');
+test('get: successful responses', async t => {
+  const getReq = () => new Cloudworker.Request('https://example.com/')
+  const res1 = await t.context.cw.dispatch(getReq());
+  t.is(res1.status, 200);
+  t.is(await res1.text(), 'Hello from Haskell')
+  const res2 = await t.context.cw.dispatch(getReq());
+  t.is(res2.status, 200);
+  t.is(await res2.text(), 'Hello from Haskell');
 });
 
 test("post: missing name", async t => {

--- a/asterius/test/cloudflare/test.js
+++ b/asterius/test/cloudflare/test.js
@@ -37,11 +37,14 @@ test("post: missing name", async t => {
   t.is(res.status, 400);
 });
 
-test('post: successful response', async t => {
-  const req = new Cloudworker.Request(
+test('post: successful responses', async t => {
+  const postReq = (name) => new Cloudworker.Request(
     'https://example.com/',
-    {method: "POST", body: '{"name": "cloudflare"}'})
-  const res = await t.context.cw.dispatch(req);
-  t.is(res.status, 200);
-  t.is(await res.text(), 'Hello cloudflare');
+    {method: "POST", body: JSON.stringify({name: name})});
+  const res1 = await t.context.cw.dispatch(postReq('cloudflare'));
+  t.is(res1.status, 200);
+  t.is(await res1.text(), 'Hello cloudflare');
+  const res2 = await t.context.cw.dispatch(postReq('asterius'));
+  t.is(res2.status, 200);
+  t.is(await res2.text(), 'Hello asterius');
 });

--- a/asterius/test/cloudflare/test.js
+++ b/asterius/test/cloudflare/test.js
@@ -19,34 +19,26 @@ test.beforeEach(t => {
     })
 });
 
-test('get: successful response', t => {
-  const req = new Cloudworker.Request(
-    'https://example.com/')
-  return t.context.cw.dispatch(req).then((res) => {
-    t.is(res.status, 200);
-    res.text().then((body) =>{
-      t.is(body, 'Hello from Haskell');
-    })
-  })
+test('get: successful response', async t => {
+  const req = new Cloudworker.Request('https://example.com/');
+  const res = await t.context.cw.dispatch(req);
+  t.is(res.status, 200);
+  t.is(await res.text(), 'Hello from Haskell');
 });
 
-test("post: missing name", t => {
+test("post: missing name", async t => {
   const req = new Cloudworker.Request(
     'https://example.com/',
     {method: "POST", body: '{"hello": "cloudflare"}'})
-  return t.context.cw.dispatch(req).then((res) => {
-    t.is(res.status, 400)
-  })
+  const res = await t.context.cw.dispatch(req);
+  t.is(res.status, 400);
 });
 
-test('post: successful response', t => {
+test('post: successful response', async t => {
   const req = new Cloudworker.Request(
     'https://example.com/',
     {method: "POST", body: '{"name": "cloudflare"}'})
-  return t.context.cw.dispatch(req).then((res) => {
-    t.is(res.status, 200);
-    res.text().then((body) =>{
-      t.is(body, "Hello cloudflare");
-    })
-  })
+  const res = await t.context.cw.dispatch(req);
+  t.is(res.status, 200);
+  t.is(await res.text(), 'Hello cloudflare');
 });


### PR DESCRIPTION
This PR attempts to address most of #290.

There is a bit more JS code in `cloudflare.mjs` to hande the initialization of Asterius's runtime and the `fetch` event listener.

`cloudflare.hs` exports a handler function instead of having a `main` function. (Note: the handler looks identical to [this template project's](https://github.com/ento/worker-haskell-template/blob/3b393e2027013fbbe2b749047508a912de5c1108/src/worker.hs) because both this PR and that template project grew organically out of my attempt to use Asterius to write a Cloudflare Workers script.)

There is also a fair bit of JS code in `test.js` to test the compiled code using "@dollarshaveclub/cloudworker". This _could_ be written in Haskell, which would launch `cloudworker` as a child process and send test requests against it. The choice of using JS here is due to my inexperience with that kind of testing in Haskell.

I did not add `Cloudflare` to the `Asterius.Main.Task.Target` type in this PR, because it worked without doing so. The benefits I can see right now are:

1. The step to generate HTML can be skipped
2. The step to generate `.wasm.mjs` can be skipped, if we keep the current setup of letting the user write the entire entry script.
   - Alternatively, `.wasm.mjs` can export a Promise that resolves to a new Asterius instance (`asteriusInstance` in this PR's code). In this case, the compiler will need to know -- probably through a command line flag -- the global variable name (binding name) under which Cloudflare Workers runtime will make the Wasm module available. As noted in `cloudflare.mjs` below, the binding name is configurable by the user when using the API. It gets hardcoded to 'wasm' when using the Wrangler CLI (as of v1.6.0).
