### PR TITLE
Implementing Performance API

### DIFF
--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -36,7 +36,7 @@ extra-source-files:
   - test/nodeio/**/*.hs
 
 data-files:
-  - rts/*.mjs
+  - rts/**/*.mjs
   - boot-init.sh
   - boot.sh
 

--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -34,6 +34,7 @@ extra-source-files:
   - test/sizeof_md5context/**/*.hs
   - test/largenum/**/*.hs
   - test/nodeio/**/*.hs
+  - test/time/**/*.hs
 
 data-files:
   - rts/**/*.mjs
@@ -320,3 +321,11 @@ tests:
     ghc-options: -threaded -rtsopts
     dependencies:
       - asterius
+
+  time:
+    source-dirs: test
+    main: time.hs
+    ghc-options: -threaded -rtsopts
+    dependencies:
+      - asterius
+      - time

--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -328,4 +328,3 @@ tests:
     ghc-options: -threaded -rtsopts
     dependencies:
       - asterius
-      - time

--- a/asterius/rts/browser/default.mjs
+++ b/asterius/rts/browser/default.mjs
@@ -9,7 +9,7 @@ export default {
     /**
      * Returns the current timestamp, where 0 represents
      * the time origin of the document.
-     * The output is a [seconds, nanoseconds] Array.
+     * @returns A [seconds, nanoseconds] Array.
      */
     getCPUTime: () => {
       const ms = performance.now(),
@@ -19,7 +19,7 @@ export default {
     },
     /**
      * Returns the current timestamp, where 0 represents UNIX Epoch.
-     * The output is a [seconds, nanoseconds] Array.
+     * @returns A [seconds, nanoseconds] Array.
      */
     getUnixEpochTime: () => {
       const ms = Date.now(),

--- a/asterius/rts/browser/default.mjs
+++ b/asterius/rts/browser/default.mjs
@@ -5,27 +5,30 @@ export default {
   /**
    * The Performance Web API.
    */
-  Performance: window.performance,
+  Performance: performance,
   /**
    * A custom Time interface, used in {@link TimeCBits}.
    */
   Time: {
     /**
-     * Returns the current millisecond timestamp,
-     * where 0 represents the time origin of the document.
+     * Returns the current timestamp, where 0 represents
+     * the time origin of the document.
+     * The output is a [seconds, nanoseconds] Array.
      */
-    now: () => {
-      return performance.now();
+    getCPUTime: () => {
+      const ms = performance.now(),
+            s = Math.floor(ms / 1000.0),
+            ns = Math.floor(ms - s * 1000) * 1000000;
+      return [s, ns];
     },
     /**
-     * Returns the current millisecond timestamp,
-     * where 0 represents UNIX Epoch. The output is a
-     * [seconds, nanoseconds] Array.
+     * Returns the current timestamp, where 0 represents UNIX Epoch.
+     * The output is a [seconds, nanoseconds] Array.
      */
-    time: () => {
+    getUnixEpochTime: () => {
       const ms = Date.now(),
             s = Math.floor(ms / 1000.0),
-            ns = Math.floow(ms - s * 1000) * 1000000;
+            ns = Math.floor(ms - s * 1000) * 1000000;
       return [s, ns];
     },
     /**

--- a/asterius/rts/browser/default.mjs
+++ b/asterius/rts/browser/default.mjs
@@ -3,10 +3,6 @@
  */
 export default {
   /**
-   * The Performance Web API.
-   */
-  Performance: performance,
-  /**
    * A custom Time interface, used in {@link TimeCBits}.
    */
   Time: {

--- a/asterius/rts/browser/default.mjs
+++ b/asterius/rts/browser/default.mjs
@@ -1,5 +1,5 @@
 /**
- * This module contains browser-specific functionality.
+ * @file Implements browser-specific functionality.
  */
 export default {
   /**

--- a/asterius/rts/browser/default.mjs
+++ b/asterius/rts/browser/default.mjs
@@ -1,1 +1,41 @@
-export default "stub";
+/**
+ * This module contains browser-specific functionality.
+ */
+export default {
+  /**
+   * The Performance Web API.
+   */
+  Performance: window.performance,
+  /**
+   * A custom Time interface, used in {@link TimeCBits}.
+   */
+  Time: {
+    /**
+     * Returns the current millisecond timestamp,
+     * where 0 represents the time origin of the document.
+     */
+    now: () => {
+      return performance.now();
+    },
+    /**
+     * Returns the current millisecond timestamp,
+     * where 0 represents UNIX Epoch. The output is a
+     * [seconds, nanoseconds] Array.
+     */
+    time: () => {
+      const ms = Date.now(),
+            s = Math.floor(ms / 1000.0),
+            ns = Math.floow(ms - s * 1000) * 1000000;
+      return [s, ns];
+    },
+    /**
+     * The resolution of the timestamps in nanoseconds.
+     * Note! Due to the Spectre attack, browsers do not
+     * provide high-resolution timestamps anymore.
+     * See https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
+     * and https://spectreattack.com.
+     * We fallback to a resolution of 1ms.
+     */
+    resolution: 1000000
+  }
+};

--- a/asterius/rts/browser/default.mjs
+++ b/asterius/rts/browser/default.mjs
@@ -1,0 +1,1 @@
+export default "stub";

--- a/asterius/rts/node/default.mjs
+++ b/asterius/rts/node/default.mjs
@@ -1,8 +1,8 @@
+/**
+ * @file Implements Node.js-specific functionality.
+ */
 import { performance } from "perf_hooks";
 
-/**
- * This module contains Node.js-specific functionality.
- */
 export default {
   /**
    * The Performance Web API.

--- a/asterius/rts/node/default.mjs
+++ b/asterius/rts/node/default.mjs
@@ -5,10 +5,6 @@ import { performance } from "perf_hooks";
 
 export default {
   /**
-   * The Performance Web API.
-   */
-  Performance: performance,
-  /**
    * A custom Time interface, used in {@link TimeCBits}.
    */
   Time: {

--- a/asterius/rts/node/default.mjs
+++ b/asterius/rts/node/default.mjs
@@ -13,18 +13,22 @@ export default {
    */
   Time: {
     /**
-     * Returns the current millisecond timestamp,
+     * Returns the current high-resolution timestamp,
      * where 0 represents the start of the node.js process.
+     * The output is a [seconds, nanoseconds] Array.
      */
-    now: () => {
-      return performance.now();
+    getCPUTime: () => {
+      const ms = performance.now(),
+            s = Math.floor(ms / 1000.0),
+            ns = Math.floor(ms - s * 1000) * 1000000;
+      return [s, ns];
     },
     /**
      * Returns the current high-resolution timestamp,
      * where 0 represents UNIX Epoch. The output is a
      * [seconds, nanoseconds] Array.
      */
-    time: () => {
+    getUnixEpochTime: () => {
       return process.hrtime();
     },
     /**

--- a/asterius/rts/node/default.mjs
+++ b/asterius/rts/node/default.mjs
@@ -11,7 +11,7 @@ export default {
     /**
      * Returns the current high-resolution timestamp,
      * where 0 represents the start of the node.js process.
-     * The output is a [seconds, nanoseconds] Array.
+     * @returns A [seconds, nanoseconds] Array.
      */
     getCPUTime: () => {
       const ms = performance.now(),
@@ -21,8 +21,8 @@ export default {
     },
     /**
      * Returns the current high-resolution timestamp,
-     * where 0 represents UNIX Epoch. The output is a
-     * [seconds, nanoseconds] Array.
+     * where 0 represents UNIX Epoch.
+     * @returns A [seconds, nanoseconds] Array.
      */
     getUnixEpochTime: () => {
       return process.hrtime();

--- a/asterius/rts/node/default.mjs
+++ b/asterius/rts/node/default.mjs
@@ -1,0 +1,1 @@
+export default "stub";

--- a/asterius/rts/node/default.mjs
+++ b/asterius/rts/node/default.mjs
@@ -1,1 +1,36 @@
-export default "stub";
+import { performance } from "perf_hooks";
+
+/**
+ * This module contains Node.js-specific functionality.
+ */
+export default {
+  /**
+   * The Performance Web API.
+   */
+  Performance: performance,
+  /**
+   * A custom Time interface, used in {@link TimeCBits}.
+   */
+  Time: {
+    /**
+     * Returns the current millisecond timestamp,
+     * where 0 represents the start of the node.js process.
+     */
+    now: () => {
+      return performance.now();
+    },
+    /**
+     * Returns the current high-resolution timestamp,
+     * where 0 represents UNIX Epoch. The output is a
+     * [seconds, nanoseconds] Array.
+     */
+    time: () => {
+      return process.hrtime();
+    },
+    /**
+     * The resolution of the timestamp in nanoseconds
+     * (high-resolution, ~~1ns).
+     */
+    resolution: 1,
+  }
+};

--- a/asterius/rts/rts.constants.mjs
+++ b/asterius/rts/rts.constants.mjs
@@ -94,3 +94,5 @@ export const offset_StgWeak_link = 0x28;
 export const sizeof_StgStableName = 0x10;
 export const offset_StgStableName_header = 0x0;
 export const offset_StgStableName_sn = 0x8;
+export const clock_monotonic = 0x1;
+export const clock_realtime = 0x0;

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -74,7 +74,7 @@ export async function newAsteriusInstance(req) {
     __asterius_fs = new MemoryFileSystem(),
     __asterius_bytestring_cbits = new ByteStringCBits(null),
     __asterius_text_cbits = new TextCBits(__asterius_memory),
-    __asterius_time_cbits = new TimeCBits(__asterius_memory),
+    __asterius_time_cbits = new TimeCBits(__asterius_memory, req.targetSpecificModule),
     __asterius_gc = new GC(
       __asterius_memory,
       __asterius_heapalloc,

--- a/asterius/rts/rts.time.mjs
+++ b/asterius/rts/rts.time.mjs
@@ -46,7 +46,7 @@ export class TimeCBits {
   clock_gettime(clk_id, addr) {
     if (addr) {
       // fallback by default on the realtime timer
-      const time = clk_id == clock_monotonic ? this.getCPUTime() : this.getUnixEpochTime();
+      const time = clk_id == rtsConstants.clock_monotonic ? this.getCPUTime() : this.getUnixEpochTime();
       this.memory.i64Store(addr + rtsConstants.offset_timespec_tv_sec, time[0]);
       this.memory.i64Store(addr + rtsConstants.offset_timespec_tv_nsec, time[1]);
     }

--- a/asterius/rts/rts.time.mjs
+++ b/asterius/rts/rts.time.mjs
@@ -1,32 +1,52 @@
 import * as rtsConstants from "./rts.constants.mjs";
 
 export class TimeCBits {
-  constructor(memory) {
+  constructor(memory, targetSpecificModule) {
     this.memory = memory;
-    this.epoch = Date.now();
+    // Obtain Time API from the passed target-specific module
+    this.resolution = targetSpecificModule.Time.resolution; // ns
+    this.now = targetSpecificModule.Time.now; // output: ms
+    this.time = targetSpecificModule.Time.time; // output: [s,ns]
     Object.freeze(this);
   }
 
-  clock_getres(clk_id, res) {
-    if (res) {
-      this.memory.i64Store(res + rtsConstants.offset_timespec_tv_sec, 1);
-      this.memory.i64Store(res + rtsConstants.offset_timespec_tv_nsec, 0);
-    }
-    return 0;
-  }
-
-  clock_gettime(clk_id, tp) {
-    if (tp) {
-      const ms = Date.now(),
-        s = Math.floor(ms / 1000),
-        ns = (ms - s * 1000) * 1000000;
-      this.memory.i64Store(tp + rtsConstants.offset_timespec_tv_sec, s);
-      this.memory.i64Store(tp + rtsConstants.offset_timespec_tv_nsec, ns);
-    }
-    return 0;
-  }
-
+  /**
+   * Returns a (monotonic) nanoseconds timestamp.
+   */
   getMonotonicNSec() {
-    return (Date.now() - this.epoch) * 1000000;
+    // convert this.now() from ms to ns
+    return Math.floor(this.now() * 1000000);
+  }
+
+  /**
+   * Stores at a memory address the resolution of a given clock.
+   * @param clk_id the id of the clock
+   * @param addr the memory address 
+   */
+  clock_getres(clk_id, addr) {
+    if (addr) {
+      var sec = 0, nsec = this.resolution;
+      if (nsec > 1000000000) { // more than 1s
+        sec = Math.floor(this.resolution / 1000000000);
+        nsec = 0;
+      }
+      this.memory.i64Store(addr + rtsConstants.offset_timespec_tv_sec, sec);
+      this.memory.i64Store(addr + rtsConstants.offset_timespec_tv_nsec, nsec);
+    }
+    return 0;
+  }
+
+  /**
+   * Stores at a memory address the time of a given clock.
+   * @param clk_id the id of the clock
+   * @param addr the memory address 
+   */
+  clock_gettime(clk_id, addr) {
+    if (addr) {
+      const time = this.time();
+      this.memory.i64Store(addr + rtsConstants.offset_timespec_tv_sec, time[0]);
+      this.memory.i64Store(addr + rtsConstants.offset_timespec_tv_nsec, time[1]);
+    }
+    return 0;
   }
 }

--- a/asterius/src/Asterius/JSGen/Constants.hs
+++ b/asterius/src/Asterius/JSGen/Constants.hs
@@ -137,6 +137,8 @@ rtsConstants =
                  ("offset_StgWeak_link", offset_StgWeak_link),
                  ("sizeof_StgStableName", sizeof_StgStableName),
                  ("offset_StgStableName_header", offset_StgStableName_header),
-                 ("offset_StgStableName_sn", offset_StgStableName_sn)
+                 ("offset_StgStableName_sn", offset_StgStableName_sn),
+                 ("clock_monotonic", clock_monotonic),
+                 ("clock_realtime", clock_realtime)
                ]
          ]

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -420,7 +420,10 @@ ahcDistMain logger task (final_m, report) = do
   let rts_files = filter (\x -> x /= "browser" && x /= "node") rts_files'
   for_ rts_files $
     \f -> copyFile (dataDir </> "rts" </> f) (outputDirectory task </> f)
-  let specificFolder = map toLower $ show $ target task
+  let specificFolder = 
+        case target task of
+          Node -> "node"
+          Browser -> "browser"
   createDirectoryIfMissing False (outputDirectory task </> specificFolder)
   copyFile (dataDir </> "rts" </> specificFolder </> "default.mjs") (outputDirectory task </> specificFolder </> "default.mjs")
   logger $ "[INFO] Writing JavaScript loader module to " <> show out_wasm_lib
@@ -452,7 +455,9 @@ ahcDistMain logger task (final_m, report) = do
           "--no-autoinstall",
           "--no-content-hash",
           "--target",
-          map toLower $ show $ target task,
+          case target task of
+            Node -> "node"
+            Browser -> "browser"
           takeFileName out_entry
         ]
   when (target task == Browser) $ do

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -457,7 +457,7 @@ ahcDistMain logger task (final_m, report) = do
           "--target",
           case target task of
             Node -> "node"
-            Browser -> "browser"
+            Browser -> "browser",
           takeFileName out_entry
         ]
   when (target task == Browser) $ do

--- a/asterius/src/Asterius/Main/Task.hs
+++ b/asterius/src/Asterius/Main/Task.hs
@@ -33,7 +33,7 @@ import Asterius.Types (AsteriusEntitySymbol)
 data Target
   = Node
   | Browser
-  deriving (Eq)
+  deriving (Eq, Show)
 
 data Backend
   = WasmToolkit

--- a/asterius/src/Asterius/Main/Task.hs
+++ b/asterius/src/Asterius/Main/Task.hs
@@ -33,7 +33,7 @@ import Asterius.Types (AsteriusEntitySymbol)
 data Target
   = Node
   | Browser
-  deriving (Eq, Show)
+  deriving (Eq)
 
 data Backend
   = WasmToolkit

--- a/asterius/test/time.hs
+++ b/asterius/test/time.hs
@@ -1,0 +1,7 @@
+import System.Environment
+import System.Process
+
+main :: IO ()
+main = do
+  args <- getArgs
+  callProcess "ahc-link" $ ["--input-hs", "test/time/time.hs", "--run"] <> args

--- a/asterius/test/time/time.hs
+++ b/asterius/test/time/time.hs
@@ -1,11 +1,11 @@
-import Data.Time.Clock.POSIX
+-- import Data.Time.Clock.POSIX
+-- import Data.Time.LocalTime
 import System.CPUTime
-import Data.Time.LocalTime
 
 -- | Print current POSIX time and CPU time
 main :: IO ()
 main = do
-  currentTime <- Data.Time.Clock.POSIX.getCurrentTime
-  print currentTime
+  -- currentTime <- Data.Time.Clock.POSIX.getCurrentTime
+  -- print currentTime
   cpuTime <- System.CPUTime.getCPUTime
   print cpuTime

--- a/asterius/test/time/time.hs
+++ b/asterius/test/time/time.hs
@@ -1,0 +1,11 @@
+import Data.Time.Clock.POSIX
+import System.CPUTime
+import Data.Time.LocalTime
+
+-- | Print current POSIX time and CPU time
+main :: IO ()
+main = do
+  currentTime <- Data.Time.Clock.POSIX.getCurrentTime
+  print currentTime
+  cpuTime <- System.CPUTime.getCPUTime
+  print cpuTime

--- a/ghc-toolkit/cbits/ghc_constants.c
+++ b/ghc-toolkit/cbits/ghc_constants.c
@@ -523,3 +523,7 @@ HsInt sizeof_StgStableName() { return sizeof(StgStableName); }
 HsInt offset_StgStableName_header() { return offsetof(StgStableName, header); }
 
 HsInt offset_StgStableName_sn() { return offsetof(StgStableName, sn); }
+
+HsInt clock_monotonic() { return CLOCK_MONOTONIC; }
+
+HsInt clock_realtime() { return CLOCK_REALTIME; }

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Constants.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Constants.hs
@@ -583,3 +583,7 @@ foreign import ccall unsafe "offset_StgStableName_header"
 
 foreign import ccall unsafe "offset_StgStableName_sn"
   offset_StgStableName_sn :: Int
+
+foreign import ccall unsafe "clock_monotonic" clock_monotonic :: Int
+
+foreign import ccall unsafe "clock_realtime" clock_realtime :: Int


### PR DESCRIPTION
This is work in progress to enable the asterius runtime to import a different module according to the deployment target (for now, either Node.js or the browser).

This target-specific module should provide a target-independent interface for methods useful to other classes: for instance, the Performance API that we plan to use for recording statistics about garbage collection, which is currently available in browsers and node.js in a different way.

The current commit adds two new folders to the rts, `browser` and `node`, each containing a target-specific `default.mjs` file (currently a stub, to be filled later). The `target` attribute in a `Task` object determines which folder to copy at link time. 

The target-specific import is obtained by a dynamic import performed inside the JS `req` object, and stored in the `targetSpecificModule` attribute.