### PR TITLE
Increase number of initial MBlocks

### DIFF
--- a/asterius/rts/rts.memory.mjs
+++ b/asterius/rts/rts.memory.mjs
@@ -64,7 +64,7 @@ export class Memory {
     this.staticMBlocks = static_mblocks;
     this.initView();
     this.capacity = this.buffer.byteLength / rtsConstants.mblock_size;
-    this.liveBitset = mask(this.capacity);
+    this.liveBitset = mask(static_mblocks);
   }
 
   /**

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -41,7 +41,7 @@ export async function newAsteriusInstance(req) {
       initial: req.tableSlots
     }),
     __asterius_wasm_memory = new WebAssembly.Memory({
-      initial: req.staticMBlocks * (rtsConstants.mblock_size / 65536)
+      initial: (req.staticMBlocks + 3) * (rtsConstants.mblock_size / 65536)
     }),
     __asterius_memory = new Memory(),
     __asterius_memory_trap = new MemoryTrap(


### PR DESCRIPTION
Right now the Wasm memory is resized twice during the initialisation of the RTS. The initial capacity is set as the number of static MBlocks, but right after creation three new MBlocks are allocated: one for unpinned closures, one for pinned closures, and the nursery.

This PR may improve init time by avoiding this double resizing, as it allocates right away three more MBlocks.