### PR TITLE
Avoid repeated stack invocations in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,1 @@
-PATH_add $(stack path --compiler-bin)
-PATH_add $(stack path --snapshot-install-root)/bin
-PATH_add $(stack path --local-install-root)/bin
+export PATH=$(stack exec printenv PATH)

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ package-lock.json
 *.linked.txt
 *.unlinked.bin
 *.wasm-toolkit.txt
+
+/test


### PR DESCRIPTION
The previous `.envrc` file calls `stack path` multiple times and is pretty slow. This PR speeds up things a bit by only calling `stack` once and exports the `PATH` from there.

Another tiny change that sneaks in: we add `/test` to `.gitignore` so it's convenient to test stuff in the project directory, call `ahc` directly without watching out accidental checking in of the artifacts.