### PR TITLE
Basic generational machinery in HeapAlloc

### DIFF
--- a/asterius/rts/rts.constants.mjs
+++ b/asterius/rts/rts.constants.mjs
@@ -13,6 +13,7 @@ export const sizeof_first_mblock = 0xfc000;
 export const offset_bdescr_start = 0x0;
 export const offset_bdescr_free = 0x8;
 export const offset_bdescr_link = 0x10;
+export const offset_bdescr_gen_no = 0x28;
 export const offset_bdescr_node = 0x2c;
 export const offset_bdescr_flags = 0x2e;
 export const offset_bdescr_blocks = 0x30;

--- a/asterius/rts/rts.gc.mjs
+++ b/asterius/rts/rts.gc.mjs
@@ -115,7 +115,7 @@ export class GC {
   }
 
   /**
-   * Heap alloactes a physical copy of the given closure.
+   * Heap allocates a physical copy of the given closure.
    * Used during evacuation by {@link GC#evacuateClosure}.
    * @param c The source address of the closure
    * @param bytes The size in bytes of the closure
@@ -264,7 +264,7 @@ export class GC {
       // a forwarding address: just follow it
       return Memory.setDynTag(info, tag);
     } else if (this.nonMovedObjects.has(untagged_c)) {
-      // The closure is eiter pinned or static, and has
+      // The closure is either pinned or static, and has
       // already been enqueued for scavenging: just return it
       return c;
     } else if (!this.memory.heapAlloced(untagged_c)) {
@@ -1028,7 +1028,11 @@ export class GC {
       return;
     }
     this.reentrancyGuard.enter(1);
-    this.heapAlloc.initUnpinned();
+
+    // Set the current generation number to 1, so that
+    // closures are evacuated in the older generation.
+    // Also, only major collections for now.
+    this.heapAlloc.setGenerationNo(1);
 
     // Evacuate TSOs
     for (const [_, tso_info] of this.scheduler.tsos) {
@@ -1072,6 +1076,8 @@ export class GC {
 
     // mark unused MBlocks
     this.heapAlloc.handleLiveness(this.liveMBlocks, this.deadMBlocks);
+    // set current generation back to 0
+    this.heapAlloc.setGenerationNo(0);
     // allocate a new nursery
     this.updateNursery();
     // garbage collect unused JSVals

--- a/asterius/rts/rts.heapalloc.mjs
+++ b/asterius/rts/rts.heapalloc.mjs
@@ -31,6 +31,13 @@ export class HeapAlloc {
      */
     this.currentPools = [undefined, undefined];
     /**
+     * An array containing the addresses of
+     * the (block descriptors of the) MBlocks
+     * allocated for each generation.
+     * @name HeapAlloc#generations
+     */
+    this.generations = new Array(2); // 2 generations
+    /**
      * The set of all currently allocated MegaGroups.
      */
     this.mgroups = new Set();
@@ -41,28 +48,35 @@ export class HeapAlloc {
    * Initializes the pinned & unpinned pools.
    */
   init() {
-    this.currentPools[0] = this.allocMegaGroup(1);
-    this.currentPools[1] = this.allocMegaGroup(1);
-    this.memory.i16Store(
-      this.currentPools[1] + rtsConstants.offset_bdescr_flags,
-      rtsConstants.BF_PINNED
-    );
+    this.setGenerationNo(0);
+    this.currentPools[1] = this.allocMegaGroup(1, true);
   }
   /**
-   * Initializes only the unpinned pool.
+   * Sets the current generation number, so that new closures and 
+   * MBlocks are allocated in the right space and with correct flag.
+   * @param {number} gen_no The generation number
+   * @param {boolean} [forceNewAlloc=true] Force the allocation
+   *   of a new MBlock. 
    */
-  initUnpinned() {
-    this.currentPools[0] = this.allocMegaGroup(1);
+  setGenerationNo(gen_no, forceNewAlloc=true) {
+    let pool = this.generations[gen_no];
+    if (forceNewAlloc || !pool) {
+      pool = this.allocMegaGroup(1, false, gen_no);
+      this.generations[gen_no] = pool;
+    }
+    this.currentPools[0] = pool;
   }
 
   /**
    * Allocates a new MegaGroup of enough MBlocks to
    * accommodate the supplied amount of bytes.
    * @param b The number of bytes to allocate
+   * @param pinned Whether the MBlocks should be pinned
+   * @param gen_no The generation number
    * @returns The address of the block descriptor
    *  of the first MBlock of the MegaGroup.
    */
-  hpAlloc(b) {
+  hpAlloc(b, pinned=false, gen_no=0) {
     const mblocks =
         b <= rtsConstants.sizeof_first_mblock
           ? 1
@@ -70,7 +84,7 @@ export class HeapAlloc {
             Math.ceil(
               (b - rtsConstants.sizeof_first_mblock) / rtsConstants.mblock_size
             ),
-      bd = this.allocMegaGroup(mblocks);
+      bd = this.allocMegaGroup(mblocks, pinned, gen_no);
     return bd;
   }
 
@@ -81,22 +95,19 @@ export class HeapAlloc {
    * @param pinned Whether to allocate in the pinned pool
    */
   allocate(n, pinned = false) {
-    let b = n << 3, // The size in bytes
-      // Large objects are forced to be pinned as well
-      // (by large, we mean >= 4KiB):
-      pool_i = Number(pinned || b >= rtsConstants.block_size),
+    const b = n << 3; // The size in bytes
+    // Large objects are forced to be pinned as well
+    // (by large, we mean >= 4KiB):
+    pinned = pinned || b >= rtsConstants.block_size;
+    let pool = this.currentPools[Number(pinned)],
       current_start = Number(
-        this.memory.i64Load(
-          this.currentPools[pool_i] + rtsConstants.offset_bdescr_start
-        )
+        this.memory.i64Load(pool + rtsConstants.offset_bdescr_start)
       ),
       current_free = Number(
-        this.memory.i64Load(
-          this.currentPools[pool_i] + rtsConstants.offset_bdescr_free
-        )
-      ),
-      current_blocks = this.memory.i32Load(
-        this.currentPools[pool_i] + rtsConstants.offset_bdescr_blocks
+        this.memory.i64Load(pool + rtsConstants.offset_bdescr_free)
+      );
+    const current_blocks = this.memory.i32Load(
+        pool + rtsConstants.offset_bdescr_blocks
       ),
       current_limit = current_start + rtsConstants.block_size * current_blocks,
       new_free = current_free + b;
@@ -104,25 +115,28 @@ export class HeapAlloc {
     if (new_free <= current_limit) {
       // if the pool has enough space
       this.memory.i64Store(
-        this.currentPools[pool_i] + rtsConstants.offset_bdescr_free,
+        pool + rtsConstants.offset_bdescr_free,
         new_free
       );
     } else {
       // not enough space in the corresponding pool,
       // allocate a new one
-      this.currentPools[pool_i] = this.hpAlloc(b);
-      if (pool_i)
-        this.memory.i16Store(
-          this.currentPools[pool_i] + rtsConstants.offset_bdescr_flags,
-          rtsConstants.BF_PINNED
-        );
+      if (pinned) {
+        pool = this.hpAlloc(b, true);
+        this.currentPools[1] = pool;
+      } else {
+        const gen_no = this.memory.i16Load(pool + rtsConstants.offset_bdescr_gen_no);
+        pool = this.hpAlloc(b, false, gen_no);
+        this.currentPools[0] = pool;
+        this.generations[gen_no] = pool;
+      }
       current_free = Number(
         this.memory.i64Load(
-          this.currentPools[pool_i] + rtsConstants.offset_bdescr_free
+          pool + rtsConstants.offset_bdescr_free
         )
       );
       this.memory.i64Store(
-        this.currentPools[pool_i] + rtsConstants.offset_bdescr_free,
+        pool + rtsConstants.offset_bdescr_free,
         current_free + b
       );
     }
@@ -138,12 +152,14 @@ export class HeapAlloc {
   }
 
   /**
-   * Allocates a new MegaGroup of size the supplies number of MBlocks.
+   * Allocates a new MegaGroup of size the supplied number of MBlocks.
    * @param n The number of requested MBlocks
+   * @param pinned Whether the MBlocks should be pinned
+   * @param gen_no The generation number
    * @return The address of the block descriptor
    *  of the first MBlock of the MegaGroup
    */
-  allocMegaGroup(n) {
+  allocMegaGroup(n, pinned=false, gen_no=0) {
     const req_blocks =
         (rtsConstants.mblock_size * n - rtsConstants.offset_first_block) /
         rtsConstants.block_size,
@@ -155,6 +171,11 @@ export class HeapAlloc {
     this.memory.i64Store(bd + rtsConstants.offset_bdescr_link, 0);
     this.memory.i16Store(bd + rtsConstants.offset_bdescr_node, n);
     this.memory.i32Store(bd + rtsConstants.offset_bdescr_blocks, req_blocks);
+    this.memory.i16Store(
+      bd + rtsConstants.offset_bdescr_flags,
+      pinned ? rtsConstants.BF_PINNED : 0
+    );
+    this.memory.i16Store(bd + rtsConstants.offset_bdescr_gen_no, gen_no);
     this.mgroups.add(bd);
     return bd;
   }
@@ -165,8 +186,9 @@ export class HeapAlloc {
    * garbage collector. Used by {@link GC#performGC}.
    * @param live_mblocks The set of current live MBlocks
    * @param live_mblocks The set of current dead MBlocks
+   * @param major Whether this info comes from a minor or major GC
    */
-  handleLiveness(live_mblocks, dead_mblocks) {
+  handleLiveness(live_mblocks, dead_mblocks, major=true) {
     for (const bd of live_mblocks) {
       if (!this.mgroups.has(bd)) {
         throw new WebAssembly.RuntimeError(
@@ -186,26 +208,37 @@ export class HeapAlloc {
         n = this.memory.i16Load(bd + rtsConstants.offset_bdescr_node);
       this.memory.freeMBlocks(p, n);
     }
+
     // Free unreachable MBlocks
     for (const bd of Array.from(this.mgroups)) {
       if (!live_mblocks.has(bd)) {
-        this.mgroups.delete(bd);
-        const p = bd - rtsConstants.offset_first_bdescr,
-          n = this.memory.i16Load(bd + rtsConstants.offset_bdescr_node);
-        this.memory.freeMBlocks(p, n);
+        const
+          gen_no = this.memory.i16Load(bd + rtsConstants.offset_bdescr_gen_no),
+          pinned = Boolean(
+            this.memory.i16Load(bd + rtsConstants.offset_bdescr_flags) & rtsConstants.BF_PINNED
+          );
+        // Note: not all unreachable MBlocks can be 
+        // freed during a minor collection. This is because
+        // pinned MBlocks or older MBlocks may look unreachable
+        // since only the pointers to younger generations
+        // are stored in the remembered set.
+        if(major || (!pinned && gen_no == 0)) {
+          this.mgroups.delete(bd);
+          const p = bd - rtsConstants.offset_first_bdescr,
+            n = this.memory.i16Load(bd + rtsConstants.offset_bdescr_node);
+          this.memory.freeMBlocks(p, n);
+        }
       }
     }
-    // Reinitialize pools if necessary
-    if (!this.mgroups.has(this.currentPools[0])) {
-      this.currentPools[0] = this.allocMegaGroup(1);
-    }
+    // Reallocate pinned pool if the current has been freed
     if (!this.mgroups.has(this.currentPools[1])) {
-      this.currentPools[1] = this.allocMegaGroup(1);
-      this.memory.i16Store(
-        this.currentPools[1] + rtsConstants.offset_bdescr_flags,
-        rtsConstants.BF_PINNED
-      );
+      this.currentPools[1] = this.allocMegaGroup(1, true);
     }
+    // Reinitialize generations if necessary
+    for (let i=0; i < this.generations.length; i++)
+      if (!this.mgroups.has(this.generations[i])) {
+        this.generations[i] = undefined;
+      }
   }
 
   /**

--- a/asterius/src/Asterius/JSGen/Constants.hs
+++ b/asterius/src/Asterius/JSGen/Constants.hs
@@ -49,6 +49,8 @@ rtsConstants =
       intHex offset_bdescr_free,
       ";\nexport const offset_bdescr_link = ",
       intHex offset_bdescr_link,
+      ";\nexport const offset_bdescr_gen_no = ",
+      intHex offset_bdescr_gen_no,
       ";\nexport const offset_bdescr_node = ",
       intHex offset_bdescr_node,
       ";\nexport const offset_bdescr_flags = ",

--- a/ghc-toolkit/cbits/ghc_constants.c
+++ b/ghc-toolkit/cbits/ghc_constants.c
@@ -32,6 +32,8 @@ HsInt offset_bdescr_free() { return offsetof(bdescr, free); }
 
 HsInt offset_bdescr_link() { return offsetof(bdescr, link); }
 
+HsInt offset_bdescr_gen_no() { return offsetof(bdescr, gen_no); }
+
 HsInt offset_bdescr_node() { return offsetof(bdescr, node); }
 
 HsInt offset_bdescr_flags() { return offsetof(bdescr, flags); }

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Constants.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Constants.hs
@@ -35,6 +35,8 @@ foreign import ccall unsafe "offset_bdescr_free" offset_bdescr_free :: Int
 
 foreign import ccall unsafe "offset_bdescr_link" offset_bdescr_link :: Int
 
+foreign import ccall unsafe "offset_bdescr_gen_no" offset_bdescr_gen_no :: Int
+
 foreign import ccall unsafe "offset_bdescr_node" offset_bdescr_node :: Int
 
 foreign import ccall unsafe "offset_bdescr_flags" offset_bdescr_flags :: Int


### PR DESCRIPTION
This PR is a prerequisite for generational GC #455, and it basically introduces generations in the RTS `HeapAlloc` module.
- It adds the new constant `offset_bdescr_gen_no` to read/write generation numbers of MBlocks;
- It adds to `HeapAlloc` the new attribute `generations` which is an array containing the addresses of the block descriptors of the pools for each generation;
- It adds the new method `setGenerationNo` which sets the current unpinned pool to the desired generation, also allocating a new MBlock within that generation if necessary;
- It adds optional arguments to various functions (`hpAlloc`, `allocMegaGroup`, `handleLiveness`), so to handle uniformly pinned/unpinned blocks and generation numbers.