### PR TITLE
Test more cabal packages on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,11 +194,11 @@ jobs:
       - run:
           name: Test ahc-cabal
           command: |
-            stack exec ahc-cabal new-update
-            stack exec ahc-cabal new-install -j1 --symlink-bindir . \
+            stack exec ahc-cabal -- new-update
+            stack exec ahc-cabal -- new-install -j1 --symlink-bindir . \
               hello \
               cql
-            stack exec ahc-dist --input-exe hello --run
+            stack exec ahc-dist -- --input-exe hello --run
 
   asterius-test-ghc-testsuite:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,11 +194,14 @@ jobs:
       - run:
           name: Test ahc-cabal
           command: |
-            stack exec ahc-cabal -- new-update
-            stack exec ahc-cabal -- new-install -j1 --symlink-bindir . \
-              hello \
-              cql
-            stack exec ahc-dist -- --input-exe hello --run
+            ahc-cabal new-update
+            ahc-cabal new-install -j1 --symlink-bindir . \
+              hello
+            ahc-dist --input-exe hello --run
+
+            cd ghc-toolkit/boot-libs
+            ahc-cabal v1-install -j2 --package-db=clear --package-db=global \
+              contravariant-extras
 
   asterius-test-ghc-testsuite:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,11 +194,11 @@ jobs:
       - run:
           name: Test ahc-cabal
           command: |
-            ahc-cabal new-update
-            ahc-cabal new-install -j1 --symlink-bindir . \
+            stack exec ahc-cabal new-update
+            stack exec ahc-cabal new-install -j1 --symlink-bindir . \
               hello \
               cql
-            ahc-dist --input-exe hello --run
+            stack exec ahc-dist --input-exe hello --run
 
   asterius-test-ghc-testsuite:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,8 @@ jobs:
           command: |
             ahc-cabal new-update
             ahc-cabal new-install -j1 --symlink-bindir . \
-              hello
+              hello \
+              contravariant-extras
             ahc-dist --input-exe hello --run
 
   asterius-test-ghc-testsuite:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
             ahc-cabal new-update
             ahc-cabal new-install -j1 --symlink-bindir . \
               hello \
-              contravariant-extras
+              cql
             ahc-dist --input-exe hello --run
 
   asterius-test-ghc-testsuite:


### PR DESCRIPTION
When curating the new docker images for `lts-14.21`, we discovered regressions in the TH runner for `contravariant-extras-0.3.5` and `cql-4.0.2`, which prints gc-related rts error message:

```
RuntimeError: RuntimeError: Invalid live mblock 0x1ffff700100100
    at HeapAlloc.handleLiveness (file:///home/asterius/.asterius/.stack-work/install/x86_64-linux-custom-asterius-tinfo6/a6f37316a3da926688ff81f5b3da56a72cf3b7b83dd723525b6931d11f77da34/8.6.5/share/x86_64-linux-ghc-8.6.5/asterius-0.0.1/rts/rts.heapalloc.mjs:172:15)
    at GC.performGC (file:///home/asterius/.asterius/.stack-work/install/x86_64-linux-custom-asterius-tinfo6/a6f37316a3da926688ff81f5b3da56a72cf3b7b83dd723525b6931d11f77da34/8.6.5/share/x86_64-linux-ghc-8.6.5/asterius-0.0.1/rts/rts.gc.mjs:863:20)
    at Scheduler.returnedFromTSO (file:///home/asterius/.asterius/.stack-work/install/x86_64-linux-custom-asterius-tinfo6/a6f37316a3da926688ff81f5b3da56a72cf3b7b83dd723525b6931d11f77da34/8.6.5/share/x86_64-linux-ghc-8.6.5/asterius-0.0.1/rts/rts.scheduler.mjs:115:17)
    at Scheduler.scheduler_loop (file:///home/asterius/.asterius/.stack-work/install/x86_64-linux-custom-asterius-tinfo6/a6f37316a3da926688ff81f5b3da56a72cf3b7b83dd723525b6931d11f77da34/8.6.5/share/x86_64-linux-ghc-8.6.5/asterius-0.0.1/rts/rts.scheduler.mjs:425:18)
    at file:///home/asterius/.asterius/.stack-work/install/x86_64-linux-custom-asterius-tinfo6/a6f37316a3da926688ff81f5b3da56a72cf3b7b83dd723525b6931d11f77da34/8.6.5/share/x86_64-linux-ghc-8.6.5/asterius-0.0.1/rts/rts.scheduler.mjs:298:15
library/Contravariant/Extras/Contrazip.hs:1:1: error:
    Exception when trying to run compile-time code:
      {handle: <file descriptor: 17>}: GHCi.Message.remoteCall: end of file
    Code: return
            (join
               (map (TH.divisibleContrazipDecs "contrazip") (reverse [2 .. 42])))
  |
1 | -- |
  | ^
```

The regression was sneaked in by #424, and while we revert it for the time being, we should add the offending package's build to CI, to prevent a similar regression.