### PR TITLE
Add "ignore" option to ahc-ld

### DIFF
--- a/asterius/app/ahc-ld.hs
+++ b/asterius/app/ahc-ld.hs
@@ -58,4 +58,5 @@ main = do
       rsp <- readFile rsp_path
       let rsp_args = map read $ lines rsp
       task <- parseLinkTask rsp_args
-      linkExe task
+      ignore <- isJust <$> getEnv "ASTERIUS_AHC_LD_IGNORE"
+      if ignore then writeFile "" (linkOutput task) else linkExe task


### PR DESCRIPTION
This PR adds an "ignore" option to `ahc-ld`: when `ASTERIUS_AHC_LD_IGNORE` is set in the environment variables, `ahc-ld` skips linking logic and simply touches the output executable path.

This is not intended to be used by end-users of `asterius`; but it's useful for the docker image builder, since we always delete the pseudo-executables of prebuilt packages anyway, and it would be better to avoid actual linking in the first place.