### PR TITLE
Recover support for the TeeLocal opcode

### DIFF
--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -287,6 +287,9 @@ marshalExpression sym_map m e = flip runContT pure $ case e of
   SetLocal {..} -> lift $ do
     v <- marshalExpression sym_map m value
     c_BinaryenLocalSet m index v
+  TeeLocal {..} -> lift $ do
+    v <- marshalExpression sym_map m value
+    c_BinaryenLocalTee m index v $ marshalValueType valueType
   Load {..} -> lift $ do
     p <- marshalExpression sym_map m ptr
     c_BinaryenLoad

--- a/asterius/src/Asterius/Backends/WasmToolkit.hs
+++ b/asterius/src/Asterius/Backends/WasmToolkit.hs
@@ -448,6 +448,19 @@ makeInstructions tail_calls sym_map _module_symtable@ModuleSymbolTable {..} _de_
         v <> DList.singleton Wasm.SetLocal
           { setLocalIndex = lookupLocalContext _local_ctx index
           }
+    TeeLocal {..} -> do
+      v <-
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
+          value
+      pure $
+        v <> DList.singleton Wasm.TeeLocal
+          { teeLocalIndex = lookupLocalContext _local_ctx index
+          }
     Load {..} -> do
       let _mem_arg = Wasm.MemoryArgument
             { memoryArgumentAlignment = 0,

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -386,6 +386,11 @@ data Expression
       { index :: BinaryenIndex,
         value :: Expression
       }
+  | TeeLocal
+      { index :: BinaryenIndex,
+        value :: Expression,
+        valueType :: ValueType
+      }
   | Load
       { signed :: Bool,
         bytes, offset :: BinaryenIndex,


### PR DESCRIPTION
This PR recovers the support for the `TeeLocal` opcode. It's not used by our cmm-to-wasm codegen, but used by `clang`, and one of `cmath` functions depends on it.