### PR TITLE
Minor improvements to `main` handling

### DIFF
--- a/asterius/app/ahc-ld.hs
+++ b/asterius/app/ahc-ld.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
 
 import Asterius.Ld
@@ -13,25 +14,27 @@ import System.Process
 parseLinkTask :: [String] -> IO LinkTask
 parseLinkTask args = do
   link_libs <- fmap catMaybes $ for link_libnames $ findFile link_libdirs
-  pure LinkTask
-    { progName = prog_name,
-      linkOutput = link_output,
-      linkObjs = link_objs,
-      linkLibs = link_libs,
-      linkModule = mempty,
-      debug = "--debug" `elem` args,
-      gcSections = "--no-gc-sections" `notElem` args,
-      verboseErr = "--verbose-err" `elem` args,
-      outputIR =
-        find ("--output-ir=" `isPrefixOf`) args
-          >>= stripPrefix "--output-ir=",
-      rootSymbols =
-        map (AsteriusEntitySymbol . fromString) $
-          str_args "--extra-root-symbol=",
-      exportFunctions =
-        map (AsteriusEntitySymbol . fromString) $
-          str_args "--export-function="
-    }
+  pure
+    LinkTask
+      { progName = prog_name,
+        linkOutput = link_output,
+        linkObjs = link_objs,
+        linkLibs = link_libs,
+        linkModule = mempty,
+        debug = "--debug" `elem` args,
+        gcSections = "--no-gc-sections" `notElem` args,
+        verboseErr = "--verbose-err" `elem` args,
+        outputIR =
+          find ("--output-ir=" `isPrefixOf`) args
+            >>= stripPrefix "--output-ir=",
+        rootSymbols =
+          map (AsteriusEntitySymbol . fromString) $
+            str_args "--extra-root-symbol=",
+        exportFunctions =
+          ("main" :)
+            $ map (AsteriusEntitySymbol . fromString)
+            $ str_args "--export-function="
+      }
   where
     prog_name
       | Just (stripPrefix "--prog-name=" -> Just v) <-

--- a/asterius/rts/rts.exports.mjs
+++ b/asterius/rts/rts.exports.mjs
@@ -1,5 +1,3 @@
-import * as rtsConstants from "./rts.constants.mjs";
-
 export class Exports {
   constructor(
     memory,
@@ -32,14 +30,5 @@ export class Exports {
 
   rts_evalLazyIO(p) {
     return this.context.scheduler.submitCmdCreateThread("createIOThread", p);
-  }
-
-  main() {
-    return this.rts_evalLazyIO(
-      this.rts_apply(
-        this.context.symbolTable.base_AsteriusziTopHandler_runMainIO_closure,
-        this.context.symbolTable.Main_main_closure
-      )
-    );
   }
 }

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -20,6 +20,7 @@ where
 
 import Asterius.Builtins.CMath
 import Asterius.Builtins.Hashable
+import Asterius.Builtins.Main
 import Asterius.Builtins.MD5
 import Asterius.Builtins.Posix
 import Asterius.Builtins.SM
@@ -205,6 +206,7 @@ rtsAsteriusModule opts =
     <> sptCBits
     <> stgPrimFloatCBits
     <> timeCBits
+    <> mainBuiltins
 
 -- Generate the module consisting of functions which need to be wrapped
 -- for communication with the external runtime.

--- a/asterius/src/Asterius/Builtins/Main.hs
+++ b/asterius/src/Asterius/Builtins/Main.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Asterius.Builtins.Main
+  ( mainBuiltins,
+  )
+where
+
+import Asterius.Types
+import qualified Data.Map.Strict as M
+import Language.Haskell.GHC.Toolkit.Constants
+
+mainBuiltins :: AsteriusModule
+mainBuiltins =
+  mempty
+    { staticsMap =
+        M.singleton
+          "main_closure"
+          AsteriusStatics
+            { staticsType = Closure,
+              asteriusStatics =
+                [ SymbolStatic "stg_ap_2_upd_info" 0,
+                  Uninitialized $ offset_StgThunk_payload - 8,
+                  SymbolStatic "base_AsteriusziTopHandler_runMainIO_closure" 0,
+                  SymbolStatic "Main_main_closure" 0
+                ]
+            },
+      ffiMarshalState =
+        mempty
+          { ffiExportDecls =
+              M.singleton
+                "main"
+                FFIExportDecl
+                  { ffiFunctionType =
+                      FFIFunctionType
+                        { ffiParamTypes = [],
+                          ffiResultTypes = [],
+                          ffiInIO = True
+                        },
+                    ffiExportClosure = "main_closure"
+                  }
+          }
+    }

--- a/asterius/src/Asterius/JSFFI.hs
+++ b/asterius/src/Asterius/JSFFI.hs
@@ -293,6 +293,7 @@ generateFFIExportLambda FFIExportDecl {ffiFunctionType = FFIFunctionType {..}, .
     ret_closure = "this.context.scheduler.getTSOret(" <> tid <> ")"
     tid = "await this." <> eval_func <> "(" <> eval_closure <> ")"
     eval_func
+      | ffiInIO && null ffiResultTypes = "rts_evalLazyIO"
       | ffiInIO = "rts_evalIO"
       | otherwise = "rts_eval"
     eval_closure =

--- a/asterius/src/Asterius/Ld.hs
+++ b/asterius/src/Asterius/Ld.hs
@@ -53,7 +53,6 @@ rtsUsedSymbols :: Set AsteriusEntitySymbol
 rtsUsedSymbols =
   Set.fromList
     [ "barf",
-      "base_AsteriusziTopHandler_runMainIO_closure",
       "base_AsteriusziTypes_makeJSException_closure",
       "base_GHCziPtr_Ptr_con_info",
       "ghczmprim_GHCziTypes_Czh_con_info",
@@ -65,7 +64,6 @@ rtsUsedSymbols =
       "ghczmprim_GHCziTypes_ZC_con_info",
       "ghczmprim_GHCziTypes_ZMZN_closure",
       "MainCapability",
-      "Main_main_closure",
       "stg_ARR_WORDS_info",
       "stg_BLACKHOLE_info",
       "stg_WHITEHOLE_info",


### PR DESCRIPTION
Previously, when we link a Haskell program with `main`, we simply ensure the `runMainIO` and `main` closures are root symbols, and the `main` method of the exports object would call `rts_apply` to create a thunk for evaluation. Come to think of it, there are two drawbacks to the approach:

* Unsafe! The `main` closure is *not* a GC root iirc. What if the exported `main` method is called multiple times, with GC triggered in between, and `main` references into the dynamic heap?
* Not elegant. `main` takes special logic in linker & runtime, but it's just yet another exported `IO a` closure.

This PR removes the `main` method in the runtime. We now handle `main` as if it's yet another `foreign export javascript` thing, but since the export declaration isn't really written by the user in the main module, we have to encode the relevant FFI info as a piece of rts builtin module. Still, it's more elegant now, and the `main` closure is properly marked as GC root upon initialization, just like all other foreign export closures.

Another minor change: when we generate JS code for exports, and the export result type is `IO ()`, we now use `rts_evalLazyIO` instead of `rts_eval`. Slightly more efficient, but semantics may change when an export returns a bottom. But we don't need to force the result anyway.

Note that `main` isn't 100% treated as an ordinary export yet; we don't apply the top handler to other exports for now. This will soon be fixed.