### PR TITLE
Get rid of custom global `DynFlags`

### DIFF
--- a/asterius/src/Asterius/Boot.hs
+++ b/asterius/src/Asterius/Boot.hs
@@ -29,7 +29,7 @@ import Language.Haskell.GHC.Toolkit.BuildInfo
     sandboxGhcLibDir,
   )
 import Language.Haskell.GHC.Toolkit.Compiler
-import Language.Haskell.GHC.Toolkit.Orphans.Show
+import Language.Haskell.GHC.Toolkit.Orphans.Show ()
 import Language.Haskell.GHC.Toolkit.Run
   ( defaultConfig,
     ghcFlags,
@@ -101,7 +101,6 @@ bootRTSCmm BootArgs {..} =
         GHC.setSessionDynFlags $
           GHC.setGeneralFlag' GHC.Opt_SuppressTicks dflags0
       dflags <- GHC.getSessionDynFlags
-      setDynFlagsRef dflags
       is_debug <- isJust <$> liftIO (lookupEnv "ASTERIUS_DEBUG")
       obj_paths_ref <- liftIO $ newIORef []
       cmm_files <-

--- a/asterius/src/Asterius/FrontendPlugin.hs
+++ b/asterius/src/Asterius/FrontendPlugin.hs
@@ -23,7 +23,7 @@ import qualified GhcPlugins as GHC
 import qualified Hooks as GHC
 import Language.Haskell.GHC.Toolkit.Compiler
 import Language.Haskell.GHC.Toolkit.FrontendPlugin
-import Language.Haskell.GHC.Toolkit.Orphans.Show
+import Language.Haskell.GHC.Toolkit.Orphans.Show ()
 import qualified Stream
 import System.Environment.Blank
 import System.FilePath
@@ -75,7 +75,6 @@ frontendPlugin = makeFrontendPlugin $ do
     mempty
       { withHaskellIR = \GHC.ModSummary {..} ir@HaskellIR {..} obj_path -> do
           dflags <- GHC.getDynFlags
-          setDynFlagsRef dflags
           let mod_sym = marshalToModuleSymbol ms_mod
           liftIO $ do
             ffi_mod <- getFFIModule dflags mod_sym
@@ -92,7 +91,6 @@ frontendPlugin = makeFrontendPlugin $ do
                   asmPrint dflags (p "dump-cmm-raw") cmm_raw,
         withCmmIR = \ir@CmmIR {..} obj_path -> do
           dflags <- GHC.getDynFlags
-          setDynFlagsRef dflags
           let ms_mod =
                 GHC.Module GHC.rtsUnitId $ GHC.mkModuleName $
                   takeBaseName

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/FrontendPlugin.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/FrontendPlugin.hs
@@ -12,7 +12,7 @@ import GHC
 import GhcPlugins hiding ((<>))
 import Language.Haskell.GHC.Toolkit.Compiler
 import Language.Haskell.GHC.Toolkit.Hooks
-import Language.Haskell.GHC.Toolkit.Orphans.Show
+import Language.Haskell.GHC.Toolkit.Orphans.Show ()
 import Panic
 
 makeFrontendPlugin :: Ghc Compiler -> FrontendPlugin
@@ -32,7 +32,6 @@ makeFrontendPlugin init_c =
                     tablesNextToCode = False,
                     hooks = h
                   }
-            getSessionDynFlags >>= setDynFlagsRef
             env <- getSession
             liftIO $ oneShot env StopLn targets
           else do
@@ -53,7 +52,6 @@ makeFrontendPlugin init_c =
                     ldInputs = map (FileOption "") o_files ++ ldInputs dflags'
                   }
             traverse (uncurry GHC.guessTarget) hs_targets >>= setTargets
-            getSessionDynFlags >>= setDynFlagsRef
             ok_flag <- load LoadAllTargets
             when (failed ok_flag) $ liftIO $ throwGhcExceptionIO $
               Panic

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Orphans/Show.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Orphans/Show.hs
@@ -5,14 +5,13 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Language.Haskell.GHC.Toolkit.Orphans.Show
-  ( setDynFlagsRef,
+  (
   )
 where
 
 import CLabel
 import Cmm
 import CoAxiom
-import Control.Monad.IO.Class
 import CostCentre
 import CostCentreState
 import Data.IORef
@@ -28,22 +27,13 @@ import Text.Show.Functions ()
 import TyCoRep
 import UniqDSet
 
-{-# NOINLINE dynFlagsRef #-}
-dynFlagsRef :: IORef DynFlags
-dynFlagsRef = unsafePerformIO $ newIORef unsafeGlobalDynFlags
-
-setDynFlagsRef :: MonadIO m => DynFlags -> m ()
-setDynFlagsRef = liftIO . atomicWriteIORef dynFlagsRef
-
 fakeShow :: Outputable a => String -> a -> String
-fakeShow tag val = unsafePerformIO $ do
-  dflags <- readIORef dynFlagsRef
-  pure $
-    "("
-      ++ tag
-      ++ " "
-      ++ show (showSDoc dflags $ pprCode AsmStyle $ ppr val)
-      ++ ")"
+fakeShow tag val =
+  "("
+    ++ tag
+    ++ " "
+    ++ show (showSDoc unsafeGlobalDynFlags $ pprCode AsmStyle $ ppr val)
+    ++ ")"
 
 instance Outputable SDoc where
   ppr = id


### PR DESCRIPTION
This PR uses the `unsafeGlobalDynFlags` in GHC API for the orphan `Show` instances and replaces the previous `dynFlagsRef`. May help plug a bit of leak here.