### PR TITLE
Implement __decodeDouble_2Int

### DIFF
--- a/asterius/rts/rts.float.mjs
+++ b/asterius/rts/rts.float.mjs
@@ -1,3 +1,5 @@
+import { Memory } from "./rts.memory.mjs";
+
 // Implements primitives from primFloat.c
 export class FloatCBits {
   constructor(memory) {
@@ -240,6 +242,14 @@ export class FloatCBits {
     }
 
     return [man_sign, man_high, man_low, exp];
+  }
+
+  __decodeDouble_2Int(p_man_sign, p_man_high, p_man_low, p_exp, dbl) {
+    const [man_sign, man_high, man_low, exp] = this.__decodeDouble_2IntJS(dbl);
+    this.memory.dataView.setBigInt64(Memory.unTag(p_man_sign), BigInt(man_sign), true);
+    this.memory.i64Store(p_man_high, man_high);
+    this.memory.i64Store(p_man_low, man_low);
+    this.memory.i64Store(p_exp, exp);
   }
 
   // From GHC/Integer/Type.hs

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -795,7 +795,8 @@ floatCBits =
       ("isDoubleInfinite", [F64], [I64]),
       ("__decodeFloat_Int", [I64, I64, F32], []),
       ("rintDouble", [F64], [F64]),
-      ("rintFloat", [F32], [F32])
+      ("rintFloat", [F32], [F32]),
+      ("__decodeDouble_2Int", [I64, I64, I64, I64, F64], [])
     ]
 
 md5CBits :: [(AsteriusEntitySymbol, (FunctionImport, Function))]


### PR DESCRIPTION
This PR implements `__decodeDouble_2Int`, which is just wrapping existing implementation in `rts.float.mjs`. In the future this kind of bit-fiddling code should be rewritten in pure wasm.