### PR TITLE
Implement growable stack

### DIFF
--- a/asterius/rts/rts.scheduler.mjs
+++ b/asterius/rts/rts.scheduler.mjs
@@ -122,7 +122,16 @@ export class Scheduler {
       }
       case 2: {
         // StackOverflow
-        throw new WebAssembly.RuntimeError("StackOverflow");
+        const prev_stack = Number(
+            this.memory.i64Load(tso + rtsConstants.offset_StgTSO_stackobj)
+          ),
+          next_stack = this.exports.growStack(prev_stack);
+        this.memory.i64Store(
+          tso + rtsConstants.offset_StgTSO_stackobj,
+          next_stack
+        );
+        this.runQueue.push(tid);
+        this.submitCmdWakeUp();
         break;
       }
       case 3: {

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -1065,9 +1065,9 @@ createThreadFunction BuiltinsOptions {..} = runEDSL "createThread" $ do
       "allocatePinned"
       [mainCapability, constI64 $ roundup_bytes_to_words sizeof_StgTSO]
       I64
-  stack_p <- call' "allocatePinned" [mainCapability, constI64 65536] I64
+  stack_p <- call' "allocatePinned" [mainCapability, constI64 4096] I64
   storeI64 stack_p 0 $ symbol "stg_STACK_info"
-  stack_size_w <- i64Local $ constI64 $ (65536 - offset_StgStack_stack) `div` 8
+  stack_size_w <- i64Local $ constI64 $ (4096 - offset_StgStack_stack) `div` 8
   storeI32 stack_p offset_StgStack_stack_size $ wrapInt64 stack_size_w
   storeI64 stack_p offset_StgStack_sp $
     (stack_p `addInt64` constI64 offset_StgStack_stack)

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -22,6 +22,7 @@ import Asterius.Builtins.CMath
 import Asterius.Builtins.Hashable
 import Asterius.Builtins.MD5
 import Asterius.Builtins.Posix
+import Asterius.Builtins.SM
 import Asterius.Builtins.StgPrimFloat
 import Asterius.Builtins.Time
 import Asterius.EDSL
@@ -194,6 +195,8 @@ rtsAsteriusModule opts =
     -- the module wrapped by using `generateWrapperModule`.
     <> generateRtsExternalInterfaceModule opts
     <> generateWrapperModule (generateRtsExternalInterfaceModule opts)
+    <> smCBits
+    <> generateWrapperModule smCBits
     <> cmathCBits
     <> hashableCBits
     <> md5CBits
@@ -707,7 +710,8 @@ rtsFunctionExports debug =
           "getStablePtr",
           "deRefStablePtr",
           "hs_free_stable_ptr",
-          "makeStableName"
+          "makeStableName",
+          "growStack"
         ]
   ]
     <> [ FunctionExport {internalName = "__asterius_" <> f, externalName = f}

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -46,7 +46,6 @@ wasmPageSize = 65536
 data BuiltinsOptions
   = BuiltinsOptions
       { progName :: String,
-        threadStateSize :: Int,
         debug, hasMain :: Bool,
         jsvalConInfo :: Maybe AsteriusEntitySymbol
       }
@@ -56,7 +55,6 @@ defaultBuiltinsOptions = BuiltinsOptions
   { progName =
       error
         "Asterius.Builtins.defaultBuiltinsOptions: unknown progName",
-    threadStateSize = 65536,
     debug = False,
     hasMain = True,
     jsvalConInfo =
@@ -1058,15 +1056,14 @@ getThreadIdFunction BuiltinsOptions {} = runEDSL "rts_getThreadId" $ do
 
 createThreadFunction BuiltinsOptions {..} = runEDSL "createThread" $ do
   setReturnTypes [I64]
-  let alloc_words = constI64 $ roundup_bytes_to_words threadStateSize
-  tso_p <- call' "allocatePinned" [mainCapability, alloc_words] I64
-  stack_p <- i64Local $ tso_p `addInt64` constI64 offset_StgTSO_StgStack
+  tso_p <-
+    call'
+      "allocatePinned"
+      [mainCapability, constI64 $ roundup_bytes_to_words sizeof_StgTSO]
+      I64
+  stack_p <- call' "allocatePinned" [mainCapability, constI64 65536] I64
   storeI64 stack_p 0 $ symbol "stg_STACK_info"
-  stack_size_w <-
-    i64Local $
-      alloc_words
-        `subInt64` constI64
-          ((offset_StgTSO_StgStack + offset_StgStack_stack) `div` 8)
+  stack_size_w <- i64Local $ constI64 $ (65536 - offset_StgStack_stack) `div` 8
   storeI32 stack_p offset_StgStack_stack_size $ wrapInt64 stack_size_w
   storeI64 stack_p offset_StgStack_sp $
     (stack_p `addInt64` constI64 offset_StgStack_stack)
@@ -1578,9 +1575,6 @@ getF64GlobalRegFunction ::
 getF64GlobalRegFunction _ n gr = runEDSL n $ do
   setReturnTypes [F64]
   emit $ convertSInt64ToFloat64 $ getLVal $ global gr
-
-offset_StgTSO_StgStack :: Int
-offset_StgTSO_StgStack = 8 * roundup_bytes_to_words sizeof_StgTSO
 
 -- @cheng: there is a trade-off here: Either I emit the low-level
 -- store and load, or I expose a _lot more_ from the EDSL

--- a/asterius/src/Asterius/Builtins/SM.hs
+++ b/asterius/src/Asterius/Builtins/SM.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Asterius.Builtins.SM
+  ( smCBits,
+  )
+where
+
+import Asterius.EDSL
+import Asterius.Types
+import Language.Haskell.GHC.Toolkit.Constants
+
+smCBits :: AsteriusModule
+smCBits = growStack
+
+growStack :: AsteriusModule
+growStack = runEDSL "growStack" $ do
+  setReturnTypes [I64]
+  prev_stack_obj <- param I64
+  prev_sp <- i64Local $ loadI64 prev_stack_obj offset_StgStack_sp
+  prev_stack_obj_size <-
+    i64Local
+      $ addInt64 (constI64 offset_StgStack_stack)
+      $ mulInt64 (constI64 8)
+      $ extendUInt32
+      $ loadI32 prev_stack_obj offset_StgStack_stack_size
+  prev_stack_used <-
+    i64Local $
+      prev_stack_obj_size
+        `subInt64` (prev_sp `subInt64` prev_stack_obj)
+  next_stack_obj_size <- i64Local $ prev_stack_obj_size `mulInt64` constI64 2
+  next_stack_obj <-
+    call'
+      "allocatePinned"
+      [mainCapability, next_stack_obj_size]
+      I64
+  next_sp <-
+    i64Local $
+      next_stack_obj
+        `addInt64` next_stack_obj_size
+        `subInt64` prev_stack_used
+  _ <-
+    call'
+      "memcpy"
+      [next_stack_obj, prev_stack_obj, constI64 offset_StgStack_stack]
+      I64
+  storeI32 next_stack_obj offset_StgStack_stack_size
+    $ wrapInt64
+    $ (next_stack_obj_size `subInt64` constI64 offset_StgStack_stack)
+      `divUInt64` constI64 8
+  storeI64 next_stack_obj offset_StgStack_sp next_sp
+  _ <- call' "memcpy" [next_sp, prev_sp, prev_stack_used] I64
+  emit next_stack_obj


### PR DESCRIPTION
This PR implements growable stacks. Previously, our stack size is hard-wired to `65536` (actually a bit less), and when the stack space runs out, the runtime simply panics. Now, we would allocate a new stack object with twice the size, copy the stack frames there, and resume execution. The default stack size is also cut down to `4096` now since small stacks should be sufficient most of the time. This is a critical runtime improvement that should have been done quite some while ago..

There are still possible improvements in this space, but they shall be done in future PRs:

* Unpin the TSO and stack objects
* Set maximum stack size threshold, and when the stack grows beyond the threshold, throw a `StackOverflow` exception in the offending Haskell thread instead of a runtime panic
* Implement stack chunks, so only individual chunks of the stack need to be marked as dirty and handled by the gc