### PR TITLE
Change JSFFI import syntax

### DIFF
--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -65,7 +65,6 @@ dependencies:
   - libiserv
   - mtl
   - npm-utils
-  - parsec
   - process
   - template-haskell
   - transformers

--- a/asterius/src/Asterius/Foreign/Internals.hs
+++ b/asterius/src/Asterius/Foreign/Internals.hs
@@ -88,10 +88,7 @@ parseFFIFunctionType accept_prim norm_sig_ty = case res_ty of
 parseField :: Parser a -> Parser (Chunk a)
 parseField f = do
   void $ char '$'
-  void $ char '{'
-  v <- f
-  void $ char '}'
-  pure $ Field v
+  Field <$> f
 
 parseChunk :: Parser (Chunk a) -> Parser (Chunk a)
 parseChunk f = try f <|> do

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -38,7 +38,6 @@ module Asterius.Types
     RelooperAddBranch (..),
     RelooperBlock (..),
     RelooperRun (..),
-    Chunk (..),
     FFIValueTypeRep (..),
     FFIValueType (..),
     FFIFunctionType (..),
@@ -597,13 +596,6 @@ data RelooperRun
 
 instance Binary RelooperRun
 
-data Chunk a
-  = Lit String
-  | Field a
-  deriving (Eq, Show, Generic, Data)
-
-instance Binary a => Binary (Chunk a)
-
 data FFIValueTypeRep
   = FFILiftedRep
   | FFIUnliftedRep
@@ -647,7 +639,7 @@ data FFIImportDecl
   = FFIImportDecl
       { ffiFunctionType :: FFIFunctionType,
         ffiSafety :: FFISafety,
-        ffiSourceChunks :: [Chunk Int]
+        ffiSourceText :: SBS.ShortByteString
       }
   deriving (Eq, Show, Generic, Data)
 

--- a/asterius/test/array/array.hs
+++ b/asterius/test/array/array.hs
@@ -1,7 +1,7 @@
 import Data.Array.IArray
 import Data.Array.Unboxed
 
-foreign import javascript "console.log(${1})" js_print_int :: Int -> IO ()
+foreign import javascript "console.log($1)" js_print_int :: Int -> IO ()
 
 facts :: [Int]
 facts = scanl (*) 1 [1 ..]

--- a/asterius/test/cloudflare/cloudflare.hs
+++ b/asterius/test/cloudflare/cloudflare.hs
@@ -21,11 +21,11 @@ handleFetch ev = do
     _ ->
       js_new_response (toJSString "Hello from Haskell") 200
 
-foreign import javascript "${1} === undefined"
+foreign import javascript "$1 === undefined"
   js_is_undefined :: JSVal -> Bool
 
-foreign import javascript safe "${1}.json()"
+foreign import javascript safe "$1.json()"
   js_request_json :: JSVal -> JSObject
 
-foreign import javascript "new Response(${1}, {\"status\": ${2}})"
+foreign import javascript "new Response($1, {\"status\": $2})"
   js_new_response :: JSString -> Int -> IO JSObject

--- a/asterius/test/jsffi/AsteriusPrim.hs
+++ b/asterius/test/jsffi/AsteriusPrim.hs
@@ -86,27 +86,27 @@ callJSFunction f args = js_function_apply f js_object_empty (toJSArray args)
 
 foreign import javascript "\"\"" js_string_empty :: JSVal
 
-foreign import javascript "${1}.concat(${2})"
+foreign import javascript "$1.concat($2)"
   js_concat :: JSVal -> JSVal -> JSVal
 
-foreign import javascript "${1}.length" js_length :: JSVal -> Int
+foreign import javascript "$1.length" js_length :: JSVal -> Int
 
-foreign import javascript "String.fromCodePoint(${1})"
+foreign import javascript "String.fromCodePoint($1)"
   js_string_fromchar :: Char -> JSVal
 
-foreign import javascript "${1}.codePointAt(${2})"
+foreign import javascript "$1.codePointAt($2)"
   js_string_tochar :: JSVal -> Int -> Char
 
 foreign import javascript "[]" js_array_empty :: JSVal
 
-foreign import javascript "${1}[${2}]" js_index_by_int :: JSVal -> Int -> JSVal
+foreign import javascript "$1[$2]" js_index_by_int :: JSVal -> Int -> JSVal
 
 foreign import javascript "{}" js_object_empty :: JSVal
 
-foreign import javascript "${1}[${2}]"
+foreign import javascript "$1[$2]"
   js_index_by_jsref :: JSVal -> JSVal -> JSVal
 
 foreign import javascript "JSON" js_json :: JSVal
 
-foreign import javascript "${1}.apply(${2}, ${3})"
+foreign import javascript "$1.apply($2, $3)"
   js_function_apply :: JSVal -> JSVal -> JSVal -> JSVal

--- a/asterius/test/jsffi/jsffi.hs
+++ b/asterius/test/jsffi/jsffi.hs
@@ -6,16 +6,16 @@ import Foreign.StablePtr
 
 foreign import javascript "new Date()" current_time :: IO JSVal
 
-foreign import javascript "console.log(${1})" js_print :: JSVal -> IO ()
+foreign import javascript "console.log($1)" js_print :: JSVal -> IO ()
 
-foreign import javascript "console.log(String.fromCodePoint(${1}))"
+foreign import javascript "console.log(String.fromCodePoint($1))"
   js_putchar :: Char -> IO ()
 
-foreign import javascript "${1} * ${2}" js_mult :: Int -> Int -> Int
+foreign import javascript "$1 * $2" js_mult :: Int -> Int -> Int
 
-foreign import javascript "console.log(${1})" print_int :: Int -> IO ()
+foreign import javascript "console.log($1)" print_int :: Int -> IO ()
 
-foreign import javascript "${1}"
+foreign import javascript "$1"
   js_stableptr_id :: StablePtr Int -> IO (StablePtr Int)
 
 foreign import javascript "false" js_false :: Bool
@@ -24,7 +24,7 @@ foreign import javascript "true" js_true :: Bool
 
 foreign import javascript "Math.random()" js_random :: IO Double
 
-foreign import javascript "console.log(${1})" js_print_double :: Double -> IO ()
+foreign import javascript "console.log($1)" js_print_double :: Double -> IO ()
 
 foreign export javascript "mult_hs_int" (*) :: Int -> Int -> Int
 

--- a/asterius/test/parsec/parsec.hs
+++ b/asterius/test/parsec/parsec.hs
@@ -6,7 +6,7 @@ import Text.Parsec.Combinator
 import Text.Parsec.Prim
 import Text.Parsec.Token
 
-foreign import javascript "console.log(${1})" js_print :: JSVal -> IO ()
+foreign import javascript "console.log($1)" js_print :: JSVal -> IO ()
 
 main :: IO ()
 main = do

--- a/asterius/test/rts/FFI.hs
+++ b/asterius/test/rts/FFI.hs
@@ -6,7 +6,7 @@ import Control.Exception
 import Control.Monad
 import Data.Coerce
 
-foreign import javascript "console.log(${1})" js_print :: JSVal -> IO ()
+foreign import javascript "console.log($1)" js_print :: JSVal -> IO ()
 
 foreign import javascript safe "(() => {throw 'FAILED'})()" js_failed :: IO ()
 

--- a/asterius/test/rts/ForkIO.hs
+++ b/asterius/test/rts/ForkIO.hs
@@ -3,7 +3,7 @@ import Control.Concurrent
 import Control.Monad
 import Data.Coerce
 
-foreign import javascript "console.log(${1})" js_print :: JSVal -> IO ()
+foreign import javascript "console.log($1)" js_print :: JSVal -> IO ()
 
 printString :: String -> IO ()
 printString s = js_print (coerce (toJSString s))

--- a/asterius/test/rts/MVar.hs
+++ b/asterius/test/rts/MVar.hs
@@ -7,7 +7,7 @@ import Control.Monad
 import Data.Coerce
 import System.Mem
 
-foreign import javascript "console.log(${1})" js_print :: JSVal -> IO ()
+foreign import javascript "console.log($1)" js_print :: JSVal -> IO ()
 
 printString :: String -> IO ()
 printString s = js_print (coerce (toJSString s))

--- a/asterius/test/rts/ThreadDelay.hs
+++ b/asterius/test/rts/ThreadDelay.hs
@@ -2,7 +2,7 @@ import Asterius.Types
 import Control.Concurrent
 import Data.Coerce
 
-foreign import javascript "console.log(${1})" js_print :: JSVal -> IO ()
+foreign import javascript "console.log($1)" js_print :: JSVal -> IO ()
 
 printString :: String -> IO ()
 printString s = js_print (coerce (toJSString s))

--- a/asterius/test/rtsapi/rtsapi.hs
+++ b/asterius/test/rtsapi/rtsapi.hs
@@ -7,7 +7,7 @@ module Main
   )
 where
 
-foreign import javascript "console.log(${1})" js_print_int :: Int -> IO ()
+foreign import javascript "console.log($1)" js_print_int :: Int -> IO ()
 
 printInt :: Int -> IO ()
 printInt = js_print_int

--- a/asterius/test/teletype/teletype.hs
+++ b/asterius/test/teletype/teletype.hs
@@ -13,18 +13,18 @@ foreign import javascript safe "['asdf', 'zer0']" js_get_arr :: IO JSArray
 foreign import javascript safe "(new Uint8Array([2, 3, 5, 7])).buffer"
   js_get_buf :: IO JSArrayBuffer
 
-foreign import javascript safe "console.log(new Uint8Array(${1}))"
+foreign import javascript safe "console.log(new Uint8Array($1))"
   js_print_buf :: JSArrayBuffer -> IO ()
 
-foreign import javascript safe "console.log(${1})" js_print :: JSVal -> IO ()
+foreign import javascript safe "console.log($1)" js_print :: JSVal -> IO ()
 
-foreign import javascript safe "setTimeout(${1},${2},${3})"
+foreign import javascript safe "setTimeout($1,$2,$3)"
   js_setTimeout :: JSFunction -> Int -> JSVal -> IO ()
 
-foreign import javascript safe "console.log([${1},${2}])"
+foreign import javascript safe "console.log([$1,$2])"
   js_print2 :: JSVal -> JSVal -> IO ()
 
-foreign import javascript safe "setTimeout(${1},${2},${3},${4})"
+foreign import javascript safe "setTimeout($1,$2,$3,$4)"
   js_setTimeout2 :: JSFunction -> Int -> JSVal -> JSVal -> IO ()
 
 main :: IO ()

--- a/asterius/test/text/text.hs
+++ b/asterius/test/text/text.hs
@@ -6,11 +6,11 @@ import qualified Data.Char as C
 import Data.Coerce
 import Data.Text as Text
 
-foreign import javascript "console.log(${1})" js_print_bool :: Bool -> IO ()
+foreign import javascript "console.log($1)" js_print_bool :: Bool -> IO ()
 
-foreign import javascript "console.log(${1})" js_print_int :: Int -> IO ()
+foreign import javascript "console.log($1)" js_print_int :: Int -> IO ()
 
-foreign import javascript "console.log(${1})" js_print :: JSVal -> IO ()
+foreign import javascript "console.log($1)" js_print :: JSVal -> IO ()
 
 sampleText :: Text
 {-# NOINLINE sampleText #-}

--- a/asterius/test/todomvc/WebAPI.hs
+++ b/asterius/test/todomvc/WebAPI.hs
@@ -63,30 +63,30 @@ localStorageGetItem k = do
   where
     js_k = toJSString k
 
-foreign import javascript "console.log(${1})" consoleLog :: JSVal -> IO ()
+foreign import javascript "console.log($1)" consoleLog :: JSVal -> IO ()
 
-foreign import javascript "document.createElement(${1})"
+foreign import javascript "document.createElement($1)"
   js_createElement :: JSString -> IO JSVal
 
-foreign import javascript "${1}.setAttribute(${2},${3})"
+foreign import javascript "$1.setAttribute($2,$3)"
   js_setAttribute :: JSVal -> JSString -> JSString -> IO ()
 
-foreign import javascript "${1}.appendChild(${2})"
+foreign import javascript "$1.appendChild($2)"
   appendChild :: JSVal -> JSVal -> IO ()
 
-foreign import javascript "${1}.hidden = ${2}"
+foreign import javascript "$1.hidden = $2"
   setHidden :: JSVal -> Bool -> IO ()
 
-foreign import javascript "${1}.addEventListener(${2},${3})"
+foreign import javascript "$1.addEventListener($2,$3)"
   js_addEventListener :: JSVal -> JSString -> JSFunction -> IO ()
 
-foreign import javascript "document.createTextNode(${1})"
+foreign import javascript "document.createTextNode($1)"
   js_createTextNode :: JSString -> IO JSVal
 
-foreign import javascript "${1}.replaceWith(${2})"
+foreign import javascript "$1.replaceWith($2)"
   replaceWith :: JSVal -> JSVal -> IO ()
 
-foreign import javascript "window.addEventListener(\"popstate\", ${1})"
+foreign import javascript "window.addEventListener(\"popstate\", $1)"
   onPopstate :: JSFunction -> IO ()
 
 foreign import javascript "window.location.href.split(\"#/\")[1] || \"\""
@@ -95,14 +95,14 @@ foreign import javascript "window.location.href.split(\"#/\")[1] || \"\""
 foreign import javascript "Math.random().toString(36).slice(2)"
   js_randomString :: IO JSString
 
-foreign import javascript "document.getElementById(${1})"
+foreign import javascript "document.getElementById($1)"
   js_getElementById :: JSString -> IO JSVal
 
-foreign import javascript "localStorage.setItem(${1},${2})"
+foreign import javascript "localStorage.setItem($1,$2)"
   js_localStorage_setItem :: JSString -> JSString -> IO ()
 
-foreign import javascript "localStorage.getItem(${1}) !== null"
+foreign import javascript "localStorage.getItem($1) !== null"
   js_localStorage_hasItem :: JSString -> IO Bool
 
-foreign import javascript "localStorage.getItem(${1})"
+foreign import javascript "localStorage.getItem($1)"
   js_localStorage_getItem :: JSString -> IO JSString

--- a/docs/jsffi.md
+++ b/docs/jsffi.md
@@ -53,7 +53,7 @@ import Asterius.Types
 
 foreign import javascript "new Date()" current_time :: IO JSVal
 
-foreign import javascript interruptible "fetch(${1})" fetch :: JSVal -> IO JSVal
+foreign import javascript interruptible "fetch($1)" fetch :: JSVal -> IO JSVal
 ```
 
 The source text of `foreign import javascript` should be a single valid

--- a/ghc-toolkit/boot-libs/asterius-prelude/src/Asterius/Aeson.hs
+++ b/ghc-toolkit/boot-libs/asterius-prelude/src/Asterius/Aeson.hs
@@ -16,6 +16,6 @@ jsonToJSVal = js_dec . utf8ToJSString . A.encode
 jsonFromJSVal :: A.FromJSON a => JSVal -> Either String a
 jsonFromJSVal = A.eitherDecode' . utf8FromJSString . js_enc
 
-foreign import javascript "JSON.stringify(${1})" js_enc :: JSVal -> JSString
+foreign import javascript "JSON.stringify($1)" js_enc :: JSVal -> JSString
 
-foreign import javascript "JSON.parse(${1})" js_dec :: JSString -> JSVal
+foreign import javascript "JSON.parse($1)" js_dec :: JSString -> JSVal

--- a/ghc-toolkit/boot-libs/asterius-prelude/src/Asterius/UTF8.hs
+++ b/ghc-toolkit/boot-libs/asterius-prelude/src/Asterius/UTF8.hs
@@ -37,12 +37,12 @@ foreign import javascript "''" js_str_empty :: JSString
 foreign import javascript "(() => {const dec = new TextDecoder('utf-8', {fatal: true}); dec.result = ''; return dec;})()"
   js_dec :: IO JSVal
 
-foreign import javascript "${1}.result += ${1}.decode(new Uint8Array(__asterius_jsffi.exports.memory.buffer, ${2} & 0xffffffff, ${3}), {stream: true})"
+foreign import javascript "$1.result += $1.decode(new Uint8Array(__asterius_jsffi.exports.memory.buffer, $2 & 0xffffffff, $3), {stream: true})"
   js_dec_chunk :: JSVal -> Ptr a -> Int -> IO ()
 
-foreign import javascript "${1}.result" js_dec_result :: JSVal -> IO JSString
+foreign import javascript "$1.result" js_dec_result :: JSVal -> IO JSString
 
-foreign import javascript "${1}.length" js_str_len :: JSString -> IO Int
+foreign import javascript "$1.length" js_str_len :: JSString -> IO Int
 
-foreign import javascript "(new TextEncoder()).encodeInto(${1}, new Uint8Array(__asterius_jsffi.exports.memory.buffer, ${2} & 0xffffffff, ${3})).written"
+foreign import javascript "(new TextEncoder()).encodeInto($1, new Uint8Array(__asterius_jsffi.exports.memory.buffer, $2 & 0xffffffff, $3)).written"
   js_utf8_from_str :: JSString -> Ptr a -> Int -> IO Int

--- a/ghc-toolkit/boot-libs/base/Asterius/Prim.hs
+++ b/ghc-toolkit/boot-libs/base/Asterius/Prim.hs
@@ -163,61 +163,61 @@ foreign import ccall unsafe "__asterius_fromJSArray"
 foreign import javascript "__asterius_jsffi.newTmpJSVal('')"
   js_newString :: IO Int
 
-foreign import javascript "__asterius_jsffi.mutTmpJSVal(${1}, s => s + String.fromCodePoint(${2}))"
+foreign import javascript "__asterius_jsffi.mutTmpJSVal($1, s => s + String.fromCodePoint($2))"
   js_appendString :: Int -> Char -> IO ()
 
 foreign import javascript "__asterius_jsffi.newTmpJSVal([])"
   js_newArray :: IO Int
 
-foreign import javascript "__asterius_jsffi.mutTmpJSVal(${1}, arr => (arr.push(${2}), arr))"
+foreign import javascript "__asterius_jsffi.mutTmpJSVal($1, arr => (arr.push($2), arr))"
   js_appendArray :: Int -> JSVal -> IO ()
 
-foreign import javascript "__asterius_jsffi.freezeTmpJSVal(${1})"
+foreign import javascript "__asterius_jsffi.freezeTmpJSVal($1)"
   js_freezeTmpJSVal :: Int -> IO JSVal
 
-foreign import javascript "__asterius_jsffi.decodeUTF8(${1})"
+foreign import javascript "__asterius_jsffi.decodeUTF8($1)"
   jsStringDecodeUTF8 :: JSArrayBuffer -> JSString
 
-foreign import javascript "__asterius_jsffi.encodeUTF8(${1})"
+foreign import javascript "__asterius_jsffi.encodeUTF8($1)"
   jsStringEncodeUTF8 :: JSString -> JSArrayBuffer
 
-foreign import javascript "__asterius_jsffi.decodeLatin1(${1})"
+foreign import javascript "__asterius_jsffi.decodeLatin1($1)"
   jsStringDecodeLatin1 :: JSArrayBuffer -> JSString
 
-foreign import javascript "__asterius_jsffi.encodeLatin1(${1})"
+foreign import javascript "__asterius_jsffi.encodeLatin1($1)"
   jsStringEncodeLatin1 :: JSString -> JSArrayBuffer
 
-foreign import javascript "__asterius_jsffi.decodeUTF16LE(${1})"
+foreign import javascript "__asterius_jsffi.decodeUTF16LE($1)"
   jsStringDecodeUTF16LE :: JSArrayBuffer -> JSString
 
-foreign import javascript "__asterius_jsffi.encodeUTF16LE(${1})"
+foreign import javascript "__asterius_jsffi.encodeUTF16LE($1)"
   jsStringEncodeUTF16LE :: JSString -> JSArrayBuffer
 
-foreign import javascript "__asterius_jsffi.decodeUTF32LE(${1})"
+foreign import javascript "__asterius_jsffi.decodeUTF32LE($1)"
   jsStringDecodeUTF32LE :: JSArrayBuffer -> JSString
 
-foreign import javascript "__asterius_jsffi.encodeUTF32LE(${1})"
+foreign import javascript "__asterius_jsffi.encodeUTF32LE($1)"
   jsStringEncodeUTF32LE :: JSString -> JSArrayBuffer
 
-foreign import javascript "${1}[${2}]"
+foreign import javascript "$1[$2]"
   js_object_index :: JSObject -> JSString -> IO JSVal
 
-foreign import javascript "${1}[${2}]=${3}"
+foreign import javascript "$1[$2]=$3"
   js_object_set :: JSObject -> JSString -> JSVal -> IO ()
 
-foreign import javascript "${1}.apply({},${2})"
+foreign import javascript "$1.apply({},$2)"
   js_apply :: JSFunction -> JSArray -> IO JSVal
 
-foreign import javascript "__asterius_jsffi.makeHaskellCallback(${1})"
+foreign import javascript "__asterius_jsffi.makeHaskellCallback($1)"
   js_mk_hs_callback :: StablePtr# (IO ()) -> IO JSFunction
 
-foreign import javascript "__asterius_jsffi.makeHaskellCallback1(${1})"
+foreign import javascript "__asterius_jsffi.makeHaskellCallback1($1)"
   js_mk_hs_callback1 :: StablePtr# (JSVal -> IO ()) -> IO JSFunction
 
-foreign import javascript "__asterius_jsffi.makeHaskellCallback2(${1})"
+foreign import javascript "__asterius_jsffi.makeHaskellCallback2($1)"
   js_mk_hs_callback2 :: StablePtr# (JSVal -> JSVal -> IO ()) -> IO JSFunction
 
-foreign import javascript "JSON.parse(${1})" js_jsonParse :: JSString -> JSVal
+foreign import javascript "JSON.parse($1)" js_jsonParse :: JSString -> JSVal
 
-foreign import javascript "JSON.stringify(${1})"
+foreign import javascript "JSON.stringify($1)"
   js_jsonStringify :: JSVal -> JSString

--- a/ghc-toolkit/boot-libs/base/Asterius/Types.hs
+++ b/ghc-toolkit/boot-libs/base/Asterius/Types.hs
@@ -26,5 +26,5 @@ makeJSException :: JSVal -> SomeException
 makeJSException v =
   toException (JSException v (fromJSString (js_err_toString v)))
 
-foreign import javascript "${1}.stack ? ${1}.stack : ${1}.toString()"
+foreign import javascript "$1.stack ? $1.stack : $1.toString()"
   js_err_toString :: JSVal -> JSString


### PR DESCRIPTION
Closes #411 

We used to use `${i}` to represent the `i`-th argument in the JSFFI source text. Now we switch to `$i` to improve the syntax. Benefits:

* `$i` is a proper JavaScript identifier, no more need for a hacky custom lexer/parser.
* Fixed the templated literals in the source text.
* Got rid of the source text lexer based on `parsec`. We can now emit the source text directly as a vanilla JavaScript expression's source code.
* More closely matches GHCJS import source text syntax.
* Fewer keystrokes.

It's a breaking change, but better break earlier than later! Here's a tip on fixing broken code and documentation: grep for `${1}`, replace with `$1`, increment and repeat. Should be pretty easy.