### PR TITLE
Add vscode remote containers support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,54 @@
+FROM debian:sid
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV \
+  LANG=C.UTF-8 \
+  LC_ALL=C.UTF-8 \
+  LC_CTYPE=C.UTF-8 \
+  PATH=/home/asterius/.local/bin:${PATH}
+
+RUN \
+  echo 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20200224T000000Z sid main' > /etc/apt/sources.list && \
+  apt update && \
+  apt full-upgrade -y && \
+  apt install -y \
+    automake \
+    cmake \
+    curl \
+    direnv \
+    g++ \
+    gawk \
+    gcc \
+    git \
+    gnupg \
+    libffi-dev \
+    libgmp-dev \
+    libncurses-dev \
+    libnuma-dev \
+    make \
+    python3-pip \
+    sudo \
+    xz-utils \
+    zlib1g-dev && \
+  curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+  echo "deb https://deb.nodesource.com/node_13.x sid main" > /etc/apt/sources.list.d/nodesource.list && \
+  apt update && \
+  apt install -y nodejs && \
+  useradd --create-home --shell /bin/bash asterius && \
+  echo "asterius ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+USER asterius
+
+WORKDIR /home/asterius
+
+RUN \
+  echo "eval \"\$(direnv hook bash)\"" >> ~/.bashrc && \
+  mkdir -p ~/.local/bin && \
+  curl -L https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack' && \
+  curl -L https://downloads.haskell.org/~cabal/cabal-install-3.0.0.0/cabal-install-3.0.0.0-x86_64-unknown-linux.tar.xz | tar xJ -C ~/.local/bin 'cabal' && \
+  stack update && \
+  cabal v1-update && \
+  pip3 install \
+    recommonmark \
+    sphinx

--- a/.devcontainer/build.sh
+++ b/.devcontainer/build.sh
@@ -1,0 +1,22 @@
+#!/bin/sh -e
+
+export CPUS=$(getconf _NPROCESSORS_ONLN 2>/dev/null)
+export ASTERIUS_BUILD_OPTIONS=-j$CPUS
+export MAKEFLAGS=-j$CPUS
+
+stack build -j$CPUS \
+  brittany \
+  ghcid \
+  hlint \
+  ormolu \
+  wabt \
+  wai-app-static
+
+stack build -j$CPUS --test --no-run-tests \
+  asterius \
+  ghc-toolkit \
+  wasm-toolkit
+
+stack exec ahc-boot
+
+direnv allow .envrc

--- a/.devcontainer/build.sh
+++ b/.devcontainer/build.sh
@@ -4,17 +4,17 @@ export CPUS=$(getconf _NPROCESSORS_ONLN 2>/dev/null)
 export ASTERIUS_BUILD_OPTIONS=-j$CPUS
 export MAKEFLAGS=-j$CPUS
 
-stack build -j$CPUS \
+stack install -j$CPUS \
   brittany \
   ghcid \
   hlint \
   ormolu \
-  wabt \
   wai-app-static
 
 stack build -j$CPUS --test --no-run-tests \
   asterius \
   ghc-toolkit \
+  wabt \
   wasm-toolkit
 
 stack exec ahc-boot

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "asterius",
+  "dockerFile": "Dockerfile",
+  "appPort": [3000],
+  "remoteUser": "asterius",
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+  "postCreateCommand": ".devcontainer/build.sh",
+  "extensions": [
+    "justusadam.language-haskell",
+    "hoovercj.haskell-linter",
+    "maxgabriel.brittany",
+    "sjurmillidahl.ormolu-vscode",
+    "esbenp.prettier-vscode",
+    "stkb.rewrap"
+  ]
+}

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-export PATH=$(stack path --bin-path)
+export PATH=$(stack exec printenv PATH)


### PR DESCRIPTION
This PR adds the configuration for [vscode remote containers](https://code.visualstudio.com/docs/remote/containers). For vscode users, setting up the dev environment for hacking on asterius should be way simpler than before: do an initial build of the container, go grab a cup of tea, period. Some common tools are included in the build script: `ghcid`, `hlint`, `brittany`, `ormolu`, `wai-app-static` and `wabt`.