### PR TITLE
Fix `binaryen` building for older `cmake` versions

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 resolver: lts-15.0
 extra-deps:
-  - https://github.com/tweag/binaryen/archive/4bb1bf4021bc04255704d2d4cf0d18f5d69fb3fe.tar.gz
+  - https://github.com/tweag/binaryen/archive/00cc255cd1015bb5ab3fb4bf145a57fe5230f3d1.tar.gz
   - url: https://github.com/tweag/inline-js/archive/bd000373e0f02d213a881119298e1aea5962e149.tar.gz
     subdirs:
       - inline-js-core


### PR DESCRIPTION
Our `binaryen` build script uses `cmake -S .. -B ..` to specify source & build directories, but that doesn't work for `cmake` prior to `3.13`. Regression discovered by @gkaracha when building on `ubuntu:bionic`.