### PR TITLE
Use eager blackholing for thunk entry code

### DIFF
--- a/asterius/src/Asterius/FrontendPlugin.hs
+++ b/asterius/src/Asterius/FrontendPlugin.hs
@@ -61,6 +61,7 @@ frontendPlugin = makeFrontendPlugin $ do
                 GHC.sPgm_i = "false"
               }
         }
+        `GHC.gopt_set` GHC.Opt_EagerBlackHoling
         `GHC.gopt_set` GHC.Opt_ExternalInterpreter
   when is_debug $ do
     dflags <- GHC.getSessionDynFlags


### PR DESCRIPTION
This PR flips on `-feager-blackholing`. This should be a good default compared to lazy blackholing:

* Two additional store instructions when entering a thunk. No atomic instruction here so the additional overhead is quite small.
* Drop references to thunk free variables early. May help in reducing heap residency.
* Help catching cyclic data dependency and avoiding wasted calculation of thunks.
* No need for a stack traversal to update the update frames in `threadPaused`.

The proper implementation of `messageBlackhole` and `updateThunk`, as well as the logic of throwing non-termination exceptions or resurrecting threads blocked on a thunk, will follow in subsequent PRs.