### PR TITLE
Enable Haskell code to recover from synchronous JavaScript exceptions

### DIFF
--- a/asterius/rts/rts.scheduler.mjs
+++ b/asterius/rts/rts.scheduler.mjs
@@ -327,7 +327,7 @@ export class Scheduler {
             tso_info.ffiRetErr = undefined;
 
             // execute the TSO.
-            this.exports.scheduleTSO(tso, this.symbolTable.stg_returnToStackTop);
+            this.exports.scheduleTSO(tso);
             this.returnedFromTSO(tid);
             this.exports.context.reentrancyGuard.exit(0);
   }

--- a/asterius/rts/rts.scheduler.mjs
+++ b/asterius/rts/rts.scheduler.mjs
@@ -327,7 +327,15 @@ export class Scheduler {
             tso_info.ffiRetErr = undefined;
 
             // execute the TSO.
-            this.exports.scheduleTSO(tso);
+            try {
+              this.exports.scheduleTSO(tso);
+            } catch (err) {
+              this.exports.stg_returnToSchedNotPaused();
+              tso_info.ffiRetErr = err;
+              setImmediate(() => this.scheduler_tick(tid));
+              this.exports.context.reentrancyGuard.exit(0);
+              return;
+            }
             this.returnedFromTSO(tid);
             this.exports.context.reentrancyGuard.exit(0);
   }

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -915,7 +915,7 @@ dirtySTACK _ stack =
 -- function
 scheduleTSOFunction :: BuiltinsOptions -> AsteriusModule
 scheduleTSOFunction BuiltinsOptions {} = runEDSL "scheduleTSO" $ do
-  [tso, func] <- params [I64, I64]
+  tso <- param I64
   -- store the current TSO
   putLVal currentTSO tso
   -- indicate in the Capability that we are running the TSO
@@ -929,7 +929,7 @@ scheduleTSOFunction BuiltinsOptions {} = runEDSL "scheduleTSO" $ do
   dirtyTSO mainCapability tso
   dirtySTACK mainCapability (loadI64 tso offset_StgTSO_stackobj)
   -- execute the TSO (using stgRun trampolining machinery)
-  stgRun func
+  stgRun $ symbol "stg_returnToStackTop"
   -- indicate in the Capability that we are not running anything
   storeI64
     mainCapability

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -679,7 +679,11 @@ rtsFunctionExports debug =
                  else []
              )
                <> ["hs_init"]
-       ]
+       ] <> [ FunctionExport
+      { internalName = "stg_returnToSchedNotPaused",
+        externalName = "stg_returnToSchedNotPaused"
+      }
+  ]
 
 emitErrorMessage :: [ValueType] -> SBS.ShortByteString -> Expression
 emitErrorMessage vts ev = Barf {barfMessage = ev, barfReturnTypes = vts}

--- a/asterius/src/Asterius/Ld.hs
+++ b/asterius/src/Asterius/Ld.hs
@@ -72,7 +72,6 @@ rtsUsedSymbols =
       "stg_NO_FINALIZER_closure",
       "stg_raise_info",
       "stg_raise_ret_info",
-      "stg_returnToStackTop",
       "stg_STABLE_NAME_info",
       "stg_WEAK_info"
     ]


### PR DESCRIPTION
This PR enables user Haskell code to handle `JSException`s even when they are thrown synchronously, either in some piece of `foreign import javascript unsafe` code, or from the runtime itself (e.g. some `TextDecoder` error or something).

IMHO this is a really huge improvement over simply crashing and leaving the thread state in an inconsistent zombie state. It's a good first step towards proper crash semantics of the whole runtime and user code. In our future work, different kinds of crashes should be handled in different manners:

* Runtime crashes which are unrecoverable. These crashes make the whole runtime state inconsistent and no Haskell execution may take place from there. We should immediately reject all pending Haskell thread `Promise`s, do some logging, probably detangling some references by `delete`ing some stuff to allow the dead runtime to be quickly GC'ed.
* Synchronous crashes or `Promise` rejections that affect a single thread, e.g. triggering a `barf`. This should be wrapped as a `JSException` and thrown to that thread.
* Maybe there are certain runtime crashes that affect all existing threads, but after some cleanup new threads can still evaluate as normal. I'm not aware of such kind of errors yet, but won't hurt to keep this case in mind.