### PR TITLE
Add stack-ide.sh

### DIFF
--- a/utils/readme.md
+++ b/utils/readme.md
@@ -2,7 +2,7 @@
 
 This directory contains util scripts for hacking on asterius.
 
-## Cleaning & rebuilding
+## Shell scripts
 
 These scripts must be called at the project root directory.
 
@@ -13,6 +13,9 @@ These scripts must be called at the project root directory.
 * `utils/noon-break.sh`: Similar to coffee break, but disables parallelism when
   booting for deterministic ABI, and enables `ASTERIUS_DEBUG` for IR dumps and
   Core/STG/Cmm linting. Natually, this one takes a lot of more time.
+* `utils/stack-ide.sh`: Run `stack build` with the `--file-watch` option to get
+  real time GHC compilation error feedback when working on the Haskell sources
+  of `asterius`.
 
 In general, when the boot libs source or the wasm codegen logic is changed, the
 existing boot cache becomes out of date and thus must be rebuilt. Pick

--- a/utils/stack-ide.sh
+++ b/utils/stack-ide.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+stack build --fast --file-watch --ghc-options="-H512m -j" asterius:lib


### PR DESCRIPTION
`utils/stack-ide.sh` can be useful as a last-resort "IDE" when working on the Haskell sources of `asterius`. It's a pity we don't have proper `ghcid` support for now (see #395), but having this script is better than having a typechecker in my brain.