### PR TITLE
Remove `rts_eval` and `createGenThread`

### DIFF
--- a/asterius/rts/rts.exports.mjs
+++ b/asterius/rts/rts.exports.mjs
@@ -17,10 +17,6 @@ export class Exports {
     Object.assign(this, exports);
   }
 
-  rts_eval(p) {
-    return this.context.scheduler.submitCmdCreateThread("createGenThread", p);
-  }
-
   rts_evalIO(p) {
     return this.context.scheduler.submitCmdCreateThread(
       "createStrictIOThread",

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -214,7 +214,6 @@ generateRtsExternalInterfaceModule :: BuiltinsOptions -> AsteriusModule
 generateRtsExternalInterfaceModule opts =
   mempty
     <> rtsApplyFunction opts
-    <> createGenThreadFunction opts
     <> createIOThreadFunction opts
     <> createStrictIOThreadFunction opts
     <> scheduleTSOFunction opts
@@ -694,7 +693,6 @@ rtsFunctionExports debug =
           "rts_getStablePtr",
           "rts_getJSVal",
           "rts_apply",
-          "createGenThread",
           "createStrictIOThread",
           "createIOThread",
           "scheduleTSO",
@@ -886,7 +884,6 @@ hsInitFunction,
   rtsCheckSchedStatusFunction,
   scheduleTSOFunction,
   createThreadFunction,
-  createGenThreadFunction,
   createIOThreadFunction,
   createStrictIOThreadFunction,
   getThreadIdFunction,
@@ -1097,10 +1094,6 @@ createThreadHelper mk_closures = do
   t <- call' "createThread" [] I64
   for_ (mk_closures closure) $ pushClosure t
   emit t
-
-createGenThreadFunction _ =
-  runEDSL "createGenThread" $ createThreadHelper $ \closure ->
-    [closure, symbol "stg_enter_info"]
 
 createIOThreadFunction _ =
   runEDSL "createIOThread" $ createThreadHelper $ \closure ->

--- a/asterius/test/nomain.hs
+++ b/asterius/test/nomain.hs
@@ -16,6 +16,7 @@ main = do
       "test/nomain/NoMain.hs",
       "--output-ir",
       "--ghc-option=-no-hs-main",
+      "--extra-root-symbol=base_AsteriusziTopHandler_runNonIO_closure",
       "--extra-root-symbol=NoMain_x_closure"
     ]
       <> args
@@ -25,12 +26,18 @@ main = do
       newAsteriusInstanceNonMain
         s
         "test/nomain/NoMain"
-        ["NoMain_x_closure"]
+        ["base_AsteriusziTopHandler_runNonIO_closure", "NoMain_x_closure"]
         m
     hsInit s i
-    let x_closure = deRefJSVal i <> ".symbolTable.NoMain_x_closure"
+    let x_closure =
+          deRefJSVal i
+            <> ".exports.rts_apply("
+            <> deRefJSVal i
+            <> ".symbolTable.base_AsteriusziTopHandler_runNonIO_closure,"
+            <> deRefJSVal i
+            <> ".symbolTable.NoMain_x_closure)"
         x_tid =
-          "await " <> deRefJSVal i <> ".exports.rts_eval(" <> x_closure <> ")"
+          "await " <> deRefJSVal i <> ".exports.rts_evalIO(" <> x_closure <> ")"
         x_ret = deRefJSVal i <> ".exports.getTSOret(" <> x_tid <> ")"
         x_sp = deRefJSVal i <> ".exports.rts_getStablePtr(" <> x_ret <> ")"
         x_val' = deRefJSVal i <> ".getJSVal(" <> x_sp <> ")"

--- a/asterius/test/rtsapi.hs
+++ b/asterius/test/rtsapi.hs
@@ -10,6 +10,7 @@ main = do
       "--input-mjs",
       "test/rtsapi/rtsapi.mjs",
       "--run",
+      "--extra-root-symbol=base_AsteriusziTopHandler_runNonIO_closure",
       "--extra-root-symbol=Main_printInt_closure",
       "--extra-root-symbol=Main_fact_closure",
       "--extra-root-symbol=base_GHCziBase_id_closure"

--- a/asterius/test/rtsapi/rtsapi.mjs
+++ b/asterius/test/rtsapi/rtsapi.mjs
@@ -20,10 +20,13 @@ module
         )
       )
     );
-    const tid_p1 = await i.exports.rts_eval(
+    const tid_p1 = await i.exports.rts_evalIO(
       i.exports.rts_apply(
-        i.symbolTable.Main_fact_closure,
-        i.exports.rts_mkInt(5)
+        i.symbolTable.base_AsteriusziTopHandler_runNonIO_closure,
+        i.exports.rts_apply(
+          i.symbolTable.Main_fact_closure,
+          i.exports.rts_mkInt(5)
+        )
       )
     );
     console.log(i.exports.rts_getInt(i.exports.getTSOret(tid_p1)));
@@ -36,10 +39,13 @@ module
     console.log(i.exports.rts_getBool(i.exports.rts_mkBool(0)));
     console.log(i.exports.rts_getBool(i.exports.rts_mkBool(42)));
     const x0 = Math.random();
-    const tid_p3 = await i.exports.rts_eval(
+    const tid_p3 = await i.exports.rts_evalIO(
       i.exports.rts_apply(
-        i.symbolTable.base_GHCziBase_id_closure,
-        i.exports.rts_mkDouble(x0)
+        i.symbolTable.base_AsteriusziTopHandler_runNonIO_closure,
+        i.exports.rts_apply(
+          i.symbolTable.base_GHCziBase_id_closure,
+          i.exports.rts_mkDouble(x0)
+        )
       )
     );
     const x1 = i.exports.rts_getDouble(i.exports.getTSOret(tid_p3));


### PR DESCRIPTION
This PR removes the `rts_eval` and `createGenThread` functions from the runtime since they're no longer used after #470.