### PR TITLE
Strip prof libs from base image

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -92,7 +92,7 @@ RUN \
     /home/asterius/.asterius-local-install-root/bin \
     /home/asterius/.asterius-local-install-root/share \
     /tmp && \
-  sudo rm -rf \
+  sudo rm -rf -v \
     /home/asterius/.asterius \
     /home/asterius/.asterius-compiler-bin/../share \
     /home/asterius/.cabal \
@@ -100,6 +100,7 @@ RUN \
     /home/asterius/.local/bin/stack \
     /home/asterius/.npm \
     /home/asterius/.stack/programs/*/*.tar.xz \
+    $(find /home/asterius -name "*.p_hi" -o -name "*.p_o" -o -name "*_p.a") \
     /var/lib/apt/lists/* \
     /var/tmp/* && \
   sudo mkdir -p $(realpath -m /home/asterius/.asterius-local-install-root) && \
@@ -112,7 +113,7 @@ RUN \
     /home/asterius/.asterius-snapshot-install-root/share \
     /home/asterius/.stack/programs \
     /tmp && \
-  sudo rm -rf /home/asterius/.stack && \
+  sudo rm -rf -v /home/asterius/.stack && \
   sudo mkdir -p $(realpath -m /home/asterius/.asterius-snapshot-install-root) && \
   sudo mv \
     /tmp/bin \
@@ -122,7 +123,7 @@ RUN \
     /tmp/programs \
     /home/asterius/.stack && \
   sudo chown -c -h -R asterius:asterius /home/asterius && \
-  sudo rm -rf \
+  sudo rm -rf -v \
     /tmp/*
 
 RUN \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -38,7 +38,7 @@ RUN \
   apt install -y nodejs && \
   apt autoremove --purge -y && \
   apt clean && \
-  rm -rf /var/lib/apt/lists/* && \
+  rm -rf -v /var/lib/apt/lists/* && \
   useradd --create-home --shell /bin/bash asterius && \
   echo "asterius ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
@@ -74,7 +74,7 @@ RUN \
     ormolu \
     wai-app-static && \
   cd /home/asterius && \
-  sudo rm -rf \
+  sudo rm -rf -v \
     /home/asterius/.stack/programs/*/*.tar.xz \
     /tmp/* \
     /var/tmp/*

--- a/stackage.Dockerfile
+++ b/stackage.Dockerfile
@@ -16,7 +16,7 @@ RUN \
 USER root
 
 RUN \
-  rm -rf \
+  rm -rf -v \
     $ASTERIUS_LIB_DIR/bin \
     /home/asterius/.cabal \
     /tmp/* \


### PR DESCRIPTION
This PR strips the compiled profile-flavour libs from the base image to further reduce image size. The prebuilt GHC bindists come with profile libs, but the profile libs aren't used in the prebuilt images.