### PR TITLE
Fix static pointers support

### DIFF
--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -11,6 +11,7 @@ import { MemoryTrap } from "./rts.memorytrap.mjs";
 import { HeapAlloc } from "./rts.heapalloc.mjs";
 import { StablePtrManager } from "./rts.stableptr.mjs";
 import { StableNameManager } from "./rts.stablename.mjs";
+import { StaticPtrManager } from "./rts.staticptr.mjs";
 import { Scheduler } from "./rts.scheduler.mjs";
 import { HeapBuilder } from "./rts.heapbuilder.mjs";
 import { IntegerManager } from "./rts.integer.mjs";
@@ -57,6 +58,7 @@ export async function newAsteriusInstance(req) {
       __asterius_heapalloc,
       req.symbolTable
     ),
+    __asterius_staticptr_manager = new StaticPtrManager(__asterius_memory, __asterius_stableptr_manager, req.sptEntries),
     __asterius_scheduler = new Scheduler(
       __asterius_memory,
       req.symbolTable,
@@ -234,6 +236,7 @@ export async function newAsteriusInstance(req) {
       Messages: modulify(__asterius_messages),
       StablePtr: modulify(__asterius_stableptr_manager),
       StableName: modulify(__asterius_stablename_manager),
+      StaticPtr: modulify(__asterius_staticptr_manager),
       Unicode: modulify(__asterius_unicode),
       Tracing: modulify(__asterius_tracer),
       Scheduler: modulify(__asterius_scheduler)

--- a/asterius/rts/rts.staticptr.mjs
+++ b/asterius/rts/rts.staticptr.mjs
@@ -32,7 +32,7 @@ export class StaticPtrManager {
       );
     }
     for (const [k] of this.sptEntries) {
-      this.memory.i64Store(p, k && w0_mask);
+      this.memory.i64Store(p, k & w0_mask);
       this.memory.i64Store(p + 8, k >> BigInt(64));
       p += 16;
     }

--- a/asterius/rts/rts.staticptr.mjs
+++ b/asterius/rts/rts.staticptr.mjs
@@ -1,0 +1,41 @@
+const w0_mask = (BigInt(1) << BigInt(64)) - BigInt(1);
+
+export class StaticPtrManager {
+  constructor(memory, stableptr_manager, spt_entries) {
+    this.memory = memory;
+    this.stablePtrManager = stableptr_manager;
+    this.sptEntries = spt_entries;
+    Object.freeze(this);
+    for (const [, c] of this.sptEntries) {
+      this.stablePtrManager.newStablePtr(c);
+    }
+  }
+
+  hs_spt_lookup(w0_lo, w0_hi, w1_lo, w1_hi) {
+    const r = this.sptEntries.get(
+      (BigInt(w1_hi) << BigInt(96)) |
+        (BigInt(w1_lo) << BigInt(64)) |
+        (BigInt(w0_hi) << BigInt(32)) |
+        BigInt(w0_lo)
+    );
+    return r ? r : 0;
+  }
+
+  hs_spt_key_count() {
+    return this.sptEntries.size;
+  }
+
+  hs_spt_keys(p, n) {
+    if (n !== this.hs_spt_key_count()) {
+      throw new WebAssembly.RuntimeError(
+        `hs_spt_keys required ${n} keys, but there are ${this.hs_spt_key_count()}`
+      );
+    }
+    for (const [k] of this.sptEntries) {
+      this.memory.i64Store(p, k && w0_mask);
+      this.memory.i64Store(p + 8, k >> BigInt(64));
+      p += 16;
+    }
+    return n;
+  }
+}

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -23,6 +23,7 @@ import Asterius.Builtins.Hashable
 import Asterius.Builtins.MD5
 import Asterius.Builtins.Posix
 import Asterius.Builtins.SM
+import Asterius.Builtins.SPT
 import Asterius.Builtins.StgPrimFloat
 import Asterius.Builtins.Time
 import Asterius.EDSL
@@ -201,6 +202,7 @@ rtsAsteriusModule opts =
     <> hashableCBits
     <> md5CBits
     <> posixCBits
+    <> sptCBits
     <> stgPrimFloatCBits
     <> timeCBits
 
@@ -665,6 +667,7 @@ rtsFunctionImports debug =
       ( byteStringCBits <> floatCBits <> unicodeCBits <> textCBits
       )
     <> posixImports
+    <> sptImports
     <> timeImports
 
 rtsFunctionExports :: Bool -> [FunctionExport]

--- a/asterius/src/Asterius/Builtins/SPT.hs
+++ b/asterius/src/Asterius/Builtins/SPT.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Asterius.Builtins.SPT
+  ( sptImports,
+    sptCBits,
+  )
+where
+
+import Asterius.EDSL
+import Asterius.Types
+
+sptImports :: [FunctionImport]
+sptImports =
+  [ FunctionImport
+      { internalName = "__asterius_hs_spt_lookup",
+        externalModuleName = "StaticPtr",
+        externalBaseName = "hs_spt_lookup",
+        functionType =
+          FunctionType
+            { paramTypes = [I32, I32, I32, I32],
+              returnTypes = [F64]
+            }
+      },
+    FunctionImport
+      { internalName = "__asterius_hs_spt_key_count",
+        externalModuleName = "StaticPtr",
+        externalBaseName = "hs_spt_key_count",
+        functionType = FunctionType {paramTypes = [], returnTypes = [F64]}
+      },
+    FunctionImport
+      { internalName = "__asterius_hs_spt_keys",
+        externalModuleName = "StaticPtr",
+        externalBaseName = "hs_spt_keys",
+        functionType =
+          FunctionType
+            { paramTypes = [F64, F64],
+              returnTypes = [F64]
+            }
+      }
+  ]
+
+sptCBits :: AsteriusModule
+sptCBits = sptLookup <> sptKeyCount <> sptKeys
+
+sptLookup :: AsteriusModule
+sptLookup = runEDSL "hs_spt_lookup" $ do
+  setReturnTypes [I64]
+  [w0, w1] <- params [I64, I64]
+  truncUFloat64ToInt64
+    <$> callImport'
+      "__asterius_hs_spt_lookup"
+      [ wrapInt64 w0,
+        wrapInt64 $ w0 `shrUInt64` constI64 32,
+        wrapInt64 w1,
+        wrapInt64 $ w1 `shrUInt64` constI64 32
+      ]
+      F64
+    >>= emit
+
+sptKeyCount :: AsteriusModule
+sptKeyCount = runEDSL "hs_spt_key_count" $ do
+  setReturnTypes [I64]
+  truncUFloat64ToInt64
+    <$> callImport' "__asterius_hs_spt_key_count" [] F64
+    >>= emit
+
+sptKeys :: AsteriusModule
+sptKeys = runEDSL "hs_spt_keys" $ do
+  setReturnTypes [I64]
+  args <- params [I64, I64]
+  truncUFloat64ToInt64
+    <$> callImport'
+      "__asterius_hs_spt_keys"
+      (map convertUInt64ToFloat64 args)
+      F64
+    >>= emit

--- a/asterius/src/Asterius/Builtins/SPT.hs
+++ b/asterius/src/Asterius/Builtins/SPT.hs
@@ -18,7 +18,7 @@ sptImports =
         externalBaseName = "hs_spt_lookup",
         functionType =
           FunctionType
-            { paramTypes = [I32, I32, I32, I32],
+            { paramTypes = [F64, F64, F64, F64],
               returnTypes = [F64]
             }
       },
@@ -50,11 +50,14 @@ sptLookup = runEDSL "hs_spt_lookup" $ do
   truncUFloat64ToInt64
     <$> callImport'
       "__asterius_hs_spt_lookup"
-      [ wrapInt64 w0,
-        wrapInt64 $ w0 `shrUInt64` constI64 32,
-        wrapInt64 w1,
-        wrapInt64 $ w1 `shrUInt64` constI64 32
-      ]
+      ( map
+          convertUInt64ToFloat64
+          [ w0 `andInt64` constI64 0xFFFFFFFF,
+            w0 `shrUInt64` constI64 32,
+            w1 `andInt64` constI64 0xFFFFFFFF,
+            w1 `shrUInt64` constI64 32
+          ]
+      )
       F64
     >>= emit
 

--- a/asterius/src/Asterius/Foreign/Internals.hs
+++ b/asterius/src/Asterius/Foreign/Internals.hs
@@ -12,9 +12,9 @@ module Asterius.Foreign.Internals
   )
 where
 
+import Asterius.Internals.Name
 import Asterius.Types
 import Asterius.TypesConv
-import qualified CLabel as GHC
 import Control.Applicative
 import Control.Monad.IO.Class
 import qualified Data.ByteString.Short as SBS
@@ -421,11 +421,7 @@ processFFIExport hook_state_ref norm_sig_ty export_id (GHC.CExport (GHC.unLoc ->
         new_k = AsteriusEntitySymbol
           { entityName = SBS.toShort $ GHC.fastStringToByteString lbl
           }
-        export_closure =
-          fromString $ asmPpr dflags $
-            GHC.mkClosureLabel
-              (GHC.getName export_id)
-              GHC.NoCafRefs
+        export_closure = idClosureSymbol dflags export_id
         new_decl = FFIExportDecl
           { ffiFunctionType = ffi_ftype,
             ffiExportClosure = export_closure

--- a/asterius/src/Asterius/Internals/Name.hs
+++ b/asterius/src/Asterius/Internals/Name.hs
@@ -1,5 +1,6 @@
 module Asterius.Internals.Name
   ( fakeClosureSymbol,
+    idClosureSymbol,
   )
 where
 
@@ -9,6 +10,7 @@ import qualified CLabel as GHC
 import Data.String
 import qualified DynFlags as GHC
 import qualified FastString as GHC
+import qualified Id as GHC
 import qualified IdInfo as GHC
 import qualified Module as GHC
 import qualified Name as GHC
@@ -44,3 +46,10 @@ fakeClosureSymbol dflags pkg_name mod_name occ_name = sym
         (GHC.mkVarOcc occ_name)
     clbl = GHC.mkClosureLabel name GHC.MayHaveCafRefs
     sym = fromString $ asmPpr dflags clbl
+
+idClosureSymbol :: GHC.DynFlags -> GHC.Id -> AsteriusEntitySymbol
+idClosureSymbol dflags n =
+  fromString $ asmPpr dflags $
+    GHC.mkClosureLabel
+      (GHC.idName n)
+      (GHC.idCafInfo n)

--- a/asterius/src/Asterius/JSGen/SPT.hs
+++ b/asterius/src/Asterius/JSGen/SPT.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Asterius.JSGen.SPT
+  ( genSPT,
+  )
+where
+
+import Asterius.Internals ((!))
+import Asterius.Types
+import Data.ByteString.Builder
+import Data.Int
+import Data.List
+import qualified Data.Map.Strict as M
+import Data.Word
+
+genSPT ::
+  M.Map AsteriusEntitySymbol Int64 ->
+  M.Map AsteriusEntitySymbol (Word64, Word64) ->
+  Builder
+genSPT sym_map spt_entries =
+  "new Map(["
+    <> mconcat
+      ( intersperse
+          ","
+          [ "[0x"
+              <> word64HexFixed w1
+              <> word64HexFixed w0
+              <> "n,0x"
+              <> int64HexFixed (sym_map ! sym)
+              <> "]"
+            | (sym, (w0, w1)) <- M.toList spt_entries
+          ]
+      )
+    <> "])"

--- a/asterius/src/Asterius/Passes/GCSections.hs
+++ b/asterius/src/Asterius/Passes/GCSections.hs
@@ -26,9 +26,12 @@ gcSections ::
   AsteriusModule
 gcSections verbose_err store_mod root_syms export_funcs =
   final_m
-    { ffiMarshalState = ffi_this
+    { sptMap = spt_map,
+      ffiMarshalState = ffi_this
     }
   where
+    spt_map =
+      LM.restrictKeys (sptMap store_mod) (LM.keysSet (staticsMap final_m))
     ffi_all = ffiMarshalState store_mod
     ffi_this =
       ffi_all

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -41,6 +41,7 @@ data LinkReport
       { staticsSymbolMap, functionSymbolMap :: LM.Map AsteriusEntitySymbol Int64,
         infoTableSet :: [Int64],
         tableSlots, staticMBlocks :: Int,
+        sptEntries :: LM.Map AsteriusEntitySymbol (Word64, Word64),
         bundledFFIMarshalState :: FFIMarshalState
       }
   deriving (Generic, Show)
@@ -48,26 +49,30 @@ data LinkReport
 instance Binary LinkReport
 
 instance Semigroup LinkReport where
-  r0 <> r1 = LinkReport
-    { staticsSymbolMap = staticsSymbolMap r0 <> staticsSymbolMap r1,
-      functionSymbolMap = functionSymbolMap r0 <> functionSymbolMap r1,
-      infoTableSet = infoTableSet r0 <> infoTableSet r1,
-      tableSlots = 0,
-      staticMBlocks = 0,
-      bundledFFIMarshalState =
-        bundledFFIMarshalState r0
-          <> bundledFFIMarshalState r1
-    }
+  r0 <> r1 =
+    LinkReport
+      { staticsSymbolMap = staticsSymbolMap r0 <> staticsSymbolMap r1,
+        functionSymbolMap = functionSymbolMap r0 <> functionSymbolMap r1,
+        infoTableSet = infoTableSet r0 <> infoTableSet r1,
+        tableSlots = 0,
+        staticMBlocks = 0,
+        sptEntries = sptEntries r0 <> sptEntries r1,
+        bundledFFIMarshalState =
+          bundledFFIMarshalState r0
+            <> bundledFFIMarshalState r1
+      }
 
 instance Monoid LinkReport where
-  mempty = LinkReport
-    { staticsSymbolMap = mempty,
-      functionSymbolMap = mempty,
-      infoTableSet = mempty,
-      tableSlots = 0,
-      staticMBlocks = 0,
-      bundledFFIMarshalState = mempty
-    }
+  mempty =
+    LinkReport
+      { staticsSymbolMap = mempty,
+        functionSymbolMap = mempty,
+        infoTableSet = mempty,
+        tableSlots = 0,
+        staticMBlocks = 0,
+        sptEntries = mempty,
+        bundledFFIMarshalState = mempty
+      }
 
 makeInfoTableSet ::
   AsteriusModule -> LM.Map AsteriusEntitySymbol Int64 -> [Int64]
@@ -154,6 +159,7 @@ linkStart debug gc_sections verbose_err store root_syms export_funcs =
         infoTableSet = makeInfoTableSet merged_m ss_sym_map,
         Asterius.Resolve.tableSlots = tbl_slots,
         staticMBlocks = static_mbs,
+        sptEntries = sptMap merged_m,
         bundledFFIMarshalState = bundled_ffi_state
       }
   )

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -108,30 +108,37 @@ data AsteriusModule
       { staticsMap :: LM.Map AsteriusEntitySymbol AsteriusStatics,
         staticsErrorMap :: LM.Map AsteriusEntitySymbol AsteriusCodeGenError,
         functionMap :: LM.Map AsteriusEntitySymbol Function,
+        sptMap :: LM.Map AsteriusEntitySymbol (Word, Word),
         ffiMarshalState :: FFIMarshalState
       }
   deriving (Eq, Show, Generic, Data)
 
 instance Binary AsteriusModule where
-
   put AsteriusModule {..} =
     lazyMapPut staticsMap
       *> lazyMapPut staticsErrorMap
       *> lazyMapPut functionMap
+      *> lazyMapPut sptMap
       *> put ffiMarshalState
-
-  get = AsteriusModule <$> lazyMapGet <*> lazyMapGet <*> lazyMapGet <*> get
+  get =
+    AsteriusModule
+      <$> lazyMapGet
+      <*> lazyMapGet
+      <*> lazyMapGet
+      <*> lazyMapGet
+      <*> get
 
 instance Semigroup AsteriusModule where
-  AsteriusModule sm0 se0 fm0 mod_ffi_state0 <> AsteriusModule sm1 se1 fm1 mod_ffi_state1 =
+  AsteriusModule sm0 se0 fm0 spt0 mod_ffi_state0 <> AsteriusModule sm1 se1 fm1 spt1 mod_ffi_state1 =
     AsteriusModule
       (sm0 <> sm1)
       (se0 <> se1)
       (fm0 <> fm1)
+      (spt0 <> spt1)
       (mod_ffi_state0 <> mod_ffi_state1)
 
 instance Monoid AsteriusModule where
-  mempty = AsteriusModule mempty mempty mempty mempty
+  mempty = AsteriusModule mempty mempty mempty mempty mempty
 
 data AsteriusModuleSymbol
   = AsteriusModuleSymbol

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -108,7 +108,7 @@ data AsteriusModule
       { staticsMap :: LM.Map AsteriusEntitySymbol AsteriusStatics,
         staticsErrorMap :: LM.Map AsteriusEntitySymbol AsteriusCodeGenError,
         functionMap :: LM.Map AsteriusEntitySymbol Function,
-        sptMap :: LM.Map AsteriusEntitySymbol (Word, Word),
+        sptMap :: LM.Map AsteriusEntitySymbol (Word64, Word64),
         ffiMarshalState :: FFIMarshalState
       }
   deriving (Eq, Show, Generic, Data)

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Compiler.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Compiler.hs
@@ -10,12 +10,14 @@ where
 
 import Cmm
 import GHC
+import HscTypes
 import PipelineMonad
 import Stream (Stream)
 
-newtype HaskellIR
+data HaskellIR
   = HaskellIR
-      { cmmRaw :: Stream IO Cmm.RawCmmGroup ()
+      { sptEntries :: [SptEntry],
+        cmmRaw :: Stream IO Cmm.RawCmmGroup ()
       }
 
 newtype CmmIR


### PR DESCRIPTION
This PR fixes static pointers.

* In the `ghc-toolkit` IR, we add `SptEntry` list so the codegen can process them
* In the `asterius` IR, we add a mapping from static closure symbols to the SPT fingerprints. The mapping is added when we process raw Cmm compiled from Haskell
* In the linker, after the regular gc-sections pass, we pick out the subset of all SPT entries where the static closures are alive, and emit a mapping as `req.sptEntries` in the req script
* The RTS maintains a mapping from 128-bit `Fingerprint`s to static closure addresses. Upon startup, each SPT entry also gets a `StablePtr` allocated, so they become GC roots
* We needed to slightly patch `GHC.StaticPtr` in order to implement `staticPtrKeys`, since the fingerprint contents needs to be passed to a buffer allocated in the Haskell land