### PR TITLE
Automatically call hs_init() before newAsteriusInstance() resolves

### DIFF
--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -198,10 +198,11 @@ export async function newAsteriusInstance(req) {
       );
     }
 
+    Object.assign(__asterius_exports, __asterius_wasm_instance.exports);
+    __asterius_exports.hs_init();
+
     return Object.assign(__asterius_jsffi_instance, {
-      exports: Object.freeze(
-        Object.assign(__asterius_exports, __asterius_wasm_instance.exports)
-      ),
+      exports: __asterius_exports,
       symbolTable: req.symbolTable,
       persistentState: __asterius_persistent_state
     });

--- a/asterius/src/Asterius/GHCi/Internals.hs
+++ b/asterius/src/Asterius/GHCi/Internals.hs
@@ -20,7 +20,6 @@ import Asterius.CodeGen
 import Asterius.Internals ((!))
 import Asterius.Internals.Name
 import Asterius.Internals.Temp
-import Asterius.JSRun.Main
 import Asterius.JSRun.NonMain
 import Asterius.Ld
 import Asterius.Resolve
@@ -332,7 +331,6 @@ asteriusRunTH hsc_env _ _ q ty _ s ahc_dist_input =
           <> ",{module:"
           <> takeJSVal mod_val
           <> "}))"
-    hsInit s i
     let runner_closure =
           deRefJSVal i <> ".symbolTable."
             <> coerce

--- a/asterius/src/Asterius/JSRun/Main.hs
+++ b/asterius/src/Asterius/JSRun/Main.hs
@@ -2,7 +2,6 @@
 
 module Asterius.JSRun.Main
   ( newAsteriusInstance,
-    hsInit,
     hsMain,
     hsStdOut,
     hsStdErr,
@@ -30,9 +29,6 @@ newAsteriusInstance s req_path mod_buf = do
       <> ",{module:"
       <> takeJSVal mod_val
       <> "}))"
-
-hsInit :: JSSession -> JSVal -> IO ()
-hsInit s i = eval s $ deRefJSVal i <> ".exports.hs_init()"
 
 hsMain :: String -> JSSession -> JSVal -> IO ()
 hsMain prog_name s i =

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -209,7 +209,6 @@ genDefEntry task =
       ".req.mjs\";\n",
       mconcat
         [ "module.then(m => rts.newAsteriusInstance(Object.assign(req, {module: m}))).then(i => {\n",
-          "i.exports.hs_init();\n",
           "i.exports.main().catch(err => {if (!(err.startsWith('ExitSuccess') || err.startsWith('ExitFailure '))) i.fs.writeSync(2, `",
           string7 $ takeBaseName $ inputHS task,
           ": ${err}\n`)});\n",

--- a/asterius/test/cloudflare/cloudflare.mjs
+++ b/asterius/test/cloudflare/cloudflare.mjs
@@ -7,7 +7,6 @@ const asteriusInstance = new Promise((resolve, reject) => {
   // It gets hardcoded to 'wasm' when using the Wrangler CLI (as of v1.6.0).
   rts.newAsteriusInstance(Object.assign(cloudflare, { module: wasm }))
     .then(i => {
-      i.exports.hs_init();
       resolve(i);
     })
     .catch(e => reject(e));

--- a/asterius/test/ghc-testsuite.hs
+++ b/asterius/test/ghc-testsuite.hs
@@ -143,7 +143,6 @@ runTestCase l_opts tlref TestCase {..} = catch m h
             }
           $ \s -> do
             i <- newAsteriusInstance s (tmp_case_path -<.> "req.mjs") mod_buf
-            hsInit s i
             hsMain (takeBaseName tmp_case_path) s i
             hs_stdout <- hsStdOut s i
             hs_stderr <- hsStdErr s i

--- a/asterius/test/jsffi/jsffi.mjs
+++ b/asterius/test/jsffi/jsffi.mjs
@@ -9,7 +9,6 @@ process.on("unhandledRejection", err => {
 module
   .then(m => rts.newAsteriusInstance(Object.assign(jsffi, { module: m })))
   .then(async i => {
-    i.exports.hs_init();
     await i.exports.main();
     console.log(await i.exports.mult_hs_int(9, 9));
     console.log(await i.exports.mult_hs_double(9, 9));

--- a/asterius/test/nomain.hs
+++ b/asterius/test/nomain.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-import Asterius.JSRun.Main
 import Asterius.JSRun.NonMain
 import Data.Binary
 import qualified Data.ByteString.Lazy as LBS
@@ -33,7 +32,6 @@ main = do
           "test/nomain/NoMain"
           ["base_AsteriusziTopHandler_runNonIO_closure", "NoMain_x_closure"]
           m
-      hsInit s i
       let x_closure =
             deRefJSVal i
               <> ".exports.rts_apply("

--- a/asterius/test/rtsapi/rtsapi.mjs
+++ b/asterius/test/rtsapi/rtsapi.mjs
@@ -9,7 +9,6 @@ process.on("unhandledRejection", err => {
 module
   .then(m => rts.newAsteriusInstance(Object.assign(rtsapi, { module: m })))
   .then(async i => {
-    i.exports.hs_init();
     await i.exports.main();
     await i.exports.rts_evalLazyIO(
       i.exports.rts_apply(


### PR DESCRIPTION
This PR gets rid of the need of calling `i.exports.hs_init()` explicitly before calling any exported Haskell functions in JavaScript; it's called by the runtime automatically. After `newAsteriusInstance()` resolves with the resulting instance object, all runtime state is already initialized and it's possible to call exported functions by then.