### PR TITLE
Support exporting one-shot Haskell function closures dynamically

### DIFF
--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -175,7 +175,20 @@ export async function newAsteriusInstance(req) {
       Unicode: modulify(__asterius_unicode),
       Tracing: modulify(__asterius_tracer),
       Exports: {
-        newHaskellCallback: (sp, arg_tag, ret_tag, io) => __asterius_stableptr_manager.newJSVal(__asterius_exports.newHaskellCallback(sp, arg_tag, ret_tag, io)),
+        newHaskellCallback: (sp, arg_tag, ret_tag, io, oneshot) => {
+          let sn = [];
+          let cb = __asterius_exports.newHaskellCallback(
+            sp,
+            arg_tag,
+            ret_tag,
+            io,
+            oneshot
+              ? () => __asterius_exports.freeHaskellCallback(sn[0])
+              : () => {}
+          );
+          sn[0] = __asterius_stableptr_manager.newJSVal(cb);
+          return sn[0];
+        },
         freeHaskellCallback: sn => __asterius_exports.freeHaskellCallback(sn)
       },
       Scheduler: modulify(__asterius_scheduler)
@@ -190,11 +203,14 @@ export async function newAsteriusInstance(req) {
     __asterius_scheduler.setGC(__asterius_gc);
 
     for (const [f, p, a, r, i] of req.exportsStatic) {
-      __asterius_exports[f] = __asterius_exports.newHaskellCallback(
+      __asterius_exports[
+        f
+      ] = __asterius_exports.newHaskellCallback(
         __asterius_stableptr_manager.newStablePtr(p),
         a,
         r,
-        i
+        i,
+        () => {}
       );
     }
 

--- a/asterius/src/Asterius/Builtins/Exports.hs
+++ b/asterius/src/Asterius/Builtins/Exports.hs
@@ -18,7 +18,7 @@ exportsImports =
         externalBaseName = "newHaskellCallback",
         functionType =
           FunctionType
-            { paramTypes = [F64, F64, F64, F64],
+            { paramTypes = [F64, F64, F64, F64, F64],
               returnTypes = [F64]
             }
       },
@@ -36,7 +36,7 @@ exportsCBits = newHaskellCallback <> freeHaskellCallback
 newHaskellCallback :: AsteriusModule
 newHaskellCallback = runEDSL "newHaskellCallback" $ do
   setReturnTypes [I64]
-  args <- params [I64, I64, I64, I64]
+  args <- params [I64, I64, I64, I64, I64]
   truncUFloat64ToInt64
     <$> callImport'
       "__asterius_newHaskellCallback"

--- a/asterius/src/Asterius/Foreign/TcForeign.hs
+++ b/asterius/src/Asterius/Foreign/TcForeign.hs
@@ -58,7 +58,10 @@ asteriusTcFImport d = pprPanic "asteriusTcFImport" (ppr d)
 
 asteriusTcCheckFIType :: [Type] -> Type -> ForeignImport -> TcM ForeignImport
 asteriusTcCheckFIType arg_tys res_ty (CImport (L lc cconv) (L ls safety) mh (CFunction target) src)
-  | cconv == JavaScriptCallConv && unLoc src == SourceText "\"wrapper\"" =
+  | cconv == JavaScriptCallConv && unLoc src
+      `elem` map
+        SourceText
+        ["\"wrapper\"", "\"wrapper oneshot\""] =
     do
       case arg_tys of
         [arg1_ty] -> do


### PR DESCRIPTION
This PR is a further improvement of #502. We already support using the `foreign import javascript "wrapper"` syntax to dynamically export a Haskell function closure to JavaScript; this PR implements the `foreign import javascript "wrapper oneshot"` syntax to dynamically export a one-shot Haskell function closure.

When an exported one-shot Haskell function is called in JavaScript, after the relevant Haskell thread executes to complete, the Haskell function's `JSVal` and `StablePtr` references will be freed automatically.

Exporting Haskell functions that are called only once should be a pretty common use case. This PR optimizes for this case and users don't need to manually call `freeHaskellCallback` explicitly for such functions. Although it's possible to use `fixIO` to implement the oneshot logic completely in Haskell, it is troublesome and it's better to support it at the compiler/runtime level instead.

As for static `foreign export javascript`, the exported functions are less likely to be used only once IMHO, so one-shot logic is not implemented for static export functions for now.