### PR TITLE
import Math directly since --wasm-math-intrinsics is now default

### DIFF
--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -120,20 +120,7 @@ export async function newAsteriusInstance(req) {
   const importObject = Object.assign(
     req.jsffiFactory(__asterius_jsffi_instance),
     {
-      Math: {
-        sin: x => Math.sin(x),
-        cos: x => Math.cos(x),
-        tan: x => Math.tan(x),
-        sinh: x => Math.sinh(x),
-        cosh: x => Math.cosh(x),
-        tanh: x => Math.tanh(x),
-        asin: x => Math.asin(x),
-        acos: x => Math.acos(x),
-        atan: x => Math.atan(x),
-        log: x => Math.log(x),
-        exp: x => Math.exp(x),
-        pow: (x, y) => Math.pow(x, y)
-      },
+      Math: Math,
       WasmTable: {
         table: __asterius_wasm_table
       },


### PR DESCRIPTION
We import `Math` to support certain Cmm instructions like `MO_F64_Sin`. Back in the early days, directly importing `Math` would make V8 crash, so we had to implement eta-expanded wrapper functions for every `Math` function we import. It's not the case anymore since `--wasm-math-intrinsics` works properly and is on by default. Also checked manually that this doesn't break SpiderMonkey.