### PR TITLE
Do not emit export closures into the runtime symbol table

### DIFF
--- a/asterius/src/Asterius/JSFFI.hs
+++ b/asterius/src/Asterius/JSFFI.hs
@@ -303,8 +303,8 @@ generateFFIExportLambda FFIExportDecl {ffiFunctionType = FFIFunctionType {..}, .
       | ffiInIO = "base_AsteriusziTopHandler_runIO_closure"
       | otherwise = "base_AsteriusziTopHandler_runNonIO_closure"
     eval_closure =
-      "this.rts_apply(this.context.symbolTable."
-        <> run_func
+      "this.rts_apply(0x"
+        <> int64HexFixed (sym_map ! run_func)
         <> ","
         <> foldl'
           ( \acc (i, t) ->

--- a/asterius/src/Asterius/Ld.hs
+++ b/asterius/src/Asterius/Ld.hs
@@ -53,8 +53,6 @@ rtsUsedSymbols :: Set AsteriusEntitySymbol
 rtsUsedSymbols =
   Set.fromList
     [ "barf",
-      "base_AsteriusziTopHandler_runIO_closure",
-      "base_AsteriusziTopHandler_runNonIO_closure",
       "base_AsteriusziTypes_makeJSException_closure",
       "base_GHCziPtr_Ptr_con_info",
       "ghczmprim_GHCziTypes_Czh_con_info",
@@ -80,6 +78,13 @@ rtsUsedSymbols =
       "stg_WEAK_info"
     ]
 
+rtsPrivateSymbols :: Set AsteriusEntitySymbol
+rtsPrivateSymbols =
+  Set.fromList
+    [ "base_AsteriusziTopHandler_runIO_closure",
+      "base_AsteriusziTopHandler_runNonIO_closure"
+    ]
+
 linkModules ::
   LinkTask -> AsteriusModule -> (AsteriusModule, Module, LinkReport)
 linkModules LinkTask {..} m =
@@ -98,6 +103,7 @@ linkModules LinkTask {..} m =
     ( Set.unions
         [ Set.fromList rootSymbols,
           rtsUsedSymbols,
+          rtsPrivateSymbols,
           Set.fromList
             [ AsteriusEntitySymbol {entityName = internalName}
               | FunctionExport {..} <- rtsFunctionExports debug

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -187,7 +187,7 @@ genReq task LinkReport {..} =
       "jsffiFactory: ",
       generateFFIImportObjectFactory bundledFFIMarshalState,
       ", exports: ",
-      generateFFIExportObject bundledFFIMarshalState,
+      generateFFIExportObject bundledFFIMarshalState raw_symbol_table,
       ", symbolTable: ",
       genSymbolDict symbol_table,
       if debug task
@@ -215,13 +215,7 @@ genReq task LinkReport {..} =
     raw_symbol_table = staticsSymbolMap <> functionSymbolMap
     symbol_table =
       M.restrictKeys raw_symbol_table $
-        S.fromList
-          [ ffiExportClosure
-            | FFIExportDecl {..} <-
-                M.elems $
-                  ffiExportDecls bundledFFIMarshalState
-          ]
-          <> S.fromList (extraRootSymbols task)
+        S.fromList (extraRootSymbols task)
           <> rtsUsedSymbols
 
 genDefEntry :: Task -> Builder


### PR DESCRIPTION
Previously, all export closures are emitted into the runtime symbol table. This is not necessary since the relevant JS code is generated at link-time and doesn't need to be human-readable. This PR removes such symbol table entries, and use the absolute addresses of export closures in the emitted JS code.

The `runIO`/`runMainIO` symbols are also removed from the symbol table since they aren't used by the hand-written parts of the runtime. We now have a collection of "private symbol"s for the runtime, which is also a root symbol set but doesn't get emitted into the symbol table.

When linking without `main`, a dummy `main` method will still be generated, but the resulting `Promise` should reject with an unfound symbol error. This should be fine since we don't call `main` in such cases.