### PR TITLE
Run limit-segments pass after binaryen optimization

### DIFF
--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -14,6 +14,7 @@ module Asterius.Backends.Binaryen
     c_BinaryenSetDebugInfo,
     c_BinaryenSetOptimizeLevel,
     c_BinaryenSetShrinkLevel,
+    c_BinaryenModuleRunPasses,
     c_BinaryenModuleOptimize,
     c_BinaryenModuleValidate,
     c_BinaryenModuleRead,

--- a/asterius/src/Asterius/JSRun/NonMain.hs
+++ b/asterius/src/Asterius/JSRun/NonMain.hs
@@ -49,7 +49,9 @@ distNonMain p extra_syms =
   ahcDistMain
     putStrLn
     defTask
-      { inputHS = p,
+      { optimizeLevel = 0,
+        shrinkLevel = 0,
+        inputHS = p,
         outputDirectory = takeDirectory p,
         outputBaseName = takeBaseName p,
         Asterius.Main.Task.verboseErr = True,


### PR DESCRIPTION
This PR runs the `limit-segments` pass of `binaryen` after performing optimization. This is necessary for large outputs with lots of segments, since output wasm modules with more than 100000 segments has been spotted more than once in the wild.

We also disable binaryen optimization and shrinking for the TH runner, since the splice code is short-lived anyway so we shouldn't waste more CPU cycles there.