### PR TITLE
Flag for Garbage Collection Statistics

### DIFF
--- a/asterius/rts/rts.exports.mjs
+++ b/asterius/rts/rts.exports.mjs
@@ -6,6 +6,7 @@ export class Exports {
     reentrancy_guard,
     symbol_table,
     scheduler,
+    statistics,
     exports,
     stableptr_manager
   ) {
@@ -14,6 +15,7 @@ export class Exports {
       reentrancyGuard: reentrancy_guard,
       symbolTable: symbol_table,
       scheduler: scheduler,
+      statistics: statistics,
       stablePtrManager: stableptr_manager
     });
     Object.assign(this, exports);

--- a/asterius/rts/rts.gc.mjs
+++ b/asterius/rts/rts.gc.mjs
@@ -116,6 +116,7 @@ export class GC {
    * @param bytes The size in bytes of the closure 
    */
   copyClosure(c, bytes) {
+    this.statistics.copiedBytes(bytes);
     const dest_c = this.heapAlloc.allocate(Math.ceil(bytes / 8));
     this.memory.memcpy(dest_c, c, bytes);
     this.liveMBlocks.add(bdescr(dest_c));
@@ -843,8 +844,6 @@ export class GC {
       }
     }
 
-    // TODO:
-    this.statistics.copiedMBlocks(this.liveMBlocks.size);
     // mark unused MBlocks
     this.heapAlloc.handleLiveness(this.liveMBlocks, this.deadMBlocks);
     // allocate a new nursery

--- a/asterius/rts/rts.memory.mjs
+++ b/asterius/rts/rts.memory.mjs
@@ -13,7 +13,8 @@ function mask(n) {
  * ({@link Memory#getMBlocks} and {@link Memory#freeMBlocks}).
  */
 export class Memory {
-  constructor() {
+  constructor(statistics) {
+    this.statistics = statistics;
     /**
      * The underlying Wasm Memory instance.
      * @name Memory#memory
@@ -73,6 +74,7 @@ export class Memory {
   initView() {
     this.i8View = new Uint8Array(this.memory.buffer);
     this.dataView = new DataView(this.memory.buffer);
+    this.statistics.memoryCapacity(this.capacity);
   }
 
   static unTag(p) {
@@ -246,6 +248,7 @@ export class Memory {
    *   requested free memory area.
    */
   getMBlocks(n) {
+    this.statistics.getMBlocks(n);
     // First of all, check if there are free spots in the existing
     // memory by inspecting this.liveBitset for enough adjacent 1's.
     // In this way, we reuse previously freed MBlock slots and

--- a/asterius/rts/rts.memory.mjs
+++ b/asterius/rts/rts.memory.mjs
@@ -74,7 +74,7 @@ export class Memory {
   initView() {
     this.i8View = new Uint8Array(this.memory.buffer);
     this.dataView = new DataView(this.memory.buffer);
-    this.statistics.memoryCapacity(this.capacity);
+    this.statistics.memoryInUse(this.buffer.byteLength);
   }
 
   static unTag(p) {
@@ -248,7 +248,7 @@ export class Memory {
    *   requested free memory area.
    */
   getMBlocks(n) {
-    this.statistics.getMBlocks(n);
+    this.statistics.allocateMBlocks(n);
     // First of all, check if there are free spots in the existing
     // memory by inspecting this.liveBitset for enough adjacent 1's.
     // In this way, we reuse previously freed MBlock slots and

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -27,6 +27,7 @@ import { Unicode } from "./rts.unicode.mjs";
 import { Exports } from "./rts.exports.mjs";
 import { getNodeModules } from "./rts.node.mjs";
 import * as rtsConstants from "./rts.constants.mjs";
+import { Statistics } from "./rts.statistics.mjs";
 
 export async function newAsteriusInstance(req) {
   let __asterius_persistent_state = req.persistentState
@@ -35,6 +36,10 @@ export async function newAsteriusInstance(req) {
     __asterius_reentrancy_guard = new ReentrancyGuard(["Scheduler", "GC"]),
     __asterius_logger = new EventLogManager(req.symbolTable),
     __asterius_tracer = new Tracer(__asterius_logger, req.symbolTable),
+    __asterius_statistics = new Statistics(
+      req.targetSpecificModule.Time,
+      req.gcStatistics
+    ),
     __asterius_wasm_instance = null,
     __asterius_wasm_table = new WebAssembly.Table({
       element: "anyfunc",
@@ -43,7 +48,7 @@ export async function newAsteriusInstance(req) {
     __asterius_wasm_memory = new WebAssembly.Memory({
       initial: req.staticMBlocks * (rtsConstants.mblock_size / 65536)
     }),
-    __asterius_memory = new Memory(),
+    __asterius_memory = new Memory(__asterius_statistics),
     __asterius_memory_trap = new MemoryTrap(
       __asterius_logger,
       req.symbolTable,
@@ -80,6 +85,7 @@ export async function newAsteriusInstance(req) {
       __asterius_stableptr_manager,
       __asterius_stablename_manager,
       __asterius_scheduler,
+      __asterius_statistics,
       req.infoTables,
       req.exportStablePtrs,
       req.symbolTable,
@@ -101,6 +107,7 @@ export async function newAsteriusInstance(req) {
       __asterius_reentrancy_guard,
       req.symbolTable,
       __asterius_scheduler,
+      __asterius_statistics,
       req.exports,
       __asterius_stableptr_manager
     ),
@@ -239,6 +246,7 @@ export async function newAsteriusInstance(req) {
       Unicode: modulify(__asterius_unicode),
       MD5: modulify(__asterius_md5),
       Tracing: modulify(__asterius_tracer),
+      Statistics: modulify(__asterius_statistics),
       Scheduler: modulify(__asterius_scheduler)
     }
   );

--- a/asterius/rts/rts.statistics.mjs
+++ b/asterius/rts/rts.statistics.mjs
@@ -1,0 +1,126 @@
+export class Statistics {
+  constructor(time, gcStatistics) {
+    this.time = time;
+    this.gcStatistics = gcStatistics;
+    this.counters = {
+      init_wall_s: 0,
+      gc_wall_s: 0,
+      num_canceled_GCs: 0,
+      num_GCs: 0,
+      copiedMBlocks: [],
+      allocatedMBlocks: 0,
+      last_gc_started: 0,
+      wasm_memory_capacity: 0,
+    };
+    Object.freeze(this);
+  }
+
+  /**
+   * Force @param arg to be evaluated, i.e.
+   * in case it is a callback, @param arg is called
+   * and the result returned. Useful when tracing/logging
+   * data that is expensive to compute, so that the actual
+   * value is computed only if the logging level is
+   * appropriate.
+   */
+  static force(arg) {
+    if (typeof arg === "function") {
+      return arg();
+    } else {
+      return arg;
+    }
+  }
+
+  now() {
+    const [s,ns] = this.time.getCPUTime();
+    return s + (ns / 1000000000);
+  }
+
+  memoryCapacity(bytes) {
+    this.counters.wasm_memory_capacity = bytes;
+  }
+
+  /**
+   * Traces the end of the initialization of
+   * the runtime system (INIT)
+   */
+  endInit() {
+    if (!this.gcStatistics) return;
+    this.counters.init_wall_s = this.now();
+  }
+
+  /**
+   * Traces the request of a garbage collection
+   * i.e. {@link GC.performGC}.
+   */
+  startGC() {
+    if (!this.gcStatistics) return;
+    this.counters.last_gc_started = this.now();
+  }
+
+  /**
+   * Trace a cancelled garbage collection.
+   */
+  cancelGC() {
+    if (!this.gcStatistics) return;
+    this.counters.gc_wall_s += this.now() - this.counters.last_gc_started;
+    this.counters.num_canceled_GCs += 1;
+  }
+
+  /**
+   * Trace the end of a garbage collection.
+   */
+  endGC() {
+    if (!this.gcStatistics) return;
+    this.counters.gc_wall_s += this.now() - this.counters.last_gc_started;
+    this.counters.num_GCs += 1;
+  }
+
+  /**
+   * 
+   */
+  copiedMBlocks(n) {
+    if (!this.gcStatistics) return;
+    n = Statistics.force(n);
+    this.counters.copiedMBlocks.push(n);
+  }
+
+  /**
+   * Trace the allocation of new megablocks.
+   * Called from {@link Memory.getMBlocks}
+   * @param n The number of newly allocated megablocks
+   */
+  getMBlocks(n) {
+    if (!this.gcStatistics) return;
+    this.counters.allocatedMBlocks += Statistics.force(n);
+  }
+
+  /**
+   * Display various GC statistics.
+   */
+  displayGCStatistics() {
+    if (!this.gcStatistics) return;
+    var counters = this.counters;
+    var total_wall_s = this.now();
+    var gc_wall_s = counters.gc_wall_s;
+    var mutator_wall_s = total_wall_s - gc_wall_s - counters.init_wall_s;
+    var totalCopiedMBlocksNo = 0;
+    for(const n of counters.copiedMBlocks) {
+      totalCopiedMBlocksNo += n;
+    }
+    var copiedMBlocksAverageNo = "n/a";
+    if (counters.copiedMBlocks.length != 0) 
+      copiedMBlocksAverageNo = totalCopiedMBlocksNo / counters.copiedMBlocks.length;
+    console.log("Garbage Collector Statistics", {
+      init_wall_seconds: counters.init_wall_s,
+      mutator_wall_seconds: mutator_wall_s,
+      GC_wall_seconds: gc_wall_s,
+      num_GCs: counters.num_GCs,
+      num_canceled_GCs: counters.num_canceled_GCs,
+      copied_mblocks: totalCopiedMBlocksNo,
+      average_copied_mblocks: copiedMBlocksAverageNo,
+      allocated_mblocks: counters.allocatedMBlocks,
+      wasm_memory_capacity: counters.wasm_memory_capacity
+    });
+  }
+}

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -251,7 +251,7 @@ genDefEntry task =
           "}\n",
           "if (i.stdio.stdout().toString().length) console.log(i.stdio.stdout());\n",
           "if (i.stdio.stderr().toString().length) console.log(i.stdio.stderr());\n",
-          if gcStatistics task then "i.exports.context.statistics.displayGCStatistics();\n" else "",
+          if gcStatistics task then "i.exports.context.statistics.show();\n" else "",
           "});\n"
         ]
     ]

--- a/asterius/src/Asterius/Main/Task.hs
+++ b/asterius/src/Asterius/Main/Task.hs
@@ -24,6 +24,7 @@ module Asterius.Main.Task
     exportFunctions,
     extraRootSymbols,
     gcThreshold,
+    gcStatistics,
     defTask,
   )
 where
@@ -52,6 +53,7 @@ data Task
         tailCalls, gcSections, bundle, debug, outputIR, run, verboseErr, yolo :: Bool,
         extraGHCFlags :: [String],
         exportFunctions, extraRootSymbols :: [AsteriusEntitySymbol],
+        gcStatistics :: Bool,
         gcThreshold :: Int
       }
 
@@ -76,5 +78,6 @@ defTask = Task
     extraGHCFlags = [],
     exportFunctions = [],
     extraRootSymbols = [],
+    gcStatistics = False,
     gcThreshold = 64
   }


### PR DESCRIPTION
This PR adds to ahc-link the new flag `--gc-stats` which enables the gathering of basic statistics about garbage collection.

This flag is similar to the -s flag in GHC, and displays:
- Time spent in the RTS initialisation
- Time spent in the mutator
- Time spent in garbage collection
- Total elapsed time
- The percentage of GC time vs Total time
- The number of GCs
- The number of canceled GCs, e.g. due to yolo mode
- The total number of bytes copied due to evacuation
- The total number of MBlocks allocated
- The maximum size of requested Wasm memory

This is still WIP; I will appoint a reviewer when ready.