### PR TITLE
Apply the top handlers to all foreign exports

### DIFF
--- a/asterius/src/Asterius/Builtins/Main.hs
+++ b/asterius/src/Asterius/Builtins/Main.hs
@@ -21,7 +21,7 @@ mainBuiltins =
               asteriusStatics =
                 [ SymbolStatic "stg_ap_2_upd_info" 0,
                   Uninitialized $ offset_StgThunk_payload - 8,
-                  SymbolStatic "base_AsteriusziTopHandler_runMainIO_closure" 0,
+                  SymbolStatic "base_AsteriusziTopHandler_runIO_closure" 0,
                   SymbolStatic "Main_main_closure" 0
                 ]
             },

--- a/asterius/src/Asterius/Builtins/Main.hs
+++ b/asterius/src/Asterius/Builtins/Main.hs
@@ -13,19 +13,7 @@ import Language.Haskell.GHC.Toolkit.Constants
 mainBuiltins :: AsteriusModule
 mainBuiltins =
   mempty
-    { staticsMap =
-        M.singleton
-          "main_closure"
-          AsteriusStatics
-            { staticsType = Closure,
-              asteriusStatics =
-                [ SymbolStatic "stg_ap_2_upd_info" 0,
-                  Uninitialized $ offset_StgThunk_payload - 8,
-                  SymbolStatic "base_AsteriusziTopHandler_runIO_closure" 0,
-                  SymbolStatic "Main_main_closure" 0
-                ]
-            },
-      ffiMarshalState =
+    { ffiMarshalState =
         mempty
           { ffiExportDecls =
               M.singleton
@@ -37,7 +25,7 @@ mainBuiltins =
                           ffiResultTypes = [],
                           ffiInIO = True
                         },
-                    ffiExportClosure = "main_closure"
+                    ffiExportClosure = "Main_main_closure"
                   }
           }
     }

--- a/asterius/src/Asterius/Ld.hs
+++ b/asterius/src/Asterius/Ld.hs
@@ -53,6 +53,8 @@ rtsUsedSymbols :: Set AsteriusEntitySymbol
 rtsUsedSymbols =
   Set.fromList
     [ "barf",
+      "base_AsteriusziTopHandler_runIO_closure",
+      "base_AsteriusziTopHandler_runNonIO_closure",
       "base_AsteriusziTypes_makeJSException_closure",
       "base_GHCziPtr_Ptr_con_info",
       "ghczmprim_GHCziTypes_Czh_con_info",


### PR DESCRIPTION
Following #469, we apply the top handlers to all foreign exports:

* `Asterius.TopHandler` exports `runIO`/`runNonIO`, and their closure symbols are root symbols
* The generated JS code of foreign exports will apply the top handlers before evaluation.

For end users, this means that we now have uniform behavior for the main thread as well as user-exported functions: the `stdout`/`stderr` handles are flushed, and uncaught exceptions will be written to `stderr`.

This doesn't apply to the `makeHaskellCallback*` functions yet. Those should be deprecated in future PRs.