### PR TITLE
Make sure all unary/binary ops are present in the EDSL

### DIFF
--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -1392,7 +1392,7 @@ memcmpFunction _ = runEDSL "memcmp" $ do
       "__asterius_memcmp"
       (map convertUInt64ToFloat64 [ptr1, ptr2, n])
       I32
-  emit $ Unary ExtendSInt32 cres
+  emit $ extendSInt32 cres
 
 fromJSArrayBufferFunction _ = runEDSL "__asterius_fromJSArrayBuffer" $ do
   setReturnTypes [I64]

--- a/asterius/src/Asterius/Builtins/CMath.hs
+++ b/asterius/src/Asterius/Builtins/CMath.hs
@@ -8,6 +8,7 @@ module Asterius.Builtins.CMath
   )
 where
 
+import Asterius.EDSL
 import Asterius.Types
 
 -- | Here contains implementation of certain functions in math.h of libc. They
@@ -44,228 +45,198 @@ scalbn =
     { functionMap =
         [ ( "scalbn",
             Function
-              { functionType = FunctionType
-                  { paramTypes = [F64, I32],
-                    returnTypes = [F64]
-                  },
+              { functionType =
+                  FunctionType
+                    { paramTypes = [F64, I32],
+                      returnTypes = [F64]
+                    },
                 varTypes = [I32],
-                body = Block
-                  { name = "",
-                    bodys =
-                      [ Block
-                          { name = "1",
-                            bodys =
-                              [ Block
-                                  { name = "2",
-                                    bodys =
-                                      [ Break
-                                          { name = "2",
-                                            breakCondition = Just Binary
-                                              { binaryOp = LtSInt32,
-                                                operand0 = GetLocal
-                                                  { index = 1,
-                                                    valueType = I32
-                                                  },
-                                                operand1 = ConstI32 1024
-                                              }
-                                          },
-                                        SetLocal
-                                          { index = 0,
-                                            value = Binary
-                                              { binaryOp = MulFloat64,
-                                                operand0 = GetLocal
+                body =
+                  Block
+                    { name = "",
+                      bodys =
+                        [ Block
+                            { name = "1",
+                              bodys =
+                                [ Block
+                                    { name = "2",
+                                      bodys =
+                                        [ Break
+                                            { name = "2",
+                                              breakCondition =
+                                                Just $
+                                                  GetLocal
+                                                    { index = 1,
+                                                      valueType = I32
+                                                    }
+                                                    `ltSInt32` ConstI32 1024
+                                            },
+                                          SetLocal
+                                            { index = 0,
+                                              value =
+                                                GetLocal
                                                   { index = 0,
                                                     valueType = F64
-                                                  },
-                                                operand1 = ConstF64 0x1p+1023
-                                              }
-                                          },
-                                        Block
-                                          { name = "3",
-                                            bodys =
-                                              [ Break
-                                                  { name = "3",
-                                                    breakCondition = Just Binary
-                                                      { binaryOp = GeSInt32,
-                                                        operand0 = TeeLocal
-                                                          { index = 2,
-                                                            value = Binary
-                                                              { binaryOp = AddInt32,
-                                                                operand0 = GetLocal
+                                                  }
+                                                  `mulFloat64` ConstF64 0x1p+1023
+                                            },
+                                          Block
+                                            { name = "3",
+                                              bodys =
+                                                [ Break
+                                                    { name = "3",
+                                                      breakCondition =
+                                                        Just $
+                                                          TeeLocal
+                                                            { index = 2,
+                                                              value =
+                                                                GetLocal
                                                                   { index = 1,
                                                                     valueType =
                                                                       I32
-                                                                  },
-                                                                operand1 = ConstI32 (-1023)
-                                                              },
+                                                                  }
+                                                                  `addInt32` ConstI32 (-1023),
+                                                              valueType = I32
+                                                            }
+                                                            `geSInt32` ConstI32 1024
+                                                    },
+                                                  SetLocal
+                                                    { index = 1,
+                                                      value =
+                                                        GetLocal
+                                                          { index = 2,
                                                             valueType = I32
-                                                          },
-                                                        operand1 = ConstI32 1024
-                                                      }
-                                                  },
-                                                SetLocal
-                                                  { index = 1,
-                                                    value = GetLocal
-                                                      { index = 2,
-                                                        valueType = I32
-                                                      }
-                                                  },
-                                                Break {name = "1", breakCondition = Nothing}
-                                              ],
-                                            blockReturnTypes = []
-                                          },
-                                        SetLocal
-                                          { index = 0,
-                                            value = Binary
-                                              { binaryOp = MulFloat64,
-                                                operand0 = GetLocal
+                                                          }
+                                                    },
+                                                  Break {name = "1", breakCondition = Nothing}
+                                                ],
+                                              blockReturnTypes = []
+                                            },
+                                          SetLocal
+                                            { index = 0,
+                                              value =
+                                                GetLocal
                                                   { index = 0,
                                                     valueType = F64
-                                                  },
-                                                operand1 = ConstF64 0x1p+1023
-                                              }
-                                          },
-                                        SetLocal
-                                          { index = 1,
-                                            value = Binary
-                                              { binaryOp = AddInt32,
-                                                operand0 = If
-                                                  { condition = Binary
-                                                      { binaryOp = LtSInt32,
-                                                        operand0 = GetLocal
-                                                          { index = 1,
-                                                            valueType =
-                                                              I32
-                                                          },
-                                                        operand1 = ConstI32 3069
-                                                      },
-                                                    ifTrue = GetLocal
-                                                      { index = 1,
-                                                        valueType = I32
-                                                      },
+                                                  }
+                                                  `mulFloat64` ConstF64 0x1p+1023
+                                            },
+                                          SetLocal
+                                            { index = 1,
+                                              value =
+                                                If
+                                                  { condition =
+                                                      GetLocal
+                                                        { index = 1,
+                                                          valueType =
+                                                            I32
+                                                        }
+                                                        `ltSInt32` ConstI32 3069,
+                                                    ifTrue =
+                                                      GetLocal
+                                                        { index = 1,
+                                                          valueType = I32
+                                                        },
                                                     ifFalse = Just $ ConstI32 3069
-                                                  },
-                                                operand1 = ConstI32 (-2046)
-                                              }
-                                          },
-                                        Break {name = "1", breakCondition = Nothing}
-                                      ],
-                                    blockReturnTypes = []
-                                  },
-                                Break
-                                  { name = "1",
-                                    breakCondition = Just Binary
-                                      { binaryOp = GtSInt32,
-                                        operand0 = GetLocal
-                                          { index = 1,
-                                            valueType = I32
-                                          },
-                                        operand1 = ConstI32 (-1023)
-                                      }
-                                  },
-                                SetLocal
-                                  { index = 0,
-                                    value = Binary
-                                      { binaryOp = MulFloat64,
-                                        operand0 = GetLocal
+                                                  }
+                                                  `addInt32` ConstI32 (-2046)
+                                            },
+                                          Break {name = "1", breakCondition = Nothing}
+                                        ],
+                                      blockReturnTypes = []
+                                    },
+                                  Break
+                                    { name = "1",
+                                      breakCondition =
+                                        Just $
+                                          GetLocal
+                                            { index = 1,
+                                              valueType = I32
+                                            }
+                                            `gtSInt32` ConstI32 (-1023)
+                                    },
+                                  SetLocal
+                                    { index = 0,
+                                      value =
+                                        GetLocal
                                           { index = 0,
                                             valueType = F64
-                                          },
-                                        operand1 = ConstF64 0x1p-969
-                                      }
-                                  },
-                                Block
-                                  { name = "2_",
-                                    bodys =
-                                      [ Break
-                                          { name = "2_",
-                                            breakCondition = Just Binary
-                                              { binaryOp = LeSInt32,
-                                                operand0 = TeeLocal
-                                                  { index = 2,
-                                                    value = Binary
-                                                      { binaryOp = AddInt32,
-                                                        operand0 = GetLocal
+                                          }
+                                          `mulFloat64` ConstF64 0x1p-969
+                                    },
+                                  Block
+                                    { name = "2_",
+                                      bodys =
+                                        [ Break
+                                            { name = "2_",
+                                              breakCondition =
+                                                Just $
+                                                  TeeLocal
+                                                    { index = 2,
+                                                      value =
+                                                        GetLocal
                                                           { index = 1,
                                                             valueType =
                                                               I32
-                                                          },
-                                                        operand1 = ConstI32 969
-                                                      },
-                                                    valueType = I32
-                                                  },
-                                                operand1 = ConstI32 (-1023)
-                                              }
-                                          },
-                                        SetLocal
-                                          { index = 1,
-                                            value = GetLocal {index = 2, valueType = I32}
-                                          },
-                                        Break {name = "1", breakCondition = Nothing}
-                                      ],
-                                    blockReturnTypes = []
-                                  },
-                                SetLocal
-                                  { index = 0,
-                                    value = Binary
-                                      { binaryOp = MulFloat64,
-                                        operand0 = GetLocal
+                                                          }
+                                                          `addInt32` ConstI32 969,
+                                                      valueType = I32
+                                                    }
+                                                    `leSInt32` ConstI32 (-1023)
+                                            },
+                                          SetLocal
+                                            { index = 1,
+                                              value = GetLocal {index = 2, valueType = I32}
+                                            },
+                                          Break {name = "1", breakCondition = Nothing}
+                                        ],
+                                      blockReturnTypes = []
+                                    },
+                                  SetLocal
+                                    { index = 0,
+                                      value =
+                                        GetLocal
                                           { index = 0,
                                             valueType = F64
-                                          },
-                                        operand1 = ConstF64 0x1p-969
-                                      }
-                                  },
-                                SetLocal
-                                  { index = 1,
-                                    value = Binary
-                                      { binaryOp = AddInt32,
-                                        operand0 = If
-                                          { condition = Binary
-                                              { binaryOp = GtSInt32,
-                                                operand0 = GetLocal
-                                                  { index = 1,
-                                                    valueType = I32
-                                                  },
-                                                operand1 = ConstI32 (-2960)
-                                              },
-                                            ifTrue = GetLocal
-                                              { index = 1,
-                                                valueType = I32
-                                              },
-                                            ifFalse = Just $ ConstI32 (-2960)
-                                          },
-                                        operand1 = ConstI32 1938
-                                      }
-                                  }
-                              ],
-                            blockReturnTypes = []
-                          },
-                        Binary
-                          { binaryOp = MulFloat64,
-                            operand0 = GetLocal {index = 0, valueType = F64},
-                            operand1 = Unary
-                              { unaryOp = ReinterpretInt64,
-                                operand0 = Binary
-                                  { binaryOp = ShlInt64,
-                                    operand0 = Unary
-                                      { unaryOp = ExtendUInt32,
-                                        operand0 = Binary
-                                          { binaryOp = AddInt32,
-                                            operand0 = GetLocal
-                                              { index = 1,
-                                                valueType = I32
-                                              },
-                                            operand1 = ConstI32 1023
                                           }
-                                      },
-                                    operand1 = ConstI64 52
-                                  }
-                              }
-                          }
-                      ],
-                    blockReturnTypes = [F64]
-                  }
+                                          `mulFloat64` ConstF64 0x1p-969
+                                    },
+                                  SetLocal
+                                    { index = 1,
+                                      value =
+                                        If
+                                          { condition =
+                                              GetLocal
+                                                { index = 1,
+                                                  valueType = I32
+                                                }
+                                                `gtSInt32` ConstI32 (-2960),
+                                            ifTrue =
+                                              GetLocal
+                                                { index = 1,
+                                                  valueType = I32
+                                                },
+                                            ifFalse = Just $ ConstI32 (-2960)
+                                          }
+                                          `addInt32` ConstI32 1938
+                                    }
+                                ],
+                              blockReturnTypes = []
+                            },
+                          GetLocal {index = 0, valueType = F64}
+                            `mulFloat64` reinterpretInt64
+                              ( extendUInt32
+                                  ( GetLocal
+                                      { index = 1,
+                                        valueType = I32
+                                      }
+                                      `addInt32` ConstI32 1023
+                                  )
+                                  `shlInt64` ConstI64 52
+                              )
+                        ],
+                      blockReturnTypes = [F64]
+                    }
               }
           )
         ]

--- a/asterius/src/Asterius/Builtins/StgPrimFloat.hs
+++ b/asterius/src/Asterius/Builtins/StgPrimFloat.hs
@@ -16,39 +16,35 @@ wordEncodeDouble, wordEncodeFloat :: AsteriusModule
 wordEncodeDouble = runEDSL "__word_encodeDouble" $ do
   setReturnTypes [F64]
   [j, e] <- params [I64, I64]
-  r <- local F64 $ Unary ConvertUInt64ToFloat64 j
+  r <- local F64 $ convertUInt64ToFloat64 j
   r' <- call' "scalbn" [r, truncExponent e] F64
-  emit If
-    { condition = Binary NeFloat64 r (ConstF64 0.0),
-      ifTrue = r',
-      ifFalse = Just r
-    }
+  emit
+    If
+      { condition = r `neFloat64` ConstF64 0.0,
+        ifTrue = r',
+        ifFalse = Just r
+      }
 wordEncodeFloat = runEDSL "__word_encodeFloat" $ do
   setReturnTypes [F32]
   [j, e] <- params [I64, I64]
   r <- call' "__word_encodeDouble" [j, e] F64
-  emit $ Unary DemoteFloat64 r
+  emit $ demoteFloat64 r
 
 truncExponent :: Expression -> Expression
-truncExponent e = Unary
-  { unaryOp = WrapInt64,
-    operand0 = If
-      { condition = Binary
-          { binaryOp = GtSInt64,
-            operand0 = e,
-            operand1 = ConstI64 2147483647
-          },
+truncExponent e =
+  wrapInt64
+    If
+      { condition =
+          e `gtSInt64` ConstI64 2147483647,
         ifTrue = ConstI64 2147483647,
-        ifFalse = Just If
-          { condition = Binary
-              { binaryOp = LtSInt64,
-                operand0 = e,
-                operand1 =
-                  ConstI64
-                    (-2147483648)
-              },
-            ifTrue = ConstI64 (-2147483648),
-            ifFalse = Just e
-          }
+        ifFalse =
+          Just
+            If
+              { condition =
+                  e
+                    `ltSInt64` ConstI64
+                      (-2147483648),
+                ifTrue = ConstI64 (-2147483648),
+                ifFalse = Just e
+              }
       }
-  }

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -859,23 +859,23 @@ marshalCmmPrimCall (GHC.MO_Memcmp _) [_cres] [_ptr1, _ptr2, _n] = do
         }
     ]
 marshalCmmPrimCall (GHC.MO_PopCnt GHC.W64) [r] [x] =
-  marshalCmmUnPrimCall I64 r I64 x popCntInt64
+  marshalCmmUnPrimCall I64 r I64 x popcntInt64
 marshalCmmPrimCall (GHC.MO_PopCnt GHC.W32) [r] [x] = do
-  marshalCmmUnPrimCall I64 r I32 x (extendSInt32 . popCntInt32)
+  marshalCmmUnPrimCall I64 r I32 x (extendSInt32 . popcntInt32)
 marshalCmmPrimCall (GHC.MO_PopCnt GHC.W16) [r] [x] = do
   marshalCmmUnPrimCall
     I64
     r
     I32
     x
-    (extendSInt32 . popCntInt32 . andInt32 (constI32 0xFFFF))
+    (extendSInt32 . popcntInt32 . andInt32 (constI32 0xFFFF))
 marshalCmmPrimCall (GHC.MO_PopCnt GHC.W8) [r] [x] = do
   marshalCmmUnPrimCall
     I64
     r
     I32
     x
-    (extendSInt32 . popCntInt32 . andInt32 (constI32 0xFF))
+    (extendSInt32 . popcntInt32 . andInt32 (constI32 0xFF))
 marshalCmmPrimCall (GHC.MO_Clz GHC.W64) [r] [x] =
   marshalCmmUnPrimCall I64 r I64 x clzInt64
 marshalCmmPrimCall (GHC.MO_Clz GHC.W32) [r] [x] =

--- a/asterius/src/Asterius/EDSL.hs
+++ b/asterius/src/Asterius/EDSL.hs
@@ -52,49 +52,8 @@ module Asterius.EDSL
     break',
     whileLoop,
     switchI64,
-    notInt64,
-    notInt32,
-    eqZInt64,
-    eqZInt32,
-    extendUInt32,
-    extendSInt32,
-    wrapInt64,
-    convertUInt64ToFloat64,
-    truncUFloat64ToInt64,
-    convertSInt64ToFloat64,
-    truncSFloat64ToInt64,
-    roundupBytesToWords,
-    popCntInt32,
-    clzInt32,
-    ctzInt32,
-    popCntInt64,
-    clzInt64,
-    ctzInt64,
-    addInt64,
-    subInt64,
-    mulInt64,
-    divUInt64,
-    gtUInt64,
-    geUInt64,
-    shlInt64,
-    shrUInt64,
-    xorInt64,
-    geUInt32,
-    addInt32,
-    subInt32,
-    mulInt32,
-    shlInt32,
-    eqInt64,
-    eqInt32,
-    ltUInt64,
-    leUInt64,
-    ltUInt32,
-    neInt64,
-    neInt32,
-    andInt64,
-    orInt64,
-    andInt32,
-    orInt32,
+    module Asterius.EDSL.BinaryOp,
+    module Asterius.EDSL.UnaryOp,
     symbol,
     symbol',
     constI32,
@@ -110,6 +69,8 @@ module Asterius.EDSL
   )
 where
 
+import Asterius.EDSL.BinaryOp
+import Asterius.EDSL.UnaryOp
 import Asterius.Internals
 import Asterius.Passes.All
 import Asterius.Passes.Barf
@@ -481,96 +442,6 @@ allocStaticBytes n v = EDSL $ state $ \st ->
                 : staticsBuf st
           }
    in (symbol n, st')
-
-notInt64,
-  notInt32,
-  eqZInt64,
-  eqZInt32,
-  extendUInt32,
-  extendSInt32,
-  wrapInt64,
-  convertUInt64ToFloat64,
-  truncUFloat64ToInt64,
-  convertSInt64ToFloat64,
-  truncSFloat64ToInt64,
-  roundupBytesToWords,
-  popCntInt32,
-  clzInt32,
-  ctzInt32,
-  popCntInt64,
-  clzInt64,
-  ctzInt64 ::
-    Expression -> Expression
-notInt64 = eqZInt64
-notInt32 = eqZInt32
-eqZInt64 = Unary EqZInt64
-eqZInt32 = Unary EqZInt32
-extendUInt32 = Unary ExtendUInt32
-extendSInt32 = Unary ExtendSInt32
-wrapInt64 = Unary WrapInt64
-convertUInt64ToFloat64 = Unary ConvertUInt64ToFloat64
-truncUFloat64ToInt64 = Unary TruncUFloat64ToInt64
-convertSInt64ToFloat64 = Unary ConvertSInt64ToFloat64
-truncSFloat64ToInt64 = Unary TruncSFloat64ToInt64
-roundupBytesToWords n = (n `addInt64` constI64 7) `divUInt64` constI64 8
-popCntInt32 = Unary PopcntInt32
-clzInt32 = Unary ClzInt32
-ctzInt32 = Unary CtzInt32
-popCntInt64 = Unary PopcntInt64
-clzInt64 = Unary ClzInt64
-ctzInt64 = Unary CtzInt64
-
-addInt64,
-  subInt64,
-  mulInt64,
-  divUInt64,
-  gtUInt64,
-  geUInt64,
-  shlInt64,
-  shrUInt64,
-  xorInt64,
-  geUInt32,
-  addInt32,
-  subInt32,
-  mulInt32,
-  eqInt64,
-  eqInt32,
-  ltUInt64,
-  leUInt64,
-  ltUInt32,
-  neInt64,
-  neInt32,
-  andInt64,
-  orInt64,
-  andInt32,
-  orInt32,
-  shlInt32 ::
-    Expression -> Expression -> Expression
-addInt64 = Binary AddInt64
-subInt64 = Binary SubInt64
-mulInt64 = Binary MulInt64
-divUInt64 = Binary DivUInt64
-gtUInt64 = Binary GtUInt64
-geUInt64 = Binary GeUInt64
-shlInt64 = Binary ShlInt64
-shrUInt64 = Binary ShrUInt64
-xorInt64 = Binary XorInt64
-geUInt32 = Binary GeUInt32
-addInt32 = Binary AddInt32
-subInt32 = Binary SubInt32
-mulInt32 = Binary MulInt32
-shlInt32 = Binary ShlInt32
-eqInt64 = Binary EqInt64
-eqInt32 = Binary EqInt32
-ltUInt64 = Binary LtUInt64
-leUInt64 = Binary LeUInt64
-ltUInt32 = Binary LtUInt32
-neInt64 = Binary NeInt64
-neInt32 = Binary NeInt32
-andInt64 = Binary AndInt64
-orInt64 = Binary OrInt64
-andInt32 = Binary AndInt32
-orInt32 = Binary OrInt32
 
 symbol :: AsteriusEntitySymbol -> Expression
 symbol = flip symbol' 0

--- a/asterius/src/Asterius/EDSL/BinaryOp.hs
+++ b/asterius/src/Asterius/EDSL/BinaryOp.hs
@@ -1,0 +1,157 @@
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+
+module Asterius.EDSL.BinaryOp where
+
+import Asterius.Types
+
+addInt32 = Binary AddInt32
+
+subInt32 = Binary SubInt32
+
+mulInt32 = Binary MulInt32
+
+divSInt32 = Binary DivSInt32
+
+divUInt32 = Binary DivUInt32
+
+remSInt32 = Binary RemSInt32
+
+remUInt32 = Binary RemUInt32
+
+andInt32 = Binary AndInt32
+
+orInt32 = Binary OrInt32
+
+xorInt32 = Binary XorInt32
+
+shlInt32 = Binary ShlInt32
+
+shrUInt32 = Binary ShrUInt32
+
+shrSInt32 = Binary ShrSInt32
+
+rotLInt32 = Binary RotLInt32
+
+rotRInt32 = Binary RotRInt32
+
+eqInt32 = Binary EqInt32
+
+neInt32 = Binary NeInt32
+
+ltSInt32 = Binary LtSInt32
+
+ltUInt32 = Binary LtUInt32
+
+leSInt32 = Binary LeSInt32
+
+leUInt32 = Binary LeUInt32
+
+gtSInt32 = Binary GtSInt32
+
+gtUInt32 = Binary GtUInt32
+
+geSInt32 = Binary GeSInt32
+
+geUInt32 = Binary GeUInt32
+
+addInt64 = Binary AddInt64
+
+subInt64 = Binary SubInt64
+
+mulInt64 = Binary MulInt64
+
+divSInt64 = Binary DivSInt64
+
+divUInt64 = Binary DivUInt64
+
+remSInt64 = Binary RemSInt64
+
+remUInt64 = Binary RemUInt64
+
+andInt64 = Binary AndInt64
+
+orInt64 = Binary OrInt64
+
+xorInt64 = Binary XorInt64
+
+shlInt64 = Binary ShlInt64
+
+shrUInt64 = Binary ShrUInt64
+
+shrSInt64 = Binary ShrSInt64
+
+rotLInt64 = Binary RotLInt64
+
+rotRInt64 = Binary RotRInt64
+
+eqInt64 = Binary EqInt64
+
+neInt64 = Binary NeInt64
+
+ltSInt64 = Binary LtSInt64
+
+ltUInt64 = Binary LtUInt64
+
+leSInt64 = Binary LeSInt64
+
+leUInt64 = Binary LeUInt64
+
+gtSInt64 = Binary GtSInt64
+
+gtUInt64 = Binary GtUInt64
+
+geSInt64 = Binary GeSInt64
+
+geUInt64 = Binary GeUInt64
+
+addFloat32 = Binary AddFloat32
+
+subFloat32 = Binary SubFloat32
+
+mulFloat32 = Binary MulFloat32
+
+divFloat32 = Binary DivFloat32
+
+copySignFloat32 = Binary CopySignFloat32
+
+minFloat32 = Binary MinFloat32
+
+maxFloat32 = Binary MaxFloat32
+
+eqFloat32 = Binary EqFloat32
+
+neFloat32 = Binary NeFloat32
+
+ltFloat32 = Binary LtFloat32
+
+leFloat32 = Binary LeFloat32
+
+gtFloat32 = Binary GtFloat32
+
+geFloat32 = Binary GeFloat32
+
+addFloat64 = Binary AddFloat64
+
+subFloat64 = Binary SubFloat64
+
+mulFloat64 = Binary MulFloat64
+
+divFloat64 = Binary DivFloat64
+
+copySignFloat64 = Binary CopySignFloat64
+
+minFloat64 = Binary MinFloat64
+
+maxFloat64 = Binary MaxFloat64
+
+eqFloat64 = Binary EqFloat64
+
+neFloat64 = Binary NeFloat64
+
+ltFloat64 = Binary LtFloat64
+
+leFloat64 = Binary LeFloat64
+
+gtFloat64 = Binary GtFloat64
+
+geFloat64 = Binary GeFloat64

--- a/asterius/src/Asterius/EDSL/UnaryOp.hs
+++ b/asterius/src/Asterius/EDSL/UnaryOp.hs
@@ -1,0 +1,99 @@
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+
+module Asterius.EDSL.UnaryOp where
+
+import Asterius.Types
+
+clzInt32 = Unary ClzInt32
+
+ctzInt32 = Unary CtzInt32
+
+popcntInt32 = Unary PopcntInt32
+
+negFloat32 = Unary NegFloat32
+
+absFloat32 = Unary AbsFloat32
+
+ceilFloat32 = Unary CeilFloat32
+
+floorFloat32 = Unary FloorFloat32
+
+truncFloat32 = Unary TruncFloat32
+
+nearestFloat32 = Unary NearestFloat32
+
+sqrtFloat32 = Unary SqrtFloat32
+
+eqZInt32 = Unary EqZInt32
+
+clzInt64 = Unary ClzInt64
+
+ctzInt64 = Unary CtzInt64
+
+popcntInt64 = Unary PopcntInt64
+
+negFloat64 = Unary NegFloat64
+
+absFloat64 = Unary AbsFloat64
+
+ceilFloat64 = Unary CeilFloat64
+
+floorFloat64 = Unary FloorFloat64
+
+truncFloat64 = Unary TruncFloat64
+
+nearestFloat64 = Unary NearestFloat64
+
+sqrtFloat64 = Unary SqrtFloat64
+
+eqZInt64 = Unary EqZInt64
+
+extendSInt32 = Unary ExtendSInt32
+
+extendUInt32 = Unary ExtendUInt32
+
+wrapInt64 = Unary WrapInt64
+
+truncSFloat32ToInt32 = Unary TruncSFloat32ToInt32
+
+truncSFloat32ToInt64 = Unary TruncSFloat32ToInt64
+
+truncUFloat32ToInt32 = Unary TruncUFloat32ToInt32
+
+truncUFloat32ToInt64 = Unary TruncUFloat32ToInt64
+
+truncSFloat64ToInt32 = Unary TruncSFloat64ToInt32
+
+truncSFloat64ToInt64 = Unary TruncSFloat64ToInt64
+
+truncUFloat64ToInt32 = Unary TruncUFloat64ToInt32
+
+truncUFloat64ToInt64 = Unary TruncUFloat64ToInt64
+
+reinterpretFloat32 = Unary ReinterpretFloat32
+
+reinterpretFloat64 = Unary ReinterpretFloat64
+
+convertSInt32ToFloat32 = Unary ConvertSInt32ToFloat32
+
+convertSInt32ToFloat64 = Unary ConvertSInt32ToFloat64
+
+convertUInt32ToFloat32 = Unary ConvertUInt32ToFloat32
+
+convertUInt32ToFloat64 = Unary ConvertUInt32ToFloat64
+
+convertSInt64ToFloat32 = Unary ConvertSInt64ToFloat32
+
+convertSInt64ToFloat64 = Unary ConvertSInt64ToFloat64
+
+convertUInt64ToFloat32 = Unary ConvertUInt64ToFloat32
+
+convertUInt64ToFloat64 = Unary ConvertUInt64ToFloat64
+
+promoteFloat32 = Unary PromoteFloat32
+
+demoteFloat64 = Unary DemoteFloat64
+
+reinterpretInt32 = Unary ReinterpretInt32
+
+reinterpretInt64 = Unary ReinterpretInt64

--- a/asterius/src/Asterius/Passes/GlobalRegs.hs
+++ b/asterius/src/Asterius/Passes/GlobalRegs.hs
@@ -1,5 +1,5 @@
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 
 module Asterius.Passes.GlobalRegs
   ( unresolvedGetGlobal,
@@ -7,6 +7,7 @@ module Asterius.Passes.GlobalRegs
   )
 where
 
+import Asterius.EDSL.UnaryOp
 import Asterius.Types
 import Language.Haskell.GHC.Toolkit.Constants
 
@@ -55,7 +56,7 @@ globalRegInfo gr = case gr of
 
 mainCap, mainCap32, baseReg :: Expression
 mainCap = Symbol {unresolvedSymbol = "MainCapability", symbolOffset = 0}
-mainCap32 = Unary {unaryOp = WrapInt64, operand0 = mainCap}
+mainCap32 = wrapInt64 mainCap
 baseReg = mainCap {symbolOffset = offset_Capability_r}
 
 unresolvedGetGlobal :: UnresolvedGlobalReg -> Expression

--- a/asterius/src/Asterius/Passes/MergeSymbolOffset.hs
+++ b/asterius/src/Asterius/Passes/MergeSymbolOffset.hs
@@ -6,6 +6,7 @@ module Asterius.Passes.MergeSymbolOffset
   )
 where
 
+import Asterius.EDSL
 import Asterius.Internals.SYB
 import Asterius.Types
 import Data.Word
@@ -33,19 +34,13 @@ mergeSymbolOffset t =
             bytes = bytes,
             offset = noNeg t $ symbolOffset + fromIntegral offset,
             valueType = valueType,
-            ptr = Unary
-              { unaryOp = WrapInt64,
-                operand0 = sym {symbolOffset = 0}
-              }
+            ptr = wrapInt64 $ sym {symbolOffset = 0}
           }
       Store {ptr = Unary {unaryOp = WrapInt64, operand0 = sym@Symbol {..}}, ..} ->
         Store
           { bytes = bytes,
             offset = noNeg t $ symbolOffset + fromIntegral offset,
-            ptr = Unary
-              { unaryOp = WrapInt64,
-                operand0 = sym {symbolOffset = 0}
-              },
+            ptr = wrapInt64 $ sym {symbolOffset = 0},
             value = value,
             valueType = valueType
           }


### PR DESCRIPTION
This PR adds a simple improvement to the EDSL: all unary/binary ops are added as `Expression -> Expression` and `Expression -> Expression -> Expression` functions. When building `Expression`s in the `asterius` codebase, we can avoid writing `Unary` and `Binary` records.

The EDSL improvements are scheduled before migrating more rts js logic to wasm.