### PR TITLE
Reuse typecheck/desugar logic for `prim`/`ccall` foreign imports

### DIFF
--- a/asterius/src/Asterius/Foreign/TcForeign.hs
+++ b/asterius/src/Asterius/Foreign/TcForeign.hs
@@ -116,8 +116,12 @@ asteriusTcCheckFIType arg_tys res_ty idecl@(CImport (L lc cconv) (L ls safety) m
         ( text
             "The safe/unsafe annotation should not be used with `foreign import prim'."
         )
-      checkForeignArgs (isFFIPrimArgumentTy dflags) arg_tys
-      checkForeignRes nonIOok checkSafe (isFFIPrimResultTy dflags) res_ty
+      checkForeignArgs (asteriusIsFFIArgumentTy dflags safety) arg_tys
+      checkForeignRes
+        nonIOok
+        checkSafe
+        (asteriusIsFFIImportResultTy dflags)
+        res_ty
       return idecl
   | otherwise =
     do


### PR DESCRIPTION
This PR changes the typechecking/desugaring logic of `foreign import prim` and reuse `ccall` logic. This changes the `foreign import prim` semantics in the following ways:

* Lifted arguments and return types are now accepted.
* The return type can now be `IO`-wrapped.
* Unboxed tuples are no longer accepted as arguments and return types.
* `Any` and `JSVal` are special cases which allow passing managed pointers or JavaScript references.

This is the first part of upcoming Async FFI improvements since we'll desugar async calls into Cmm tail calls, and `foreign import prim` fits nicely here.