### PR TITLE
Tuning ghc testsuite timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,7 @@ jobs:
 
 
               # run test cases that can fail.
-              stack --no-terminal test asterius:ghc-testsuite --test-arguments="-j2 --timeout=180s" || true
+              stack --no-terminal test asterius:ghc-testsuite --test-arguments="-j2 --timeout=600s" || true
               cp asterius/test-report.csv /tmp
 
       - store_artifacts:
@@ -326,7 +326,7 @@ jobs:
 
 
               # run test cases that can fail.
-              stack --no-terminal test asterius:ghc-testsuite --test-arguments="-j2 --timeout=180s" || true
+              stack --no-terminal test asterius:ghc-testsuite --test-arguments="-j2 --timeout=600s" || true
               cp asterius/test-report.csv /tmp
 
       - store_artifacts:
@@ -391,7 +391,7 @@ jobs:
 
 
               # run test cases that can fail.
-              stack --no-terminal test asterius:ghc-testsuite --test-arguments="-j2 --timeout=180s" || true
+              stack --no-terminal test asterius:ghc-testsuite --test-arguments="-j2 --timeout=600s" || true
               cp asterius/test-report.csv /tmp
 
       - store_artifacts:
@@ -456,7 +456,7 @@ jobs:
 
 
               # run test cases that can fail.
-              stack --no-terminal test asterius:ghc-testsuite --test-arguments="-j2 --timeout=180s" || true
+              stack --no-terminal test asterius:ghc-testsuite --test-arguments="-j2 --timeout=600s" || true
               cp asterius/test-report.csv /tmp
 
       - store_artifacts:


### PR DESCRIPTION
This PR adjusts the `tasty` timeout for individual test cases of `ghc-testsuite`. Currently, when we try to diff the CSV reports of `debug` and `vanilla` flavours of the test run, the additional failures in the `debug` report are all simply `AsyncCancelled`, which is most likely caused by `tasty` timeouts.