### PR TITLE
foreign import javascript "wrapper" support

### DIFF
--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -232,6 +232,7 @@ export async function newAsteriusInstance(req) {
       StaticPtr: modulify(__asterius_staticptr_manager),
       Unicode: modulify(__asterius_unicode),
       Tracing: modulify(__asterius_tracer),
+      Exports: {newHaskellCallback: (sp, arg_tag, ret_tag, io) => __asterius_stableptr_manager.newJSVal(__asterius_exports.newHaskellCallback(sp, arg_tag, ret_tag, io))},
       Scheduler: modulify(__asterius_scheduler)
     }
   );

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -232,7 +232,10 @@ export async function newAsteriusInstance(req) {
       StaticPtr: modulify(__asterius_staticptr_manager),
       Unicode: modulify(__asterius_unicode),
       Tracing: modulify(__asterius_tracer),
-      Exports: {newHaskellCallback: (sp, arg_tag, ret_tag, io) => __asterius_stableptr_manager.newJSVal(__asterius_exports.newHaskellCallback(sp, arg_tag, ret_tag, io))},
+      Exports: {
+        newHaskellCallback: (sp, arg_tag, ret_tag, io) => __asterius_stableptr_manager.newJSVal(__asterius_exports.newHaskellCallback(sp, arg_tag, ret_tag, io)),
+        freeHaskellCallback: sn => __asterius_exports.freeHaskellCallback(sn)
+      },
       Scheduler: modulify(__asterius_scheduler)
     }
   );

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -20,6 +20,7 @@ where
 
 import Asterius.Builtins.Blackhole
 import Asterius.Builtins.CMath
+import Asterius.Builtins.Exports
 import Asterius.Builtins.Hashable
 import Asterius.Builtins.MD5
 import Asterius.Builtins.Posix
@@ -194,6 +195,7 @@ rtsAsteriusModule opts =
     <> generateWrapperModule (generateRtsExternalInterfaceModule opts)
     <> blackholeCBits
     <> generateWrapperModule blackholeCBits
+    <> exportsCBits
     <> smCBits
     <> generateWrapperModule smCBits
     <> cmathCBits
@@ -642,6 +644,7 @@ rtsFunctionImports debug =
       (fst . snd)
       ( byteStringCBits <> floatCBits <> unicodeCBits <> textCBits
       )
+    <> exportsImports
     <> posixImports
     <> sptImports
     <> timeImports

--- a/asterius/src/Asterius/Builtins/Exports.hs
+++ b/asterius/src/Asterius/Builtins/Exports.hs
@@ -21,11 +21,20 @@ exportsImports =
             { paramTypes = [F64, F64, F64, F64],
               returnTypes = [F64]
             }
+      },
+    FunctionImport
+      { internalName = "__asterius_freeHaskellCallback",
+        externalModuleName = "Exports",
+        externalBaseName = "freeHaskellCallback",
+        functionType = FunctionType {paramTypes = [F64], returnTypes = []}
       }
   ]
 
 exportsCBits :: AsteriusModule
-exportsCBits = runEDSL "newHaskellCallback" $ do
+exportsCBits = newHaskellCallback <> freeHaskellCallback
+
+newHaskellCallback :: AsteriusModule
+newHaskellCallback = runEDSL "newHaskellCallback" $ do
   setReturnTypes [I64]
   args <- params [I64, I64, I64, I64]
   truncUFloat64ToInt64
@@ -34,3 +43,8 @@ exportsCBits = runEDSL "newHaskellCallback" $ do
       (map convertUInt64ToFloat64 args)
       F64
     >>= emit
+
+freeHaskellCallback :: AsteriusModule
+freeHaskellCallback = runEDSL "freeHaskellCallback" $ do
+  arg <- param I64
+  callImport "__asterius_freeHaskellCallback" [convertUInt64ToFloat64 arg]

--- a/asterius/src/Asterius/Builtins/Exports.hs
+++ b/asterius/src/Asterius/Builtins/Exports.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Asterius.Builtins.Exports
+  ( exportsImports,
+    exportsCBits,
+  )
+where
+
+import Asterius.EDSL
+import Asterius.Types
+
+exportsImports :: [FunctionImport]
+exportsImports =
+  [ FunctionImport
+      { internalName = "__asterius_newHaskellCallback",
+        externalModuleName = "Exports",
+        externalBaseName = "newHaskellCallback",
+        functionType =
+          FunctionType
+            { paramTypes = [F64, F64, F64, F64],
+              returnTypes = [F64]
+            }
+      }
+  ]
+
+exportsCBits :: AsteriusModule
+exportsCBits = runEDSL "newHaskellCallback" $ do
+  setReturnTypes [I64]
+  args <- params [I64, I64, I64, I64]
+  truncUFloat64ToInt64
+    <$> callImport'
+      "__asterius_newHaskellCallback"
+      (map convertUInt64ToFloat64 args)
+      F64
+    >>= emit

--- a/asterius/src/Asterius/Foreign/DsForeign.hs
+++ b/asterius/src/Asterius/Foreign/DsForeign.hs
@@ -121,7 +121,7 @@ asteriusDsFExportDynamic id co0 = do
           mkIntLitInt dflags (fromIntegral ffi_ret_tag),
           mkIntLitInt dflags (if ffiInIO then 1 else 0)
         ]
-      new_hs_callback = fsLit "newHaskellCallback_wrapper"
+      new_hs_callback = fsLit "newHaskellCallback"
   ccall_adj <-
     dsCCall
       new_hs_callback

--- a/asterius/src/Asterius/Foreign/ExportStatic.hs
+++ b/asterius/src/Asterius/Foreign/ExportStatic.hs
@@ -3,6 +3,7 @@
 
 module Asterius.Foreign.ExportStatic
   ( genExportStaticObj,
+    encodeTys,
   )
 where
 

--- a/asterius/src/Asterius/Foreign/Internals.hs
+++ b/asterius/src/Asterius/Foreign/Internals.hs
@@ -7,6 +7,7 @@ module Asterius.Foreign.Internals
     globalFFIHookState,
     processFFIImport,
     processFFIExport,
+    parseFFIFunctionType,
   )
 where
 

--- a/asterius/src/Asterius/Foreign/Internals.hs
+++ b/asterius/src/Asterius/Foreign/Internals.hs
@@ -85,7 +85,7 @@ processFFIImport ::
   GHC.Type ->
   GHC.ForeignImport ->
   GHC.TcM GHC.ForeignImport
-processFFIImport hook_state_ref norm_sig_ty imp_decl@(GHC.CImport (GHC.unLoc -> GHC.JavaScriptCallConv) loc_safety _ _ (GHC.unLoc -> GHC.SourceText src)) =
+processFFIImport hook_state_ref norm_sig_ty imp_decl@(GHC.CImport (GHC.unLoc -> GHC.JavaScriptCallConv) loc_safety _ (GHC.CFunction _) (GHC.unLoc -> GHC.SourceText src)) =
   do
     dflags <- GHC.getDynFlags
     mod_sym <- marshalToModuleSymbol <$> GHC.getModule

--- a/asterius/src/Asterius/Foreign/Internals.hs
+++ b/asterius/src/Asterius/Foreign/Internals.hs
@@ -85,14 +85,16 @@ processFFIImport ::
   GHC.Type ->
   GHC.ForeignImport ->
   GHC.TcM GHC.ForeignImport
-processFFIImport hook_state_ref norm_sig_ty (GHC.CImport (GHC.unLoc -> GHC.JavaScriptCallConv) loc_safety _ _ (GHC.unLoc -> GHC.SourceText src)) =
+processFFIImport hook_state_ref norm_sig_ty imp_decl@(GHC.CImport (GHC.unLoc -> GHC.JavaScriptCallConv) loc_safety _ _ (GHC.unLoc -> GHC.SourceText src)) =
   do
     dflags <- GHC.getDynFlags
     mod_sym <- marshalToModuleSymbol <$> GHC.getModule
     u <- GHC.getUniqueM
     let ffi_ftype = case parseFFIFunctionType True norm_sig_ty of
           Just r -> r
-          _ -> GHC.panicDoc "processFFIImport" $ GHC.ppr norm_sig_ty
+          _ ->
+            GHC.panicDoc "processFFIImport" $
+              GHC.vcat [GHC.ppr norm_sig_ty, GHC.ppr imp_decl]
         ffi_safety = case GHC.unLoc loc_safety of
           GHC.PlaySafe | GHC.isGoodSrcSpan $ GHC.getLoc loc_safety -> FFISafe
           GHC.PlayInterruptible -> FFIInterruptible

--- a/asterius/src/Asterius/Foreign/TcForeign.hs
+++ b/asterius/src/Asterius/Foreign/TcForeign.hs
@@ -15,11 +15,9 @@ import Data.Maybe
 import DsMonad
 import ErrUtils
 import ForeignCall
-import qualified GHC.LanguageExtensions as LangExt
 import GhcPlugins
 import HsSyn
 import Outputable
-import Platform
 import PrelNames
 import TcEnv
 import TcExpr
@@ -48,28 +46,19 @@ asteriusTcFImport (L dloc fo@ForeignImport {fd_name = L nloc nm, fd_sig_ty = hs_
         id = mkLocalId nm sig_ty
     imp_decl' <- asteriusTcCheckFIType arg_tys res_ty imp_decl
     imp_decl'' <- processFFIImport globalFFIHookState norm_sig_ty imp_decl'
-    let fi_decl = ForeignImport
-          { fd_name = L nloc id,
-            fd_sig_ty = undefined,
-            fd_i_ext = mkSymCo norm_co,
-            fd_fi = imp_decl''
-          }
+    let fi_decl =
+          ForeignImport
+            { fd_name = L nloc id,
+              fd_sig_ty = undefined,
+              fd_i_ext = mkSymCo norm_co,
+              fd_fi = imp_decl''
+            }
     return (id, L dloc fi_decl, gres)
 asteriusTcFImport d = pprPanic "asteriusTcFImport" (ppr d)
 
 asteriusTcCheckFIType :: [Type] -> Type -> ForeignImport -> TcM ForeignImport
-asteriusTcCheckFIType arg_tys res_ty (CImport (L lc cconv) safety mh l@(CLabel _) src) =
+asteriusTcCheckFIType arg_tys res_ty (CImport (L lc JavaScriptCallConv) safety mh CWrapper src) =
   do
-    checkCg checkCOrAsmOrLlvmOrInterp
-    check
-      (isFFILabelTy (mkFunTys arg_tys res_ty))
-      (illegalForeignTyErr Outputable.empty)
-    cconv' <- asteriusCheckCConv cconv
-    return (CImport (L lc cconv') safety mh l src)
-asteriusTcCheckFIType arg_tys res_ty (CImport (L lc cconv) safety mh CWrapper src) =
-  do
-    checkCg checkCOrAsmOrLlvmOrInterp
-    cconv' <- asteriusCheckCConv cconv
     case arg_tys of
       [arg1_ty] -> do
         checkForeignArgs asteriusIsFFIExternalTy arg1_tys
@@ -80,54 +69,10 @@ asteriusTcCheckFIType arg_tys res_ty (CImport (L lc cconv) safety mh CWrapper sr
       _ ->
         addErrTc
           (illegalForeignTyErr Outputable.empty (text "One argument expected"))
-    return (CImport (L lc cconv') safety mh CWrapper src)
-asteriusTcCheckFIType arg_tys res_ty idecl@(CImport (L lc cconv) (L ls safety) mh (CFunction target) src)
-  | isDynamicTarget target =
+    return (CImport (L lc JavaScriptCallConv) safety mh CWrapper src)
+asteriusTcCheckFIType arg_tys res_ty (CImport (L lc cconv) (L ls safety) mh (CFunction target) src)
+  | not (isDynamicTarget target || cconv == PrimCallConv) =
     do
-      checkCg checkCOrAsmOrLlvmOrInterp
-      cconv' <- asteriusCheckCConv cconv
-      case arg_tys of
-        [] ->
-          addErrTc
-            ( illegalForeignTyErr
-                Outputable.empty
-                (text "At least one argument expected")
-            )
-        (arg1_ty : arg_tys) -> do
-          dflags <- getDynFlags
-          let curried_res_ty = mkFunTys arg_tys res_ty
-          check (isFFIDynTy curried_res_ty arg1_ty) (illegalForeignTyErr argument)
-          checkForeignArgs (asteriusIsFFIArgumentTy dflags safety) arg_tys
-          checkForeignRes
-            nonIOok
-            checkSafe
-            (asteriusIsFFIImportResultTy dflags)
-            res_ty
-      return $ CImport (L lc cconv') (L ls safety) mh (CFunction target) src
-  | cconv == PrimCallConv =
-    do
-      dflags <- getDynFlags
-      checkTc
-        (xopt LangExt.GHCForeignImportPrim dflags)
-        (text "Use GHCForeignImportPrim to allow `foreign import prim'.")
-      checkCg checkCOrAsmOrLlvmOrInterp
-      checkCTarget target
-      checkTc
-        (playSafe safety)
-        ( text
-            "The safe/unsafe annotation should not be used with `foreign import prim'."
-        )
-      checkForeignArgs (asteriusIsFFIArgumentTy dflags safety) arg_tys
-      checkForeignRes
-        nonIOok
-        checkSafe
-        (asteriusIsFFIImportResultTy dflags)
-        res_ty
-      return idecl
-  | otherwise =
-    do
-      checkCg checkCOrAsmOrLlvmOrInterp
-      cconv' <- asteriusCheckCConv cconv
       dflags <- getDynFlags
       checkForeignArgs (asteriusIsFFIArgumentTy dflags safety) arg_tys
       checkForeignRes
@@ -135,13 +80,15 @@ asteriusTcCheckFIType arg_tys res_ty idecl@(CImport (L lc cconv) (L ls safety) m
         checkSafe
         (asteriusIsFFIImportResultTy dflags)
         res_ty
-      checkMissingAmpersand dflags arg_tys res_ty
-      case target of
-        StaticTarget _ _ _ False
-          | not (null arg_tys) ->
-            addErrTc (text "`value' imports cannot have function types")
-        _ -> return ()
-      return $ CImport (L lc cconv') (L ls safety) mh (CFunction target) src
+      return $
+        CImport
+          (L lc JavaScriptCallConv)
+          (L ls safety)
+          mh
+          (CFunction target)
+          src
+asteriusTcCheckFIType arg_tys res_ty imp_decl =
+  tcCheckFIType arg_tys res_ty imp_decl
 
 asteriusTcForeignExports ::
   [LForeignDecl GhcRn] ->
@@ -180,17 +127,17 @@ asteriusTcFExport fo@ForeignExport {fd_name = L loc nm, fd_sig_ty = hs_ty, fd_fe
 asteriusTcFExport d = pprPanic "asteriusTcFExport" (ppr d)
 
 asteriusTcCheckFEType :: Type -> ForeignExport -> TcM ForeignExport
-asteriusTcCheckFEType sig_ty (CExport (L l (CExportStatic esrc str cconv)) src) =
+asteriusTcCheckFEType sig_ty (CExport (L l (CExportStatic esrc str JavaScriptCallConv)) src) =
   do
     checkCg checkCOrAsmOrLlvm
     checkTc (isCLabelString str) (badCName str)
-    cconv' <- asteriusCheckCConv cconv
     checkForeignArgs asteriusIsFFIExternalTy arg_tys
     checkForeignRes nonIOok noCheckSafe asteriusIsFFIExportResultTy res_ty
-    return (CExport (L l (CExportStatic esrc str cconv')) src)
+    return (CExport (L l (CExportStatic esrc str JavaScriptCallConv)) src)
   where
     (bndrs, res_ty) = tcSplitPiTys sig_ty
     arg_tys = mapMaybe binderRelevantType_maybe bndrs
+asteriusTcCheckFEType norm_sig_ty spec = tcCheckFEType norm_sig_ty spec
 
 asteriusIsFFIArgumentTy :: DynFlags -> Safety -> Type -> Validity
 asteriusIsFFIArgumentTy dflags safety ty
@@ -220,27 +167,3 @@ isAnyTy :: Type -> Bool
 isAnyTy ty = case tcSplitTyConApp_maybe ty of
   Just (tc, _) -> anyTyConKey == getUnique tc
   Nothing -> False
-
-asteriusCheckCConv :: CCallConv -> TcM CCallConv
-asteriusCheckCConv CCallConv = return CCallConv
-asteriusCheckCConv CApiConv = return CApiConv
-asteriusCheckCConv StdCallConv = do
-  dflags <- getDynFlags
-  let platform = targetPlatform dflags
-  if platformArch platform == ArchX86
-    then return StdCallConv
-    else do
-      when (wopt Opt_WarnUnsupportedCallingConventions dflags) $
-        addWarnTc
-          (Reason Opt_WarnUnsupportedCallingConventions)
-          ( text
-              "the 'stdcall' calling convention is unsupported on this platform,"
-              $$ text "treating as ccall"
-          )
-      return CCallConv
-asteriusCheckCConv PrimCallConv = do
-  addErrTc
-    ( text "The `prim' calling convention can only be used with `foreign import'"
-    )
-  return PrimCallConv
-asteriusCheckCConv JavaScriptCallConv = return JavaScriptCallConv

--- a/asterius/src/Asterius/Foreign/TcForeign.hs
+++ b/asterius/src/Asterius/Foreign/TcForeign.hs
@@ -58,7 +58,7 @@ asteriusTcFImport d = pprPanic "asteriusTcFImport" (ppr d)
 
 asteriusTcCheckFIType :: [Type] -> Type -> ForeignImport -> TcM ForeignImport
 asteriusTcCheckFIType arg_tys res_ty (CImport (L lc cconv) (L ls safety) mh (CFunction target) src)
-  | unLoc src == SourceText "\"wrapper\"" =
+  | cconv == JavaScriptCallConv && unLoc src == SourceText "\"wrapper\"" =
     do
       case arg_tys of
         [arg1_ty] -> do
@@ -70,7 +70,7 @@ asteriusTcCheckFIType arg_tys res_ty (CImport (L lc cconv) (L ls safety) mh (CFu
         _ ->
           addErrTc
             (illegalForeignTyErr Outputable.empty (text "One argument expected"))
-      return (CImport (L lc JavaScriptCallConv) (L ls safety) mh CWrapper src)
+      return (CImport (L lc cconv) (L ls safety) mh CWrapper src)
   | not (isDynamicTarget target || cconv == PrimCallConv) =
     do
       dflags <- getDynFlags
@@ -80,13 +80,7 @@ asteriusTcCheckFIType arg_tys res_ty (CImport (L lc cconv) (L ls safety) mh (CFu
         checkSafe
         (asteriusIsFFIImportResultTy dflags)
         res_ty
-      return $
-        CImport
-          (L lc JavaScriptCallConv)
-          (L ls safety)
-          mh
-          (CFunction target)
-          src
+      return $ CImport (L lc cconv) (L ls safety) mh (CFunction target) src
 asteriusTcCheckFIType arg_tys res_ty imp_decl =
   tcCheckFIType arg_tys res_ty imp_decl
 

--- a/asterius/src/Asterius/Foreign/TcForeign.hs
+++ b/asterius/src/Asterius/Foreign/TcForeign.hs
@@ -64,7 +64,19 @@ asteriusTcCheckFIType arg_tys res_ty (CImport (L lc cconv) (L ls safety) mh (CFu
         [arg1_ty] -> do
           checkForeignArgs asteriusIsFFIExternalTy arg1_tys
           checkForeignRes nonIOok checkSafe asteriusIsFFIExportResultTy res1_ty
-          checkForeignRes mustBeIO checkSafe (isFFIDynTy arg1_ty) res_ty
+          checkForeignRes
+            mustBeIO
+            checkSafe
+            ( \ty ->
+                if isJSValTy ty
+                  then IsValid
+                  else
+                    NotValid
+                      ( text
+                          "foreign import javascript \"wrapper\" expects a JSVal result"
+                      )
+            )
+            res_ty
           where
             (arg1_tys, res1_ty) = tcSplitFunTys arg1_ty
         _ ->

--- a/ghc-toolkit/boot-libs/base/Asterius/Prim.hs
+++ b/ghc-toolkit/boot-libs/base/Asterius/Prim.hs
@@ -19,6 +19,7 @@ module Asterius.Prim
     indexJSObject,
     setJSObject,
     callJSFunction,
+    freeHaskellCallback,
     makeHaskellCallback,
     makeHaskellCallback1,
     makeHaskellCallback2,

--- a/ghc-toolkit/boot-libs/base/Asterius/Types/JSFunction.hs
+++ b/ghc-toolkit/boot-libs/base/Asterius/Types/JSFunction.hs
@@ -3,6 +3,7 @@
 module Asterius.Types.JSFunction
   ( JSFunction (..),
     callJSFunction,
+    freeHaskellCallback,
   )
 where
 
@@ -22,3 +23,6 @@ callJSFunction f args = js_apply f (toJSArray args)
 
 foreign import javascript unsafe "$1(...$2)"
   js_apply :: JSFunction -> JSArray -> IO JSVal
+
+foreign import ccall unsafe "freeHaskellCallback"
+  freeHaskellCallback :: JSFunction -> IO ()


### PR DESCRIPTION
Closes #294. Finally.

This PR implements the `foreign import javascript "wrapper"` syntax for exporting arbitrary Haskell function closures to JavaScript callbacks. Example:

```haskell
type Fun = JSVal -> IO JSVal

foreign import javascript "wrapper" mk_Fun_callback :: Fun -> IO JSFunction
```

We can then use `mk_Fun_callback` to convert Haskell closures of type `Fun` to a JavaScript callback at runtime. It's an async function that resolves to a `JSVal` eventually. The callback may call into Haskell again.

When the callback is no longer needed, call `Asterius.Types.freeHaskellCallback` on the `JSFunction`. This will free the callback's own `JSVal` as well as the Haskell closure's `StablePtr`.

Our FFI story is vastly improved now. The previous `makeHaskellCallback*` family of functions will soon be deprecated.