### PR TITLE
Use generic updateThunk() when handling update frames upon exceptions

### DIFF
--- a/asterius/rts/rts.exception.mjs
+++ b/asterius/rts/rts.exception.mjs
@@ -6,9 +6,10 @@ import { Memory } from "./rts.memory.mjs";
   The methods of this class are related to exception handling in Haskell.
  */
 export class ExceptionHelper {
-  constructor(memory, heapalloc, info_tables, symbol_table) {
+  constructor(memory, heapalloc, exports, info_tables, symbol_table) {
     this.memory = memory;
     this.heapAlloc = heapalloc;
+    this.exports = exports;
     this.infoTables = info_tables;
     this.symbolTable = symbol_table;
     this.decoder = new TextDecoder("utf-8", { fatal: true });
@@ -59,9 +60,10 @@ export class ExceptionHelper {
           const p1 = Number(
             this.memory.i64Load(p + rtsConstants.offset_StgUpdateFrame_updatee)
           );
-          this.memory.i64Store(p1, this.symbolTable.stg_BLACKHOLE_info);
-          this.memory.i64Store(
-            p1 + rtsConstants.offset_StgInd_indirectee,
+          this.exports.updateThunk(
+            this.symbolTable.MainCapability,
+            tso,
+            p1,
             raise_closure
           );
           const size = Number(raw_layout & BigInt(0x3f));
@@ -96,7 +98,9 @@ export class ExceptionHelper {
         }
         default:
           throw new WebAssembly.RuntimeError(
-            "raiseExceptionHelper: unsupported stack frame"
+            `raiseExceptionHelper: unsupported stack frame ${type} at 0x${p.toString(
+              16
+            )}`
           );
       }
     }

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -88,12 +88,6 @@ export async function newAsteriusInstance(req) {
       req.yolo,
       req.gcThreshold
     ),
-    __asterius_exception_helper = new ExceptionHelper(
-      __asterius_memory,
-      __asterius_heapalloc,
-      req.infoTables,
-      req.symbolTable
-    ),
     __asterius_float_cbits = new FloatCBits(__asterius_memory),
     __asterius_messages = new Messages(__asterius_memory, __asterius_fs),
     __asterius_unicode = new Unicode(),
@@ -104,6 +98,13 @@ export async function newAsteriusInstance(req) {
       __asterius_scheduler,
       req.exports,
       __asterius_stableptr_manager
+    ),
+    __asterius_exception_helper = new ExceptionHelper(
+      __asterius_memory,
+      __asterius_heapalloc,
+      __asterius_exports,
+      req.infoTables,
+      req.symbolTable
     );
   __asterius_scheduler.exports = __asterius_exports;
 

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -196,6 +196,7 @@ rtsAsteriusModule opts =
     <> generateRtsExternalInterfaceModule opts
     <> generateWrapperModule (generateRtsExternalInterfaceModule opts)
     <> blackholeCBits
+    <> generateWrapperModule blackholeCBits
     <> smCBits
     <> generateWrapperModule smCBits
     <> cmathCBits
@@ -698,7 +699,8 @@ rtsFunctionExports debug =
           "deRefStablePtr",
           "hs_free_stable_ptr",
           "makeStableName",
-          "growStack"
+          "growStack",
+          "updateThunk"
         ]
   ]
     <> [ FunctionExport {internalName = "__asterius_" <> f, externalName = f}


### PR DESCRIPTION
A follow-up PR of #493.

Consider this example:

```haskell
import Asterius.Types
import Control.Concurrent
import Control.Exception
import Data.Foldable
import System.IO.Unsafe

main :: IO ()
main = do
  for_ [0 .. 7] $ \_ -> forkIO $ p' g
  p' g

foreign import javascript safe "new Promise((resolve,reject) => setTimeout(() => { console.error('Rejecting!'); const err = new Error('BOOM'); reject(err); }, 1000))" f :: IO Int

foreign import javascript "console.error('Printing ' + ${1})" p :: JSString -> IO ()

{-# NOINLINE g #-}
g :: Int
g = unsafeDupablePerformIO f

p' :: Show a => a -> IO ()
p' x =
  catch
    (p (toJSString (show x)))
    (\e -> p (toJSString (show (e :: JSException))))
```

The correct semantics should be: 9 different `BOOM` error messages with their JS stack traces written to the console. Why? Because `g` is a shared thunk, and upon `Promise` rejection, the thunk is updated with the `raise#` closure, and the thunk update logic must also wake up all other threads suspended by the blackhole.

Previously the thunk update logic in `raiseExceptionHelper` didn't consider the blocking queue, so once a thunk is overwritten with a `raise#` closure, the threads suspended on it are forgotten and never waken up, thus only one `BOOM` write to the console. We now improve the `updateThunk` function to handle all blackholes with/without a blocking queue attached, and then export and use the generic `updateThunk` function in `raiseExceptionHelper`.