### PR TITLE
Slight improvements in `Asterius.Aeson`

### DIFF
--- a/ghc-toolkit/boot-libs/asterius-prelude/src/Asterius/Aeson.hs
+++ b/ghc-toolkit/boot-libs/asterius-prelude/src/Asterius/Aeson.hs
@@ -1,21 +1,40 @@
 module Asterius.Aeson
   ( jsonToJSVal,
     jsonFromJSVal,
+    jsonFromJSVal',
   )
 where
 
+import Asterius.Magic
 import Asterius.Types
 import Asterius.UTF8
 import qualified Data.Aeson as A
+import Data.Coerce
 
 {-# INLINE jsonToJSVal #-}
 jsonToJSVal :: A.ToJSON a => a -> JSVal
-jsonToJSVal = js_dec . utf8ToJSString . A.encode
+jsonToJSVal v = accursedUnutterablePerformIO $ do
+  s <- utf8ToJSString $ A.encode v
+  r <- js_dec s
+  freeJSVal (coerce s)
+  pure r
 
 {-# INLINE jsonFromJSVal #-}
 jsonFromJSVal :: A.FromJSON a => JSVal -> Either String a
-jsonFromJSVal = A.eitherDecode' . utf8FromJSString . js_enc
+jsonFromJSVal v = accursedUnutterablePerformIO $ do
+  s <- js_enc v
+  bs <- utf8FromJSString s
+  freeJSVal (coerce s)
+  pure $ A.eitherDecodeStrict' bs
 
-foreign import javascript "JSON.stringify($1)" js_enc :: JSVal -> JSString
+{-# INLINE jsonFromJSVal' #-}
+jsonFromJSVal' :: A.FromJSON a => JSVal -> a
+jsonFromJSVal' v = case jsonFromJSVal v of
+  Left e -> error e
+  Right r -> r
 
-foreign import javascript "JSON.parse($1)" js_dec :: JSString -> JSVal
+foreign import javascript unsafe "JSON.stringify($1)"
+  js_enc :: JSVal -> IO JSString
+
+foreign import javascript unsafe "JSON.parse($1)"
+  js_dec :: JSString -> IO JSVal

--- a/ghc-toolkit/boot-libs/asterius-prelude/src/Asterius/UTF8.hs
+++ b/ghc-toolkit/boot-libs/asterius-prelude/src/Asterius/UTF8.hs
@@ -4,45 +4,49 @@ module Asterius.UTF8
   )
 where
 
-import Asterius.Magic
 import Asterius.Types
 import qualified Data.ByteString.Internal as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Unsafe as BS
 import Foreign
 
-{-# INLINE utf8ToJSString #-}
-utf8ToJSString :: LBS.ByteString -> JSString
+{-# INLINEABLE utf8ToJSString #-}
+utf8ToJSString :: LBS.ByteString -> IO JSString
 utf8ToJSString s
-  | LBS.null s = js_str_empty
-  | otherwise = accursedUnutterablePerformIO $ do
+  | LBS.null s = pure js_str_empty
+  | otherwise = do
     dec <- js_dec
-    LBS.foldrChunks
-      (\c m -> BS.unsafeUseAsCStringLen c (uncurry (js_dec_chunk dec)) *> m)
+    LBS.foldlChunks
+      (\m c -> m *> BS.unsafeUseAsCStringLen c (uncurry (js_dec_chunk dec)))
       (pure ())
       s
-    js_dec_result dec
+    r <- js_dec_result dec
+    freeJSVal dec
+    pure r
 
-{-# INLINE utf8FromJSString #-}
-utf8FromJSString :: JSString -> LBS.ByteString
-utf8FromJSString s = accursedUnutterablePerformIO $ do
-  l <- js_str_len s
-  if l == 0
-    then pure mempty
-    else fmap LBS.fromStrict $ BS.createUptoN (l * 3) $ \p ->
-      js_utf8_from_str s p (l * 3)
+{-# INLINEABLE utf8FromJSString #-}
+utf8FromJSString :: JSString -> IO BS.ByteString
+utf8FromJSString s = do
+  let l = lengthOfJSString s
+  case l of
+    0 -> pure mempty
+    _ -> BS.createUptoN (l * 3) $ \p -> js_utf8_from_str s p (l * 3)
 
-foreign import javascript "''" js_str_empty :: JSString
+foreign import javascript unsafe "''"
+  js_str_empty :: JSString
 
-foreign import javascript "(() => {const dec = new TextDecoder('utf-8', {fatal: true}); dec.result = ''; return dec;})()"
+foreign import javascript unsafe "(() => {              \
+\  const dec = new TextDecoder('utf-8', {fatal: true}); \
+\  dec.result = '';                                     \
+\  return dec;                                          \
+\  })()"
   js_dec :: IO JSVal
 
-foreign import javascript "$1.result += $1.decode(new Uint8Array(__asterius_jsffi.exports.memory.buffer, $2 & 0xffffffff, $3), {stream: true})"
+foreign import javascript unsafe "$1.result += $1.decode(__asterius_jsffi.exposeMemory($2, $3), {stream: true})"
   js_dec_chunk :: JSVal -> Ptr a -> Int -> IO ()
 
-foreign import javascript "$1.result" js_dec_result :: JSVal -> IO JSString
+foreign import javascript unsafe "$1.result"
+  js_dec_result :: JSVal -> IO JSString
 
-foreign import javascript "$1.length" js_str_len :: JSString -> IO Int
-
-foreign import javascript "(new TextEncoder()).encodeInto($1, new Uint8Array(__asterius_jsffi.exports.memory.buffer, $2 & 0xffffffff, $3)).written"
+foreign import javascript unsafe "(new TextEncoder()).encodeInto($1, __asterius_jsffi.exposeMemory($2, $3)).written"
   js_utf8_from_str :: JSString -> Ptr a -> Int -> IO Int


### PR DESCRIPTION
Following recent PRs related to `Asterius.*` refactorings, this PR improves `Asterius.Aeson`:

* We now use the `__asterius_jsffi.exposeMemory` interface directly when marshaling between `JSString`s and UTF-8 encoded `ByteString`s.
* The intermediate `JSVal`s are now freed immediately.
* Added a `jsonFromJSVal'` variant which returns the successfully decoded result type, and throws if decoding fails.