### PR TITLE
Implement selector optimisation

### DIFF
--- a/asterius/src/Asterius/Ld.hs
+++ b/asterius/src/Asterius/Ld.hs
@@ -68,6 +68,8 @@ rtsUsedSymbols =
       "Main_main_closure",
       "stg_ARR_WORDS_info",
       "stg_BLACKHOLE_info",
+      "stg_WHITEHOLE_info",
+      "stg_IND_info",
       "stg_DEAD_WEAK_info",
       "stg_marked_upd_frame_info",
       "stg_NO_FINALIZER_closure",


### PR DESCRIPTION
_Selector optimisation_ is a known optimisation where thunks of applications of field selectors are evaluated during garbage collection, so to avoid space leaks caused by unused fields that look alive.

This PR fixes #422 by introducing the new function `GC.stingyEval`, which shorts-out chains made out of selector/constructor and/or indirections (also interleaved).

Note: `GC.stingyEval` uses a technique called _whiteholing_, where closures in the chain that is being explored are replaced with "whiteholes", in order to not diverge in case of cyclic closures.

- [x] Expose the necessary info pointers as `AsteriusEntitySymbol`s
- [x] Implement whiteholing
- [x] Double-check propagation of dynamic tags
