### PR TITLE
Enable certain ccall results to be dropped

### DIFF
--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -316,6 +316,9 @@ marshalExpression sym_map m e = flip runContT pure $ case e of
     x <- marshalExpression sym_map m operand0
     y <- marshalExpression sym_map m operand1
     c_BinaryenBinary m (marshalBinaryOp binaryOp) x y
+  Drop {..} -> lift $ do
+    x <- marshalExpression sym_map m dropValue
+    c_BinaryenDrop m x
   ReturnCall {..} -> case M.lookup returnCallTarget64 sym_map of
     Just t -> do
       s <- lift $ marshalExpression

--- a/asterius/src/Asterius/Backends/WasmToolkit.hs
+++ b/asterius/src/Asterius/Backends/WasmToolkit.hs
@@ -681,6 +681,16 @@ makeInstructions tail_calls sym_map _module_symtable@ModuleSymbolTable {..} _de_
         GtFloat64 -> pure Wasm.F64Gt
         GeFloat64 -> pure Wasm.F64Ge
       pure $ x <> y <> op
+    Drop {..} -> do
+      x <-
+        makeInstructions
+          tail_calls
+          sym_map
+          _module_symtable
+          _de_bruijn_ctx
+          _local_ctx
+          dropValue
+      pure $ x <> DList.singleton Wasm.Drop
     ReturnCall {..}
       | tail_calls -> case Map.lookup (coerce returnCallTarget64) functionSymbols of
         Just i -> pure $

--- a/asterius/src/Asterius/CodeGen/Droppable.hs
+++ b/asterius/src/Asterius/CodeGen/Droppable.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Asterius.CodeGen.Droppable
+  ( ccallResultDroppable,
+  )
+where
+
+import Asterius.Types
+
+ccallResultDroppable :: AsteriusEntitySymbol -> [ValueType]
+ccallResultDroppable sym | sym == "memset" || sym == "memcpy" = [I64]
+ccallResultDroppable _ = []

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -414,6 +414,9 @@ data Expression
       { binaryOp :: BinaryOp,
         operand0, operand1 :: Expression
       }
+  | Drop
+      { dropValue :: Expression
+      }
   | ReturnCall
       { returnCallTarget64 :: AsteriusEntitySymbol
       }


### PR DESCRIPTION
Should close #450. Repro: any demo which links in a reverse dep of `memory`.

This hack may go away in the future if we fundamentally change how `ccall`s are handled (e.g. using the convention implemented in `clang`, or rolling our own `libffi`-like calling convention).