### PR TITLE
Add a direnv config file for convenience

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+PATH_add $(stack path --compiler-bin)
+PATH_add $(stack path --snapshot-install-root)/bin
+PATH_add $(stack path --local-install-root)/bin


### PR DESCRIPTION
This PR adds a `.envrc` file to the project root. When `direnv` is set up in the dev environment, this exposes executables like `ahc` to `PATH`, so testing small examples locally would only need `ahc-link ...` without typing `stack exec`.

One downside of the `.envrc` file is slightly slowing down a `bash` session startup since it invokes `stack path` multiple times; the lag is more significant when the project tree is fresh and there isn't a local setup of the custom ghc bindists, since `stack path` may also enter the logic of bindist setup. However, `divenv` always allow a Ctrl+C escape from a long running `.envrc` script, so it shouldn't be a big concern.