### PR TITLE
Fix Cabal 3 support of ghc-toolkit

### DIFF
--- a/ghc-toolkit/Setup.hs
+++ b/ghc-toolkit/Setup.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wall #-}
 
@@ -10,6 +11,7 @@ import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.Program
 import Distribution.Types.BuildInfo
 import Distribution.Types.Library
+import Distribution.Types.LocalBuildInfo
 import Distribution.Types.PackageDescription
 import System.Directory
 import System.FilePath
@@ -23,7 +25,7 @@ main =
           lbi@LocalBuildInfo {localPkgDescr = pkg_descr@PackageDescription {library = Just lib@Library {libBuildInfo = bi}}, compiler = Compiler {compilerProperties = m}, withPrograms = prog_db} <-
             confHook simpleUserHooks t f
           let [clbi@LibComponentLocalBuildInfo {componentUnitId = uid}] =
-                componentNameMap lbi M.! CLibName
+                componentNameCLBIs lbi mainLibName
               amp = autogenComponentModulesDir lbi clbi
               self_installdirs =
                 absoluteComponentInstallDirs pkg_descr lbi uid NoCopyDest
@@ -72,3 +74,10 @@ main =
                     }
               }
       }
+
+mainLibName :: ComponentName
+#if MIN_VERSION_Cabal(3,0,0)
+mainLibName = CLibName defaultLibName
+#else
+mainLibName = defaultLibName
+#endif

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/GenPaths.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/GenPaths.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StrictData #-}
 
@@ -15,6 +16,7 @@ import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.Program
 import Distribution.Types.BuildInfo
 import Distribution.Types.Library
+import Distribution.Types.LocalBuildInfo
 import Distribution.Types.PackageDescription
 import System.Directory
 import System.FilePath
@@ -30,7 +32,7 @@ genPaths GenPathsOptions {..} h =
     { confHook = \t f -> do
         lbi@LocalBuildInfo {localPkgDescr = pkg_descr@PackageDescription {library = Just lib@Library {libBuildInfo = lib_bi}}} <-
           confHook h t f
-        let [clbi] = componentNameMap lbi M.! CLibName
+        let [clbi] = componentNameCLBIs lbi mainLibName
             mod_path = autogenComponentModulesDir lbi clbi
             mod_name = fromString targetModuleName
             ghc_libdir = compilerProperties (compiler lbi) M.! "LibDir"
@@ -89,3 +91,10 @@ genPaths GenPathsOptions {..} h =
                   }
             }
     }
+
+mainLibName :: ComponentName
+#if MIN_VERSION_Cabal(3,0,0)
+mainLibName = CLibName defaultLibName
+#else
+mainLibName = defaultLibName
+#endif


### PR DESCRIPTION
On top of #437 

This PR fixes `ghc-toolkit` to support being compiled by `Cabal-3`, since there are breaking changes in `Cabal` public API as usual. Note that this doesn't mean `ghc-toolkit` automatically works with `ghc-8.8`; the `8.8`-specific fixes of the library and the shipped boot lib artifacts are present in other branches.