### PR TITLE
Enable generating tail call opcodes in the `binaryen` backend

### DIFF
--- a/asterius/src/Asterius/GHCi/Internals.hs
+++ b/asterius/src/Asterius/GHCi/Internals.hs
@@ -118,7 +118,7 @@ newGHCiJSSession = do
   s <-
     newJSSession
       defJSSessionOpts
-        { nodeExtraArgs = ["--wasm-interpret-all"],
+        { nodeExtraArgs = ["--experimental-wasm-return-call", "--wasm-interpret-all"],
           nodeExtraEnv =
             [ ("ASTERIUS_NODE_READ_FD", show node_read_fd),
               ("ASTERIUS_NODE_WRITE_FD", show node_write_fd)

--- a/asterius/src/Asterius/JSRun/NonMain.hs
+++ b/asterius/src/Asterius/JSRun/NonMain.hs
@@ -55,6 +55,7 @@ distNonMain p extra_syms =
         inputHS = p,
         outputDirectory = takeDirectory p,
         outputBaseName = takeBaseName p,
+        tailCalls = True,
         Asterius.Main.Task.hasMain = False,
         Asterius.Main.Task.verboseErr = True,
         extraRootSymbols = extra_syms

--- a/asterius/test/ghc-testsuite.hs
+++ b/asterius/test/ghc-testsuite.hs
@@ -125,6 +125,7 @@ runTestCase l_opts tlref TestCase {..} = catch m h
                   takeFileName tmp_case_path,
                   "--console-history",
                   "--backend=binaryen",
+                  "--tail-calls",
                   "--verbose-err"
                 ]
                   <> l_opts
@@ -138,9 +139,7 @@ runTestCase l_opts tlref TestCase {..} = catch m h
           defJSSessionOpts
             { nodeExtraArgs =
                 ["--experimental-wasm-bigint" | "--debug" `elem` l_opts]
-                  <> [ "--experimental-wasm-return-call"
-                       | "--tail-calls" `elem` l_opts
-                     ]
+                  <> [ "--experimental-wasm-return-call" ]
             }
           $ \s -> do
             i <- newAsteriusInstance s (tmp_case_path -<.> "req.mjs") mod_buf


### PR DESCRIPTION
Closes #266. Also enables tail calls in the TH runner and `ghc-testsuite`.