### PR TITLE
Adjust ghc-toolkit IR types

### DIFF
--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -1499,6 +1499,6 @@ marshalHaskellIR this_mod HaskellIR {..} = marshalRawCmm this_mod cmmRaw
 marshalCmmIR :: GHC.Module -> CmmIR -> CodeGen AsteriusModule
 marshalCmmIR this_mod CmmIR {..} = marshalRawCmm this_mod cmmRaw
 
-marshalRawCmm :: GHC.Module -> [[GHC.RawCmmDecl]] -> CodeGen AsteriusModule
+marshalRawCmm :: GHC.Module -> [GHC.RawCmmDecl] -> CodeGen AsteriusModule
 marshalRawCmm _ cmm_decls =
-  mconcat <$> traverse marshalCmmDecl (mconcat cmm_decls)
+  mconcat <$> traverse marshalCmmDecl cmm_decls

--- a/asterius/src/Asterius/FrontendPlugin.hs
+++ b/asterius/src/Asterius/FrontendPlugin.hs
@@ -85,9 +85,7 @@ frontendPlugin = makeFrontendPlugin $ do
                   let p = (obj_path -<.>)
                   writeFile (p "dump-wasm-ast") $ show m
                   writeFile (p "dump-cmm-raw-ast") $ show cmmRaw
-                  asmPrint dflags (p "dump-cmm-raw") cmmRaw
-                  writeFile (p "dump-stg-ast") $ show stg
-                  asmPrint dflags (p "dump-stg") stg,
+                  asmPrint dflags (p "dump-cmm-raw") cmmRaw,
         withCmmIR = \ir@CmmIR {..} obj_path -> do
           dflags <- GHC.getDynFlags
           setDynFlagsRef dflags

--- a/asterius/src/Asterius/FrontendPlugin.hs
+++ b/asterius/src/Asterius/FrontendPlugin.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Asterius.FrontendPlugin
@@ -23,6 +24,7 @@ import qualified Hooks as GHC
 import Language.Haskell.GHC.Toolkit.Compiler
 import Language.Haskell.GHC.Toolkit.FrontendPlugin
 import Language.Haskell.GHC.Toolkit.Orphans.Show
+import qualified Stream
 import System.Environment.Blank
 import System.FilePath
 
@@ -76,7 +78,7 @@ frontendPlugin = makeFrontendPlugin $ do
           let mod_sym = marshalToModuleSymbol ms_mod
           liftIO $ do
             ffi_mod <- getFFIModule mod_sym
-            case runCodeGen (marshalHaskellIR ms_mod ir) dflags ms_mod of
+            runCodeGen (marshalHaskellIR ms_mod ir) dflags ms_mod >>= \case
               Left err -> throwIO err
               Right m' -> do
                 let m = ffi_mod <> m'
@@ -84,20 +86,25 @@ frontendPlugin = makeFrontendPlugin $ do
                 when is_debug $ do
                   let p = (obj_path -<.>)
                   writeFile (p "dump-wasm-ast") $ show m
-                  writeFile (p "dump-cmm-raw-ast") $ show cmmRaw
-                  asmPrint dflags (p "dump-cmm-raw") cmmRaw,
+                  cmm_raw <- Stream.collect cmmRaw
+                  writeFile (p "dump-cmm-raw-ast") $ show cmm_raw
+                  asmPrint dflags (p "dump-cmm-raw") cmm_raw,
         withCmmIR = \ir@CmmIR {..} obj_path -> do
           dflags <- GHC.getDynFlags
           setDynFlagsRef dflags
           let ms_mod =
-                GHC.Module GHC.rtsUnitId $ GHC.mkModuleName $ takeBaseName obj_path
-          liftIO $ case runCodeGen (marshalCmmIR ms_mod ir) dflags ms_mod of
-            Left err -> throwIO err
-            Right m -> do
-              encodeFile obj_path m
-              when is_debug $ do
-                let p = (obj_path -<.>)
-                writeFile (p "dump-wasm-ast") $ show m
-                writeFile (p "dump-cmm-raw-ast") $ show cmmRaw
-                asmPrint dflags (p "dump-cmm-raw") cmmRaw
+                GHC.Module GHC.rtsUnitId $ GHC.mkModuleName $
+                  takeBaseName
+                    obj_path
+          liftIO $
+            runCodeGen (marshalCmmIR ms_mod ir) dflags ms_mod >>= \case
+              Left err -> throwIO err
+              Right m -> do
+                encodeFile obj_path m
+                when is_debug $ do
+                  let p = (obj_path -<.>)
+                  writeFile (p "dump-wasm-ast") $ show m
+                  cmm_raw <- Stream.collect cmmRaw
+                  writeFile (p "dump-cmm-raw-ast") $ show cmm_raw
+                  asmPrint dflags (p "dump-cmm-raw") cmm_raw
       }

--- a/asterius/src/Asterius/GHCi/Internals.hs
+++ b/asterius/src/Asterius/GHCi/Internals.hs
@@ -24,7 +24,6 @@ import Asterius.JSRun.Main
 import Asterius.JSRun.NonMain
 import Asterius.Ld
 import Asterius.Resolve
-import qualified Asterius.Types
 import Asterius.Types
 import Asterius.TypesConv
 import qualified BasicTypes as GHC
@@ -72,7 +71,6 @@ import qualified Panic as GHC
 import qualified SimplCore as GHC
 import qualified SimplStg as GHC
 import qualified SrcLoc as GHC
-import qualified Stream
 import System.Directory
 import System.FilePath
 import System.IO
@@ -418,10 +416,10 @@ asteriusHscCompileCoreExpr hsc_env srcspan ds_expr = do
       GHC.emptyCollectedCCs
       stg_binds2
       (GHC.emptyHpcInfo False)
-  raw_cmms <- GHC.cmmToRawCmm dflags (Just this_mod) cmms >>= Stream.collect
+  raw_cmms <- GHC.cmmToRawCmm dflags (Just this_mod) cmms
   m <-
-    either throwIO pure $
-      runCodeGen (marshalRawCmm this_mod (mconcat raw_cmms)) dflags this_mod
+    runCodeGen (marshalRawCmm this_mod raw_cmms) dflags this_mod
+      >>= either throwIO pure
   this_id <- modifyMVar globalGHCiState $ \s -> do
     let this_id = succ $ ghciLastCompiledCoreExpr s
     pure

--- a/asterius/src/Asterius/GHCi/Internals.hs
+++ b/asterius/src/Asterius/GHCi/Internals.hs
@@ -421,7 +421,7 @@ asteriusHscCompileCoreExpr hsc_env srcspan ds_expr = do
   raw_cmms <- GHC.cmmToRawCmm dflags (Just this_mod) cmms >>= Stream.collect
   m <-
     either throwIO pure $
-      runCodeGen (marshalRawCmm this_mod raw_cmms) dflags this_mod
+      runCodeGen (marshalRawCmm this_mod (mconcat raw_cmms)) dflags this_mod
   this_id <- modifyMVar globalGHCiState $ \s -> do
     let this_id = succ $ ghciLastCompiledCoreExpr s
     pure

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Compiler.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Compiler.hs
@@ -11,12 +11,10 @@ where
 import Cmm
 import GHC
 import PipelineMonad
-import StgSyn
 
-data HaskellIR
+newtype HaskellIR
   = HaskellIR
-      { stg :: [CgStgTopBinding],
-        cmmRaw :: [[RawCmmDecl]]
+      { cmmRaw :: [[RawCmmDecl]]
       }
 
 newtype CmmIR

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Compiler.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Compiler.hs
@@ -11,15 +11,16 @@ where
 import Cmm
 import GHC
 import PipelineMonad
+import Stream (Stream)
 
 newtype HaskellIR
   = HaskellIR
-      { cmmRaw :: [RawCmmDecl]
+      { cmmRaw :: Stream IO Cmm.RawCmmGroup ()
       }
 
 newtype CmmIR
   = CmmIR
-      { cmmRaw :: [RawCmmDecl]
+      { cmmRaw :: Stream IO Cmm.RawCmmGroup ()
       }
 
 data Compiler

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Compiler.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Compiler.hs
@@ -14,12 +14,12 @@ import PipelineMonad
 
 newtype HaskellIR
   = HaskellIR
-      { cmmRaw :: [[RawCmmDecl]]
+      { cmmRaw :: [RawCmmDecl]
       }
 
 newtype CmmIR
   = CmmIR
-      { cmmRaw :: [[RawCmmDecl]]
+      { cmmRaw :: [RawCmmDecl]
       }
 
 data Compiler

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Hooks.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Hooks.hs
@@ -80,14 +80,14 @@ hooksFromCompiler Compiler {..} h = do
                               )
                       ir <-
                         liftIO $
-                          HaskellIR
+                          HaskellIR . mconcat
                             <$> (fetch cmm_raw_map_ref >>= Stream.collect)
                       withHaskellIR mod_summary ir obj_output_fn
                   )
               pure r
           GHC.RealPhase GHC.Cmm -> do
             void $ GHC.runPhase phase input_fn dflags
-            ir <- liftIO $ CmmIR <$> (takeMVar cmm_raw_ref >>= Stream.collect)
+            ir <- liftIO $ CmmIR . mconcat <$> (takeMVar cmm_raw_ref >>= Stream.collect)
             obj_output_fn <- GHC.phaseOutputFilename GHC.StopLn
             withCmmIR ir obj_output_fn
             pure (GHC.RealPhase GHC.StopLn, obj_output_fn)

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Hooks.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Hooks.hs
@@ -21,7 +21,6 @@ import qualified HscTypes as GHC
 import Language.Haskell.GHC.Toolkit.Compiler
 import qualified Module as GHC
 import qualified PipelineMonad as GHC
-import qualified Stream
 
 hooksFromCompiler :: Compiler -> GHC.Hooks -> IO GHC.Hooks
 hooksFromCompiler Compiler {..} h = do
@@ -72,22 +71,16 @@ hooksFromCompiler Compiler {..} h = do
                               ref
                               ( \m ->
                                   let (Just v, m') =
-                                        Map.updateLookupWithKey
-                                          (\_ _ -> Nothing)
-                                          ms_mod
-                                          m
+                                        Map.updateLookupWithKey (\_ _ -> Nothing) ms_mod m
                                    in pure (m', v)
                               )
-                      ir <-
-                        liftIO $
-                          HaskellIR . mconcat
-                            <$> (fetch cmm_raw_map_ref >>= Stream.collect)
+                      ir <- liftIO $ HaskellIR <$> fetch cmm_raw_map_ref
                       withHaskellIR mod_summary ir obj_output_fn
                   )
               pure r
           GHC.RealPhase GHC.Cmm -> do
             void $ GHC.runPhase phase input_fn dflags
-            ir <- liftIO $ CmmIR . mconcat <$> (takeMVar cmm_raw_ref >>= Stream.collect)
+            ir <- liftIO $ CmmIR <$> takeMVar cmm_raw_ref
             obj_output_fn <- GHC.phaseOutputFilename GHC.StopLn
             withCmmIR ir obj_output_fn
             pure (GHC.RealPhase GHC.StopLn, obj_output_fn)


### PR DESCRIPTION
Changeset:

* Remove the unused `stg` field from `HaskellIR` for now
* Do not convert the raw Cmm `Stream` to list at once; instead, consume the `Stream` directly in the codegen
* The `CodeGen` is now a `ReaderT` over `IO` and no longer pure, but the purity has little benefit here anyway

This will hopefully cut down quite some compile-time memory usage and speed things up a bit.