### PR TITLE
More POSIX stuff

### DIFF
--- a/asterius/rts/browser/default.mjs
+++ b/asterius/rts/browser/default.mjs
@@ -3,6 +3,12 @@
  */
 
 class Posix {
+  get_errno() {
+    throw WebAssembly.RuntimeError("Unsupported rts interface: get_errno");
+  }
+  set_errno() {
+    throw WebAssembly.RuntimeError("Unsupported rts interface: set_errno");
+  }
   open() {
     throw WebAssembly.RuntimeError("Unsupported rts interface: open");
   }

--- a/asterius/rts/browser/default.mjs
+++ b/asterius/rts/browser/default.mjs
@@ -21,6 +21,9 @@ class Posix {
   closedir() {
     throw WebAssembly.RuntimeError("Unsupported rts interface: closedir");
   }
+  getenv() {
+    throw WebAssembly.RuntimeError("Unsupported rts interface: getenv");
+  }
 }
 
 export default {

--- a/asterius/rts/browser/default.mjs
+++ b/asterius/rts/browser/default.mjs
@@ -33,6 +33,9 @@ class Posix {
   access() {
     throw WebAssembly.RuntimeError("Unsupported rts interface: access");
   }
+  getcwd() {
+    throw WebAssembly.RuntimeError("Unsupported rts interface: getcwd");
+  }
 }
 
 export default {

--- a/asterius/rts/browser/default.mjs
+++ b/asterius/rts/browser/default.mjs
@@ -30,6 +30,9 @@ class Posix {
   getenv() {
     throw WebAssembly.RuntimeError("Unsupported rts interface: getenv");
   }
+  access() {
+    throw WebAssembly.RuntimeError("Unsupported rts interface: access");
+  }
 }
 
 export default {

--- a/asterius/rts/node/default.mjs
+++ b/asterius/rts/node/default.mjs
@@ -70,6 +70,24 @@ class Posix {
     this.dirs.delete(dirPtr);
     return 0;
   }
+  getenv(keyPtr, resPtr) {
+    const res = process.env[this.memory.strLoad(keyPtr)];
+    if (res) {
+      const l = resPtr & 0xffffffff;
+      const { read, written } = new TextEncoder().encodeInto(
+        res,
+        this.memory.i8View.subarray(l, l + 32767)
+      );
+      if (read !== res.length)
+        throw new WebAssembly.RuntimeError(
+          `${res} exceeded environment variable limit`
+        );
+      this.memory.i8View[l + written] = 0;
+      return resPtr;
+    } else {
+      return 0;
+    }
+  }
 }
 
 export default {

--- a/asterius/rts/node/default.mjs
+++ b/asterius/rts/node/default.mjs
@@ -131,6 +131,15 @@ class Posix {
       return 0;
     }
   }
+  access(f, m) {
+    try {
+      fs.accessSync(this.memory.strLoad(f), m);
+      return 0;
+    } catch (err) {
+      this.set_errno(-err.errno);
+      return -1;
+    }
+  }
 }
 
 export default {

--- a/asterius/rts/node/default.mjs
+++ b/asterius/rts/node/default.mjs
@@ -140,6 +140,21 @@ class Posix {
       return -1;
     }
   }
+  getcwd(buf, size) {
+    const cwd = process.cwd();
+    const l = buf & 0xffffffff;
+    const { read, written } = new TextEncoder().encodeInto(
+      cwd,
+      this.memory.i8View.subarray(l, l - 1 + size)
+    );
+    this.memory.i8View[l + written] = 0;
+    if (read === cwd.length) {
+      return buf;
+    } else {
+      this.set_errno(34);
+      return 0;
+    }
+  }
 }
 
 export default {

--- a/asterius/rts/node/default.mjs
+++ b/asterius/rts/node/default.mjs
@@ -10,7 +10,14 @@ class Posix {
     this.rtsConstants = rtsConstants;
     this.dirs = new Map();
     this.lastDir = 0;
+    this.errno = 0;
     Object.seal(this);
+  }
+  get_errno() {
+    return this.errno;
+  }
+  set_errno(e) {
+    this.errno = e;
   }
   open(f, h, m) {
     return fs.openSync(this.memory.strLoad(f), h, m);

--- a/asterius/src/Asterius/Builtins/Posix.hs
+++ b/asterius/src/Asterius/Builtins/Posix.hs
@@ -32,6 +32,18 @@ import System.Posix.Internals
 posixImports :: [FunctionImport]
 posixImports =
   [ FunctionImport
+      { internalName = "__asterius_posix_get_errno",
+        externalModuleName = "posix",
+        externalBaseName = "get_errno",
+        functionType = FunctionType {paramTypes = [], returnTypes = [F64]}
+      },
+    FunctionImport
+      { internalName = "__asterius_posix_set_errno",
+        externalModuleName = "posix",
+        externalBaseName = "set_errno",
+        functionType = FunctionType {paramTypes = [F64], returnTypes = []}
+      },
+    FunctionImport
       { internalName = "__asterius_posix_open",
         externalModuleName = "posix",
         externalBaseName = "open",
@@ -311,12 +323,14 @@ posixOpendir =
 posixGetErrno :: AsteriusModule
 posixGetErrno = runEDSL "__hscore_get_errno" $ do
   setReturnTypes [I64]
-  emit $ constI64 0
+  truncSFloat64ToInt64
+    <$> callImport' "__asterius_posix_get_errno" [] F64
+    >>= emit
 
 posixSetErrno :: AsteriusModule
 posixSetErrno = runEDSL "__hscore_set_errno" $ do
-  _ <- param I64
-  pure ()
+  e <- param I64
+  callImport "__asterius_posix_opendir" [convertSInt64ToFloat64 e]
 
 posixDirentBuf :: AsteriusModule
 posixDirentBuf =

--- a/asterius/src/Asterius/Builtins/Posix.hs
+++ b/asterius/src/Asterius/Builtins/Posix.hs
@@ -110,6 +110,16 @@ posixImports =
             { paramTypes = [F64, F64],
               returnTypes = [F64]
             }
+      },
+    FunctionImport
+      { internalName = "__asterius_posix_access",
+        externalModuleName = "posix",
+        externalBaseName = "access",
+        functionType =
+          FunctionType
+            { paramTypes = [F64, F64],
+              returnTypes = [F64]
+            }
       }
   ]
 
@@ -134,6 +144,7 @@ posixCBits =
     <> posixClosedir
     <> posixGetenvBuf
     <> posixGetenv
+    <> posixAccess
 
 posixOpen :: AsteriusModule
 posixOpen = runEDSL "__hscore_open" $ do
@@ -398,5 +409,16 @@ posixGetenv = runEDSL "getenv" $ do
     <$> callImport'
       "__asterius_posix_getenv"
       (map convertSInt64ToFloat64 [p, symbol "__asterius_posix_getenv_buf"])
+      F64
+    >>= emit
+
+posixAccess :: AsteriusModule
+posixAccess = runEDSL "access" $ do
+  setReturnTypes [I64]
+  args <- params [I64, I64]
+  truncSFloat64ToInt64
+    <$> callImport'
+      "__asterius_posix_access"
+      (map convertSInt64ToFloat64 args)
       F64
     >>= emit

--- a/asterius/src/Asterius/Builtins/Posix.hs
+++ b/asterius/src/Asterius/Builtins/Posix.hs
@@ -120,6 +120,16 @@ posixImports =
             { paramTypes = [F64, F64],
               returnTypes = [F64]
             }
+      },
+    FunctionImport
+      { internalName = "__asterius_posix_getcwd",
+        externalModuleName = "posix",
+        externalBaseName = "getcwd",
+        functionType =
+          FunctionType
+            { paramTypes = [F64, F64],
+              returnTypes = [F64]
+            }
       }
   ]
 
@@ -145,6 +155,7 @@ posixCBits =
     <> posixGetenvBuf
     <> posixGetenv
     <> posixAccess
+    <> posixGetcwd
 
 posixOpen :: AsteriusModule
 posixOpen = runEDSL "__hscore_open" $ do
@@ -419,6 +430,17 @@ posixAccess = runEDSL "access" $ do
   truncSFloat64ToInt64
     <$> callImport'
       "__asterius_posix_access"
+      (map convertSInt64ToFloat64 args)
+      F64
+    >>= emit
+
+posixGetcwd :: AsteriusModule
+posixGetcwd = runEDSL "getcwd" $ do
+  setReturnTypes [I64]
+  args <- params [I64, I64]
+  truncSFloat64ToInt64
+    <$> callImport'
+      "__asterius_posix_getcwd"
       (map convertSInt64ToFloat64 args)
       F64
     >>= emit

--- a/asterius/src/Asterius/Builtins/Posix.hs
+++ b/asterius/src/Asterius/Builtins/Posix.hs
@@ -352,7 +352,7 @@ posixGetErrno = runEDSL "__hscore_get_errno" $ do
 posixSetErrno :: AsteriusModule
 posixSetErrno = runEDSL "__hscore_set_errno" $ do
   e <- param I64
-  callImport "__asterius_posix_opendir" [convertSInt64ToFloat64 e]
+  callImport "__asterius_posix_set_errno" [convertSInt64ToFloat64 e]
 
 posixDirentBuf :: AsteriusModule
 posixDirentBuf =


### PR DESCRIPTION
More POSIX stuff.

* We didn't have any handling of `errno` before; `get_errno` always returned `0` and `set_errno` was a no-op. When a `node` syscall throws, the rts would simply crash. Now, we catch the js exceptions and make the `errno` information available through the getter/setter functions.
* More POSIX stuff on the `node` side: `getenv`, `access`, `getcwd`.