### PR TITLE
Implement POSIX File I/O for rts, part II

### DIFF
--- a/asterius/rts/browser/default.mjs
+++ b/asterius/rts/browser/default.mjs
@@ -9,8 +9,17 @@ class Posix {
   close() {
     throw WebAssembly.RuntimeError("Unsupported rts interface: close");
   }
+  stat() {
+    throw WebAssembly.RuntimeError("Unsupported rts interface: stat");
+  }
   fstat() {
     throw WebAssembly.RuntimeError("Unsupported rts interface: fstat");
+  }
+  readdir() {
+    throw WebAssembly.RuntimeError("Unsupported rts interface: readdir");
+  }
+  closedir() {
+    throw WebAssembly.RuntimeError("Unsupported rts interface: closedir");
   }
 }
 

--- a/asterius/rts/node/default.mjs
+++ b/asterius/rts/node/default.mjs
@@ -8,7 +8,9 @@ class Posix {
   constructor(memory, rtsConstants) {
     this.memory = memory;
     this.rtsConstants = rtsConstants;
-    Object.freeze(this);
+    this.dirs = new Map();
+    this.lastDir = 0;
+    Object.seal(this);
   }
   open(f, h, m) {
     return fs.openSync(this.memory.strLoad(f), h, m);
@@ -28,6 +30,11 @@ class Posix {
     this.memory.i64Store(b + this.rtsConstants.offset_stat_dev, r.dev);
     this.memory.i64Store(b + this.rtsConstants.offset_stat_ino, r.ino);
     return 0;
+  }
+  opendir(p) {
+    const dir = fs.opendirSync(this.memory.strLoad(p));
+    this.dirs.set(++this.lastDir, dir);
+    return this.lastDir;
   }
 }
 

--- a/asterius/src/Asterius/Builtins/Posix.hs
+++ b/asterius/src/Asterius/Builtins/Posix.hs
@@ -76,6 +76,8 @@ posixCBits =
     <> posixLockFile
     <> posixUnlockFile
     <> posixOpendir
+    <> posixGetErrno
+    <> posixSetErrno
 
 posixOpen :: AsteriusModule
 posixOpen = runEDSL "__hscore_open" $ do
@@ -250,3 +252,13 @@ posixOpendir =
           [convertSInt64ToFloat64 p]
           F64
         >>= emit
+
+posixGetErrno :: AsteriusModule
+posixGetErrno = runEDSL "__hscore_get_errno" $ do
+  setReturnTypes [I64]
+  emit $ constI64 0
+
+posixSetErrno :: AsteriusModule
+posixSetErrno = runEDSL "__hscore_set_errno" $ do
+  _ <- param I64
+  pure ()


### PR DESCRIPTION
Following #441, this implements `stat`, `readdir` and `closedir` for the node `rts`.

One annoyance when doing this PR: `unix` uses the `capi` convention for `opendir`. When implementing `opendir` as a builtin function, we have to query the complete unit-id of `unix` in order to assemble the complete `opendir` symbol name. In order to do that, we launch a GHC API session and query the global package database. This is not neat. Patching `unix` can spare us this trouble but I'd like to avoid patching standard libs for now..

Another annoyance: `readdir` needs to pass `dirent` entries on every invocation. The POSIX standard says: don't call `free()` on the returned pointer, since it might be in a static section! Which means it's global. And not thread-safe. So here we have the same pitfall: we simply have a global buffer for `dirent`, and it's reused across all `readdir` invocations. If you call it from multiple Haskell threads...you are a power user and ought to be punished with a race condition. (it seems the native `directory` package has the same problem?)