### PR TITLE
Slightly modularize Backends.WasmToolkit.makeInstructions

### DIFF
--- a/asterius/src/Asterius/Backends/WasmToolkit.hs
+++ b/asterius/src/Asterius/Backends/WasmToolkit.hs
@@ -255,6 +255,137 @@ lookupLocalContext LocalContext {..} i = coerce $ case Map.lookup i localMap of
   Just j -> j
   _ -> i
 
+-- | Convert a unary operator to a Wasm instruction.
+marshalUnaryOp :: UnaryOp -> Wasm.Instruction
+marshalUnaryOp op = case op of
+  ClzInt32 -> Wasm.I32Clz
+  CtzInt32 -> Wasm.I32Ctz
+  PopcntInt32 -> Wasm.I32Popcnt
+  NegFloat32 -> Wasm.F32Neg
+  AbsFloat32 -> Wasm.F32Abs
+  CeilFloat32 -> Wasm.F32Ceil
+  FloorFloat32 -> Wasm.F32Floor
+  TruncFloat32 -> Wasm.F32Trunc
+  NearestFloat32 -> Wasm.F32Nearest
+  SqrtFloat32 -> Wasm.F32Sqrt
+  EqZInt32 -> Wasm.I32Eqz
+  ClzInt64 -> Wasm.I64Clz
+  CtzInt64 -> Wasm.I64Ctz
+  PopcntInt64 -> Wasm.I64Popcnt
+  NegFloat64 -> Wasm.F64Neg
+  AbsFloat64 -> Wasm.F64Abs
+  CeilFloat64 -> Wasm.F64Ceil
+  FloorFloat64 -> Wasm.F64Floor
+  TruncFloat64 -> Wasm.F64Trunc
+  NearestFloat64 -> Wasm.F64Nearest
+  SqrtFloat64 -> Wasm.F64Sqrt
+  EqZInt64 -> Wasm.I64Eqz
+  ExtendSInt32 -> Wasm.I64ExtendSFromI32
+  ExtendUInt32 -> Wasm.I64ExtendUFromI32
+  WrapInt64 -> Wasm.I32WrapFromI64
+  TruncSFloat32ToInt32 -> Wasm.I32TruncSFromF32
+  TruncSFloat32ToInt64 -> Wasm.I64TruncSFromF32
+  TruncUFloat32ToInt32 -> Wasm.I32TruncUFromF32
+  TruncUFloat32ToInt64 -> Wasm.I64TruncUFromF32
+  TruncSFloat64ToInt32 -> Wasm.I32TruncSFromF64
+  TruncSFloat64ToInt64 -> Wasm.I64TruncSFromF64
+  TruncUFloat64ToInt32 -> Wasm.I32TruncUFromF64
+  TruncUFloat64ToInt64 -> Wasm.I64TruncUFromF64
+  ReinterpretFloat32 -> Wasm.I32ReinterpretFromF32
+  ReinterpretFloat64 -> Wasm.I64ReinterpretFromF64
+  ConvertSInt32ToFloat32 -> Wasm.F32ConvertSFromI32
+  ConvertSInt32ToFloat64 -> Wasm.F64ConvertSFromI32
+  ConvertUInt32ToFloat32 -> Wasm.F32ConvertUFromI32
+  ConvertUInt32ToFloat64 -> Wasm.F64ConvertUFromI32
+  ConvertSInt64ToFloat32 -> Wasm.F32ConvertSFromI64
+  ConvertSInt64ToFloat64 -> Wasm.F64ConvertSFromI64
+  ConvertUInt64ToFloat32 -> Wasm.F32ConvertUFromI64
+  ConvertUInt64ToFloat64 -> Wasm.F64ConvertUFromI64
+  PromoteFloat32 -> Wasm.F64PromoteFromF32
+  DemoteFloat64 -> Wasm.F32DemoteFromF64
+  ReinterpretInt32 -> Wasm.F32ReinterpretFromI32
+  ReinterpretInt64 -> Wasm.F64ReinterpretFromI64
+
+-- | Convert a binary operator to a Wasm instruction.
+marshalBinaryOp :: BinaryOp -> Wasm.Instruction
+marshalBinaryOp op = case op of
+  AddInt32 -> Wasm.I32Add
+  SubInt32 -> Wasm.I32Sub
+  MulInt32 -> Wasm.I32Mul
+  DivSInt32 -> Wasm.I32DivS
+  DivUInt32 -> Wasm.I32DivU
+  RemSInt32 -> Wasm.I32RemS
+  RemUInt32 -> Wasm.I32RemU
+  AndInt32 -> Wasm.I32And
+  OrInt32 -> Wasm.I32Or
+  XorInt32 -> Wasm.I32Xor
+  ShlInt32 -> Wasm.I32Shl
+  ShrUInt32 -> Wasm.I32ShrU
+  ShrSInt32 -> Wasm.I32ShrS
+  RotLInt32 -> Wasm.I32RotL
+  RotRInt32 -> Wasm.I32RotR
+  EqInt32 -> Wasm.I32Eq
+  NeInt32 -> Wasm.I32Ne
+  LtSInt32 -> Wasm.I32LtS
+  LtUInt32 -> Wasm.I32LtU
+  LeSInt32 -> Wasm.I32LeS
+  LeUInt32 -> Wasm.I32LeU
+  GtSInt32 -> Wasm.I32GtS
+  GtUInt32 -> Wasm.I32GtU
+  GeSInt32 -> Wasm.I32GeS
+  GeUInt32 -> Wasm.I32GeU
+  AddInt64 -> Wasm.I64Add
+  SubInt64 -> Wasm.I64Sub
+  MulInt64 -> Wasm.I64Mul
+  DivSInt64 -> Wasm.I64DivS
+  DivUInt64 -> Wasm.I64DivU
+  RemSInt64 -> Wasm.I64RemS
+  RemUInt64 -> Wasm.I64RemU
+  AndInt64 -> Wasm.I64And
+  OrInt64 -> Wasm.I64Or
+  XorInt64 -> Wasm.I64Xor
+  ShlInt64 -> Wasm.I64Shl
+  ShrUInt64 -> Wasm.I64ShrU
+  ShrSInt64 -> Wasm.I64ShrS
+  RotLInt64 -> Wasm.I64RotL
+  RotRInt64 -> Wasm.I64RotR
+  EqInt64 -> Wasm.I64Eq
+  NeInt64 -> Wasm.I64Ne
+  LtSInt64 -> Wasm.I64LtS
+  LtUInt64 -> Wasm.I64LtU
+  LeSInt64 -> Wasm.I64LeS
+  LeUInt64 -> Wasm.I64LeU
+  GtSInt64 -> Wasm.I64GtS
+  GtUInt64 -> Wasm.I64GtU
+  GeSInt64 -> Wasm.I64GeS
+  GeUInt64 -> Wasm.I64GeU
+  AddFloat32 -> Wasm.F32Add
+  SubFloat32 -> Wasm.F32Sub
+  MulFloat32 -> Wasm.F32Mul
+  DivFloat32 -> Wasm.F32Div
+  CopySignFloat32 -> Wasm.F32Copysign
+  MinFloat32 -> Wasm.F32Min
+  MaxFloat32 -> Wasm.F32Max
+  EqFloat32 -> Wasm.F32Eq
+  NeFloat32 -> Wasm.F32Ne
+  LtFloat32 -> Wasm.F32Lt
+  LeFloat32 -> Wasm.F32Le
+  GtFloat32 -> Wasm.F32Gt
+  GeFloat32 -> Wasm.F32Ge
+  AddFloat64 -> Wasm.F64Add
+  SubFloat64 -> Wasm.F64Sub
+  MulFloat64 -> Wasm.F64Mul
+  DivFloat64 -> Wasm.F64Div
+  CopySignFloat64 -> Wasm.F64Copysign
+  MinFloat64 -> Wasm.F64Min
+  MaxFloat64 -> Wasm.F64Max
+  EqFloat64 -> Wasm.F64Eq
+  NeFloat64 -> Wasm.F64Ne
+  LtFloat64 -> Wasm.F64Lt
+  LeFloat64 -> Wasm.F64Le
+  GtFloat64 -> Wasm.F64Gt
+  GeFloat64 -> Wasm.F64Ge
+
 -- TODO: reduce infer usage
 makeInstructions ::
   MonadError MarshalError m =>
@@ -537,54 +668,7 @@ makeInstructions tail_calls sym_map _module_symtable@ModuleSymbolTable {..} _de_
           _de_bruijn_ctx
           _local_ctx
           operand0
-      op <- DList.singleton <$> case unaryOp of
-        ClzInt32 -> pure Wasm.I32Clz
-        CtzInt32 -> pure Wasm.I32Ctz
-        PopcntInt32 -> pure Wasm.I32Popcnt
-        NegFloat32 -> pure Wasm.F32Neg
-        AbsFloat32 -> pure Wasm.F32Abs
-        CeilFloat32 -> pure Wasm.F32Ceil
-        FloorFloat32 -> pure Wasm.F32Floor
-        TruncFloat32 -> pure Wasm.F32Trunc
-        NearestFloat32 -> pure Wasm.F32Nearest
-        SqrtFloat32 -> pure Wasm.F32Sqrt
-        EqZInt32 -> pure Wasm.I32Eqz
-        ClzInt64 -> pure Wasm.I64Clz
-        CtzInt64 -> pure Wasm.I64Ctz
-        PopcntInt64 -> pure Wasm.I64Popcnt
-        NegFloat64 -> pure Wasm.F64Neg
-        AbsFloat64 -> pure Wasm.F64Abs
-        CeilFloat64 -> pure Wasm.F64Ceil
-        FloorFloat64 -> pure Wasm.F64Floor
-        TruncFloat64 -> pure Wasm.F64Trunc
-        NearestFloat64 -> pure Wasm.F64Nearest
-        SqrtFloat64 -> pure Wasm.F64Sqrt
-        EqZInt64 -> pure Wasm.I64Eqz
-        ExtendSInt32 -> pure Wasm.I64ExtendSFromI32
-        ExtendUInt32 -> pure Wasm.I64ExtendUFromI32
-        WrapInt64 -> pure Wasm.I32WrapFromI64
-        TruncSFloat32ToInt32 -> pure Wasm.I32TruncSFromF32
-        TruncSFloat32ToInt64 -> pure Wasm.I64TruncSFromF32
-        TruncUFloat32ToInt32 -> pure Wasm.I32TruncUFromF32
-        TruncUFloat32ToInt64 -> pure Wasm.I64TruncUFromF32
-        TruncSFloat64ToInt32 -> pure Wasm.I32TruncSFromF64
-        TruncSFloat64ToInt64 -> pure Wasm.I64TruncSFromF64
-        TruncUFloat64ToInt32 -> pure Wasm.I32TruncUFromF64
-        TruncUFloat64ToInt64 -> pure Wasm.I64TruncUFromF64
-        ReinterpretFloat32 -> pure Wasm.I32ReinterpretFromF32
-        ReinterpretFloat64 -> pure Wasm.I64ReinterpretFromF64
-        ConvertSInt32ToFloat32 -> pure Wasm.F32ConvertSFromI32
-        ConvertSInt32ToFloat64 -> pure Wasm.F64ConvertSFromI32
-        ConvertUInt32ToFloat32 -> pure Wasm.F32ConvertUFromI32
-        ConvertUInt32ToFloat64 -> pure Wasm.F64ConvertUFromI32
-        ConvertSInt64ToFloat32 -> pure Wasm.F32ConvertSFromI64
-        ConvertSInt64ToFloat64 -> pure Wasm.F64ConvertSFromI64
-        ConvertUInt64ToFloat32 -> pure Wasm.F32ConvertUFromI64
-        ConvertUInt64ToFloat64 -> pure Wasm.F64ConvertUFromI64
-        PromoteFloat32 -> pure Wasm.F64PromoteFromF32
-        DemoteFloat64 -> pure Wasm.F32DemoteFromF64
-        ReinterpretInt32 -> pure Wasm.F32ReinterpretFromI32
-        ReinterpretInt64 -> pure Wasm.F64ReinterpretFromI64
+      let op = DList.singleton $ marshalUnaryOp unaryOp
       pure $ x <> op
     Binary {..} -> do
       x <-
@@ -603,83 +687,7 @@ makeInstructions tail_calls sym_map _module_symtable@ModuleSymbolTable {..} _de_
           _de_bruijn_ctx
           _local_ctx
           operand1
-      op <- DList.singleton <$> case binaryOp of
-        AddInt32 -> pure Wasm.I32Add
-        SubInt32 -> pure Wasm.I32Sub
-        MulInt32 -> pure Wasm.I32Mul
-        DivSInt32 -> pure Wasm.I32DivS
-        DivUInt32 -> pure Wasm.I32DivU
-        RemSInt32 -> pure Wasm.I32RemS
-        RemUInt32 -> pure Wasm.I32RemU
-        AndInt32 -> pure Wasm.I32And
-        OrInt32 -> pure Wasm.I32Or
-        XorInt32 -> pure Wasm.I32Xor
-        ShlInt32 -> pure Wasm.I32Shl
-        ShrUInt32 -> pure Wasm.I32ShrU
-        ShrSInt32 -> pure Wasm.I32ShrS
-        RotLInt32 -> pure Wasm.I32RotL
-        RotRInt32 -> pure Wasm.I32RotR
-        EqInt32 -> pure Wasm.I32Eq
-        NeInt32 -> pure Wasm.I32Ne
-        LtSInt32 -> pure Wasm.I32LtS
-        LtUInt32 -> pure Wasm.I32LtU
-        LeSInt32 -> pure Wasm.I32LeS
-        LeUInt32 -> pure Wasm.I32LeU
-        GtSInt32 -> pure Wasm.I32GtS
-        GtUInt32 -> pure Wasm.I32GtU
-        GeSInt32 -> pure Wasm.I32GeS
-        GeUInt32 -> pure Wasm.I32GeU
-        AddInt64 -> pure Wasm.I64Add
-        SubInt64 -> pure Wasm.I64Sub
-        MulInt64 -> pure Wasm.I64Mul
-        DivSInt64 -> pure Wasm.I64DivS
-        DivUInt64 -> pure Wasm.I64DivU
-        RemSInt64 -> pure Wasm.I64RemS
-        RemUInt64 -> pure Wasm.I64RemU
-        AndInt64 -> pure Wasm.I64And
-        OrInt64 -> pure Wasm.I64Or
-        XorInt64 -> pure Wasm.I64Xor
-        ShlInt64 -> pure Wasm.I64Shl
-        ShrUInt64 -> pure Wasm.I64ShrU
-        ShrSInt64 -> pure Wasm.I64ShrS
-        RotLInt64 -> pure Wasm.I64RotL
-        RotRInt64 -> pure Wasm.I64RotR
-        EqInt64 -> pure Wasm.I64Eq
-        NeInt64 -> pure Wasm.I64Ne
-        LtSInt64 -> pure Wasm.I64LtS
-        LtUInt64 -> pure Wasm.I64LtU
-        LeSInt64 -> pure Wasm.I64LeS
-        LeUInt64 -> pure Wasm.I64LeU
-        GtSInt64 -> pure Wasm.I64GtS
-        GtUInt64 -> pure Wasm.I64GtU
-        GeSInt64 -> pure Wasm.I64GeS
-        GeUInt64 -> pure Wasm.I64GeU
-        AddFloat32 -> pure Wasm.F32Add
-        SubFloat32 -> pure Wasm.F32Sub
-        MulFloat32 -> pure Wasm.F32Mul
-        DivFloat32 -> pure Wasm.F32Div
-        CopySignFloat32 -> pure Wasm.F32Copysign
-        MinFloat32 -> pure Wasm.F32Min
-        MaxFloat32 -> pure Wasm.F32Max
-        EqFloat32 -> pure Wasm.F32Eq
-        NeFloat32 -> pure Wasm.F32Ne
-        LtFloat32 -> pure Wasm.F32Lt
-        LeFloat32 -> pure Wasm.F32Le
-        GtFloat32 -> pure Wasm.F32Gt
-        GeFloat32 -> pure Wasm.F32Ge
-        AddFloat64 -> pure Wasm.F64Add
-        SubFloat64 -> pure Wasm.F64Sub
-        MulFloat64 -> pure Wasm.F64Mul
-        DivFloat64 -> pure Wasm.F64Div
-        CopySignFloat64 -> pure Wasm.F64Copysign
-        MinFloat64 -> pure Wasm.F64Min
-        MaxFloat64 -> pure Wasm.F64Max
-        EqFloat64 -> pure Wasm.F64Eq
-        NeFloat64 -> pure Wasm.F64Ne
-        LtFloat64 -> pure Wasm.F64Lt
-        LeFloat64 -> pure Wasm.F64Le
-        GtFloat64 -> pure Wasm.F64Gt
-        GeFloat64 -> pure Wasm.F64Ge
+      let op = DList.singleton $ marshalBinaryOp binaryOp
       pure $ x <> y <> op
     Drop {..} -> do
       x <-


### PR DESCRIPTION
Moved the elaboration of unary and binary operators to Wasm instructions into separate functions (and thus outside of `makeInstructions`):
```
marshalUnaryOp  :: UnaryOp -> Wasm.Instruction
marshalBinaryOp :: BinaryOp -> Wasm.Instruction
```