### PR TITLE
Enable --wasm-interpret-all for TH splices

### DIFF
--- a/asterius/src/Asterius/GHCi/Internals.hs
+++ b/asterius/src/Asterius/GHCi/Internals.hs
@@ -118,7 +118,8 @@ newGHCiJSSession = do
   s <-
     newJSSession
       defJSSessionOpts
-        { nodeExtraEnv =
+        { nodeExtraArgs = ["--wasm-interpret-all"],
+          nodeExtraEnv =
             [ ("ASTERIUS_NODE_READ_FD", show node_read_fd),
               ("ASTERIUS_NODE_WRITE_FD", show node_write_fd)
             ],


### PR DESCRIPTION
This PR forces V8 to use the Ignition interpreter when running WebAssembly code of TH splices. This should make TH compilation faster in general, since TH splice code is short-lived and TurboFan compilation is quite an overhead when the linked splice turns out to be large.