### PR TITLE
Extend Asterius.CodeGen to marshal atomic operations

### DIFF
--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -1201,7 +1201,7 @@ marshalCmmPrimCall (GHC.MO_U_QuotRem2 GHC.W64) [q, r] [lhsHi, lhsLo, rhs] = do
         }
   pure [quotout, remout]
 -- Atomic operations
-marshalCmmPrimCall (GHC.MO_AtomicRMW GHC.W64 amop) [dst] [addr,n] =
+marshalCmmPrimCall (GHC.MO_AtomicRMW GHC.W64 amop) [dst] [addr, n] =
   marshalCmmAtomicMachOpPrimCall amop dst addr n
 marshalCmmPrimCall (GHC.MO_AtomicRead GHC.W64) [dst] [addr] = do
   dstr <- marshalTypedCmmLocalReg dst I64

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -1139,73 +1139,69 @@ marshalCmmPrimCall (GHC.MO_U_QuotRem2 GHC.W64) [q, r] [lhsHi, lhsLo, rhs] = do
             AndInt64
             (Binary ShrUInt64 v (ConstI64 (n32 * 32)))
             (ConstI64 0xFFFFFFFF)
-  let quotout =
-        UnresolvedSetLocal
-          { unresolvedLocalReg = quotr,
-            value =
-              smash32IntTo64
-                CallImport
-                  { target' = "__asterius_quotrem2_quotient",
-                    operands =
-                      [ mask32 lhsHir 1,
-                        mask32 lhsHir 0,
-                        mask32 lhsLor 1,
-                        mask32 lhsLor 0,
-                        mask32 rhsr 1,
-                        mask32 rhsr 0,
-                        ConstI32 1
-                      ],
-                    callImportReturnTypes = [I32]
-                  }
-                CallImport
-                  { target' = "__asterius_quotrem2_quotient",
-                    operands =
-                      [ mask32 lhsHir 1,
-                        mask32 lhsHir 0,
-                        mask32 lhsLor 1,
-                        mask32 lhsLor 0,
-                        mask32 rhsr 1,
-                        mask32 rhsr 0,
-                        ConstI32 0
-                      ],
-                    callImportReturnTypes = [I32]
-                  }
-          }
-  let remout =
-        UnresolvedSetLocal
-          { unresolvedLocalReg = remr,
-            value =
-              smash32IntTo64
-                CallImport
-                  { target' = "__asterius_quotrem2_remainder",
-                    operands =
-                      [ mask32 lhsHir 1,
-                        mask32 lhsHir 0,
-                        mask32 lhsLor 1,
-                        mask32 lhsLor 0,
-                        mask32 rhsr 1,
-                        mask32 rhsr 0,
-                        ConstI32 1
-                      ],
-                    callImportReturnTypes = [I32]
-                  }
-                CallImport
-                  { target' = "__asterius_quotrem2_remainder",
-                    operands =
-                      [ mask32 lhsHir 1,
-                        mask32 lhsHir 0,
-                        mask32 lhsLor 1,
-                        mask32 lhsLor 0,
-                        mask32 rhsr 1,
-                        mask32 rhsr 0,
-                        ConstI32 0
-                      ],
-                    callImportReturnTypes = [I32]
-                  }
-          }
+  let quotout = UnresolvedSetLocal
+        { unresolvedLocalReg = quotr,
+          value = smash32IntTo64
+            CallImport
+              { target' = "__asterius_quotrem2_quotient",
+                operands =
+                  [ mask32 lhsHir 1,
+                    mask32 lhsHir 0,
+                    mask32 lhsLor 1,
+                    mask32 lhsLor 0,
+                    mask32 rhsr 1,
+                    mask32 rhsr 0,
+                    ConstI32 1
+                  ],
+                callImportReturnTypes = [I32]
+              }
+            CallImport
+              { target' = "__asterius_quotrem2_quotient",
+                operands =
+                  [ mask32 lhsHir 1,
+                    mask32 lhsHir 0,
+                    mask32 lhsLor 1,
+                    mask32 lhsLor 0,
+                    mask32 rhsr 1,
+                    mask32 rhsr 0,
+                    ConstI32 0
+                  ],
+                callImportReturnTypes = [I32]
+              }
+        }
+  let remout = UnresolvedSetLocal
+        { unresolvedLocalReg = remr,
+          value = smash32IntTo64
+            CallImport
+              { target' = "__asterius_quotrem2_remainder",
+                operands =
+                  [ mask32 lhsHir 1,
+                    mask32 lhsHir 0,
+                    mask32 lhsLor 1,
+                    mask32 lhsLor 0,
+                    mask32 rhsr 1,
+                    mask32 rhsr 0,
+                    ConstI32 1
+                  ],
+                callImportReturnTypes = [I32]
+              }
+            CallImport
+              { target' = "__asterius_quotrem2_remainder",
+                operands =
+                  [ mask32 lhsHir 1,
+                    mask32 lhsHir 0,
+                    mask32 lhsLor 1,
+                    mask32 lhsLor 0,
+                    mask32 rhsr 1,
+                    mask32 rhsr 0,
+                    ConstI32 0
+                  ],
+                callImportReturnTypes = [I32]
+              }
+        }
   pure [quotout, remout]
 -- Atomic operations
-marshalCmmPrimCall (GHC.MO_AtomicRMW GHC.W64 amop) [dst] [addr, n] =
+marshalCmmPrimCall (GHC.MO_AtomicRMW GHC.W64 amop) [dst] [addr,n] =
   marshalCmmAtomicMachOpPrimCall amop dst addr n
 marshalCmmPrimCall (GHC.MO_AtomicRead GHC.W64) [dst] [addr] = do
   dstr <- marshalTypedCmmLocalReg dst I64
@@ -1213,17 +1209,16 @@ marshalCmmPrimCall (GHC.MO_AtomicRead GHC.W64) [dst] [addr] = do
   pure
     [ UnresolvedSetLocal
         { unresolvedLocalReg = dstr,
-          value =
-            Load
-              { signed = False,
-                bytes = 8,
-                offset = 0,
-                valueType = I64,
-                ptr = wrapInt64 addrr
-              }
+          value = Load
+            { signed = False,
+              bytes  = 8,
+              offset = 0,
+              valueType = I64,
+              ptr = wrapInt64 addrr
+            }
         }
     ]
-marshalCmmPrimCall (GHC.MO_AtomicWrite GHC.W64) [] [addr, val] = do
+marshalCmmPrimCall (GHC.MO_AtomicWrite GHC.W64) [] [addr,val] = do
   addrr <- fst <$> marshalCmmExpr addr
   valr <- fst <$> marshalCmmExpr val
   pure
@@ -1235,7 +1230,7 @@ marshalCmmPrimCall (GHC.MO_AtomicWrite GHC.W64) [] [addr, val] = do
           valueType = I64
         }
     ]
-marshalCmmPrimCall (GHC.MO_Cmpxchg GHC.W64) [dst] [addr, oldv, newv] = do
+marshalCmmPrimCall (GHC.MO_Cmpxchg GHC.W64) [dst] [addr,oldv,newv] = do
   -- Copied from GHC.Prim:
   --
   -- Given an array, an offset in Int units, the expected old value, and
@@ -1247,31 +1242,27 @@ marshalCmmPrimCall (GHC.MO_Cmpxchg GHC.W64) [dst] [addr, oldv, newv] = do
   addrr <- fst <$> marshalCmmExpr addr
   oldr <- fst <$> marshalCmmExpr oldv
   newr <- fst <$> marshalCmmExpr newv
-  let expr1 =
-        UnresolvedSetLocal
-          { unresolvedLocalReg = dstr,
-            value =
-              Load
-                { signed = False, -- in Cmm everything is unsigned
-                  bytes = 8,
-                  offset = 0, -- StgCmmPrim.doAtomicRMW has done the work
-                  valueType = I64,
-                  ptr = wrapInt64 addrr
-                }
-          }
-  let expr2 =
-        If
-          { condition = UnresolvedGetLocal dstr `eqInt64` oldr,
-            ifTrue =
-              Store
-                { bytes = 8,
-                  offset = 0,
-                  ptr = wrapInt64 addrr,
-                  value = newr,
-                  valueType = I64
-                },
-            ifFalse = Nothing
-          }
+  let expr1 = UnresolvedSetLocal
+        { unresolvedLocalReg = dstr,
+          value = Load
+            { signed = False,  -- in Cmm everything is unsigned
+              bytes  = 8,
+              offset = 0,      -- StgCmmPrim.doAtomicRMW has done the work
+              valueType = I64,
+              ptr = wrapInt64 addrr
+            }
+        }
+  let expr2 = If
+        { condition = UnresolvedGetLocal dstr `eqInt64` oldr,
+          ifTrue = Store
+            { bytes = 8,
+              offset = 0,
+              ptr = wrapInt64 addrr,
+              value = newr,
+              valueType = I64
+            },
+          ifFalse = Nothing
+        }
   pure [expr1, expr2]
 -- Uncovered cases
 marshalCmmPrimCall op rs xs =
@@ -1283,46 +1274,39 @@ marshalCmmPrimCall op rs xs =
 
 -- | Marshal an atomic MachOp.
 marshalCmmAtomicMachOpPrimCall ::
-  -- | The atomic machop to marshal
-  GHC.AtomicMachOp ->
-  -- | The destination register
-  GHC.LocalReg ->
-  -- | The address
-  GHC.CmmExpr ->
-  -- | The second operand (I64)
-  GHC.CmmExpr ->
+  GHC.AtomicMachOp  {- ^ The atomic machop to marshal -} ->
+  GHC.LocalReg  {- ^ The destination register -} ->
+  GHC.CmmExpr  {- ^ The address -} ->
+  GHC.CmmExpr  {- ^ The second operand (I64) -} ->
   CodeGen [Expression]
 marshalCmmAtomicMachOpPrimCall machop dst addr n = do
   dstr <- marshalTypedCmmLocalReg dst I64
   addrr <- fst <$> marshalCmmExpr addr
   nr <- fst <$> marshalCmmExpr n
   let fn = case machop of
-        GHC.AMO_Add -> addInt64
-        GHC.AMO_Sub -> subInt64
-        GHC.AMO_And -> andInt64
-        GHC.AMO_Nand -> nandInt64
-        GHC.AMO_Or -> orInt64
-        GHC.AMO_Xor -> xorInt64
-  let expr1 =
-        UnresolvedSetLocal
-          { unresolvedLocalReg = dstr,
-            value =
-              Load
-                { signed = False, -- in Cmm everything is unsigned
-                  bytes = 8,
-                  offset = 0, -- StgCmmPrim.doAtomicRMW has done the work
-                  valueType = I64,
-                  ptr = wrapInt64 addrr
-                }
-          }
-  let expr2 =
-        Store
-          { bytes = 8,
-            offset = 0,
-            ptr = wrapInt64 addrr,
-            value = fn (UnresolvedGetLocal dstr) nr,
-            valueType = I64
-          }
+             GHC.AMO_Add -> addInt64
+             GHC.AMO_Sub -> subInt64
+             GHC.AMO_And -> andInt64
+             GHC.AMO_Nand -> nandInt64
+             GHC.AMO_Or -> orInt64
+             GHC.AMO_Xor -> xorInt64
+  let expr1 = UnresolvedSetLocal
+        { unresolvedLocalReg = dstr,
+          value = Load
+            { signed = False,  -- in Cmm everything is unsigned
+              bytes  = 8,
+              offset = 0,      -- StgCmmPrim.doAtomicRMW has done the work
+              valueType = I64,
+              ptr = wrapInt64 addrr
+            }
+        }
+  let expr2 = Store
+        { bytes = 8,
+          offset = 0,
+          ptr = wrapInt64 addrr,
+          value = fn (UnresolvedGetLocal dstr) nr,
+          valueType = I64
+        }
   pure [expr1, expr2]
 
 marshalCmmUnsafeCall ::

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -1139,69 +1139,73 @@ marshalCmmPrimCall (GHC.MO_U_QuotRem2 GHC.W64) [q, r] [lhsHi, lhsLo, rhs] = do
             AndInt64
             (Binary ShrUInt64 v (ConstI64 (n32 * 32)))
             (ConstI64 0xFFFFFFFF)
-  let quotout = UnresolvedSetLocal
-        { unresolvedLocalReg = quotr,
-          value = smash32IntTo64
-            CallImport
-              { target' = "__asterius_quotrem2_quotient",
-                operands =
-                  [ mask32 lhsHir 1,
-                    mask32 lhsHir 0,
-                    mask32 lhsLor 1,
-                    mask32 lhsLor 0,
-                    mask32 rhsr 1,
-                    mask32 rhsr 0,
-                    ConstI32 1
-                  ],
-                callImportReturnTypes = [I32]
-              }
-            CallImport
-              { target' = "__asterius_quotrem2_quotient",
-                operands =
-                  [ mask32 lhsHir 1,
-                    mask32 lhsHir 0,
-                    mask32 lhsLor 1,
-                    mask32 lhsLor 0,
-                    mask32 rhsr 1,
-                    mask32 rhsr 0,
-                    ConstI32 0
-                  ],
-                callImportReturnTypes = [I32]
-              }
-        }
-  let remout = UnresolvedSetLocal
-        { unresolvedLocalReg = remr,
-          value = smash32IntTo64
-            CallImport
-              { target' = "__asterius_quotrem2_remainder",
-                operands =
-                  [ mask32 lhsHir 1,
-                    mask32 lhsHir 0,
-                    mask32 lhsLor 1,
-                    mask32 lhsLor 0,
-                    mask32 rhsr 1,
-                    mask32 rhsr 0,
-                    ConstI32 1
-                  ],
-                callImportReturnTypes = [I32]
-              }
-            CallImport
-              { target' = "__asterius_quotrem2_remainder",
-                operands =
-                  [ mask32 lhsHir 1,
-                    mask32 lhsHir 0,
-                    mask32 lhsLor 1,
-                    mask32 lhsLor 0,
-                    mask32 rhsr 1,
-                    mask32 rhsr 0,
-                    ConstI32 0
-                  ],
-                callImportReturnTypes = [I32]
-              }
-        }
+  let quotout =
+        UnresolvedSetLocal
+          { unresolvedLocalReg = quotr,
+            value =
+              smash32IntTo64
+                CallImport
+                  { target' = "__asterius_quotrem2_quotient",
+                    operands =
+                      [ mask32 lhsHir 1,
+                        mask32 lhsHir 0,
+                        mask32 lhsLor 1,
+                        mask32 lhsLor 0,
+                        mask32 rhsr 1,
+                        mask32 rhsr 0,
+                        ConstI32 1
+                      ],
+                    callImportReturnTypes = [I32]
+                  }
+                CallImport
+                  { target' = "__asterius_quotrem2_quotient",
+                    operands =
+                      [ mask32 lhsHir 1,
+                        mask32 lhsHir 0,
+                        mask32 lhsLor 1,
+                        mask32 lhsLor 0,
+                        mask32 rhsr 1,
+                        mask32 rhsr 0,
+                        ConstI32 0
+                      ],
+                    callImportReturnTypes = [I32]
+                  }
+          }
+  let remout =
+        UnresolvedSetLocal
+          { unresolvedLocalReg = remr,
+            value =
+              smash32IntTo64
+                CallImport
+                  { target' = "__asterius_quotrem2_remainder",
+                    operands =
+                      [ mask32 lhsHir 1,
+                        mask32 lhsHir 0,
+                        mask32 lhsLor 1,
+                        mask32 lhsLor 0,
+                        mask32 rhsr 1,
+                        mask32 rhsr 0,
+                        ConstI32 1
+                      ],
+                    callImportReturnTypes = [I32]
+                  }
+                CallImport
+                  { target' = "__asterius_quotrem2_remainder",
+                    operands =
+                      [ mask32 lhsHir 1,
+                        mask32 lhsHir 0,
+                        mask32 lhsLor 1,
+                        mask32 lhsLor 0,
+                        mask32 rhsr 1,
+                        mask32 rhsr 0,
+                        ConstI32 0
+                      ],
+                    callImportReturnTypes = [I32]
+                  }
+          }
   pure [quotout, remout]
 -- Atomic operations
-marshalCmmPrimCall (GHC.MO_AtomicRMW GHC.W64 amop) [dst] [addr,n] =
+marshalCmmPrimCall (GHC.MO_AtomicRMW GHC.W64 amop) [dst] [addr, n] =
   marshalCmmAtomicMachOpPrimCall amop dst addr n
 marshalCmmPrimCall (GHC.MO_AtomicRead GHC.W64) [dst] [addr] = do
   dstr <- marshalTypedCmmLocalReg dst I64
@@ -1209,16 +1213,17 @@ marshalCmmPrimCall (GHC.MO_AtomicRead GHC.W64) [dst] [addr] = do
   pure
     [ UnresolvedSetLocal
         { unresolvedLocalReg = dstr,
-          value = Load
-            { signed = False,
-              bytes  = 8,
-              offset = 0,
-              valueType = I64,
-              ptr = wrapInt64 addrr
-            }
+          value =
+            Load
+              { signed = False,
+                bytes = 8,
+                offset = 0,
+                valueType = I64,
+                ptr = wrapInt64 addrr
+              }
         }
     ]
-marshalCmmPrimCall (GHC.MO_AtomicWrite GHC.W64) [] [addr,val] = do
+marshalCmmPrimCall (GHC.MO_AtomicWrite GHC.W64) [] [addr, val] = do
   addrr <- fst <$> marshalCmmExpr addr
   valr <- fst <$> marshalCmmExpr val
   pure
@@ -1230,7 +1235,7 @@ marshalCmmPrimCall (GHC.MO_AtomicWrite GHC.W64) [] [addr,val] = do
           valueType = I64
         }
     ]
-marshalCmmPrimCall (GHC.MO_Cmpxchg GHC.W64) [dst] [addr,oldv,newv] = do
+marshalCmmPrimCall (GHC.MO_Cmpxchg GHC.W64) [dst] [addr, oldv, newv] = do
   -- Copied from GHC.Prim:
   --
   -- Given an array, an offset in Int units, the expected old value, and
@@ -1242,27 +1247,31 @@ marshalCmmPrimCall (GHC.MO_Cmpxchg GHC.W64) [dst] [addr,oldv,newv] = do
   addrr <- fst <$> marshalCmmExpr addr
   oldr <- fst <$> marshalCmmExpr oldv
   newr <- fst <$> marshalCmmExpr newv
-  let expr1 = UnresolvedSetLocal
-        { unresolvedLocalReg = dstr,
-          value = Load
-            { signed = False,  -- in Cmm everything is unsigned
-              bytes  = 8,
-              offset = 0,      -- StgCmmPrim.doAtomicRMW has done the work
-              valueType = I64,
-              ptr = wrapInt64 addrr
-            }
-        }
-  let expr2 = If
-        { condition = UnresolvedGetLocal dstr `eqInt64` oldr,
-          ifTrue = Store
-            { bytes = 8,
-              offset = 0,
-              ptr = wrapInt64 addrr,
-              value = newr,
-              valueType = I64
-            },
-          ifFalse = Nothing
-        }
+  let expr1 =
+        UnresolvedSetLocal
+          { unresolvedLocalReg = dstr,
+            value =
+              Load
+                { signed = False, -- in Cmm everything is unsigned
+                  bytes = 8,
+                  offset = 0, -- StgCmmPrim.doAtomicRMW has done the work
+                  valueType = I64,
+                  ptr = wrapInt64 addrr
+                }
+          }
+  let expr2 =
+        If
+          { condition = UnresolvedGetLocal dstr `eqInt64` oldr,
+            ifTrue =
+              Store
+                { bytes = 8,
+                  offset = 0,
+                  ptr = wrapInt64 addrr,
+                  value = newr,
+                  valueType = I64
+                },
+            ifFalse = Nothing
+          }
   pure [expr1, expr2]
 -- Uncovered cases
 marshalCmmPrimCall op rs xs =
@@ -1274,39 +1283,46 @@ marshalCmmPrimCall op rs xs =
 
 -- | Marshal an atomic MachOp.
 marshalCmmAtomicMachOpPrimCall ::
-  GHC.AtomicMachOp  {- ^ The atomic machop to marshal -} ->
-  GHC.LocalReg  {- ^ The destination register -} ->
-  GHC.CmmExpr  {- ^ The address -} ->
-  GHC.CmmExpr  {- ^ The second operand (I64) -} ->
+  -- | The atomic machop to marshal
+  GHC.AtomicMachOp ->
+  -- | The destination register
+  GHC.LocalReg ->
+  -- | The address
+  GHC.CmmExpr ->
+  -- | The second operand (I64)
+  GHC.CmmExpr ->
   CodeGen [Expression]
 marshalCmmAtomicMachOpPrimCall machop dst addr n = do
   dstr <- marshalTypedCmmLocalReg dst I64
   addrr <- fst <$> marshalCmmExpr addr
   nr <- fst <$> marshalCmmExpr n
   let fn = case machop of
-             GHC.AMO_Add -> addInt64
-             GHC.AMO_Sub -> subInt64
-             GHC.AMO_And -> andInt64
-             GHC.AMO_Nand -> nandInt64
-             GHC.AMO_Or -> orInt64
-             GHC.AMO_Xor -> xorInt64
-  let expr1 = UnresolvedSetLocal
-        { unresolvedLocalReg = dstr,
-          value = Load
-            { signed = False,  -- in Cmm everything is unsigned
-              bytes  = 8,
-              offset = 0,      -- StgCmmPrim.doAtomicRMW has done the work
-              valueType = I64,
-              ptr = wrapInt64 addrr
-            }
-        }
-  let expr2 = Store
-        { bytes = 8,
-          offset = 0,
-          ptr = wrapInt64 addrr,
-          value = fn (UnresolvedGetLocal dstr) nr,
-          valueType = I64
-        }
+        GHC.AMO_Add -> addInt64
+        GHC.AMO_Sub -> subInt64
+        GHC.AMO_And -> andInt64
+        GHC.AMO_Nand -> nandInt64
+        GHC.AMO_Or -> orInt64
+        GHC.AMO_Xor -> xorInt64
+  let expr1 =
+        UnresolvedSetLocal
+          { unresolvedLocalReg = dstr,
+            value =
+              Load
+                { signed = False, -- in Cmm everything is unsigned
+                  bytes = 8,
+                  offset = 0, -- StgCmmPrim.doAtomicRMW has done the work
+                  valueType = I64,
+                  ptr = wrapInt64 addrr
+                }
+          }
+  let expr2 =
+        Store
+          { bytes = 8,
+            offset = 0,
+            ptr = wrapInt64 addrr,
+            value = fn (UnresolvedGetLocal dstr) nr,
+            valueType = I64
+          }
   pure [expr1, expr2]
 
 marshalCmmUnsafeCall ::

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -1200,7 +1200,6 @@ marshalCmmPrimCall (GHC.MO_U_QuotRem2 GHC.W64) [q, r] [lhsHi, lhsLo, rhs] = do
               }
         }
   pure [quotout, remout]
-
 -- Atomic operations
 marshalCmmPrimCall (GHC.MO_AtomicRMW GHC.W64 amop) [dst] [addr,n] =
   marshalCmmAtomicMachOpPrimCall amop dst addr n
@@ -1275,10 +1274,10 @@ marshalCmmPrimCall op rs xs =
 
 -- | Marshal an atomic MachOp.
 marshalCmmAtomicMachOpPrimCall ::
-  GHC.AtomicMachOp ->  -- ^ The atomic machop to marshal
-  GHC.LocalReg ->  -- ^ The destination register
-  GHC.CmmExpr ->  -- ^ The address
-  GHC.CmmExpr ->  -- ^ The second operand (I64)
+  GHC.AtomicMachOp  {- ^ The atomic machop to marshal -} ->
+  GHC.LocalReg  {- ^ The destination register -} ->
+  GHC.CmmExpr  {- ^ The address -} ->
+  GHC.CmmExpr  {- ^ The second operand (I64) -} ->
   CodeGen [Expression]
 marshalCmmAtomicMachOpPrimCall machop dst addr n = do
   dstr <- marshalTypedCmmLocalReg dst I64

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -1200,12 +1200,115 @@ marshalCmmPrimCall (GHC.MO_U_QuotRem2 GHC.W64) [q, r] [lhsHi, lhsLo, rhs] = do
               }
         }
   pure [quotout, remout]
+
+-- Atomic operations
+marshalCmmPrimCall (GHC.MO_AtomicRMW GHC.W64 amop) [dst] [addr,n] =
+  marshalCmmAtomicMachOpPrimCall amop dst addr n
+marshalCmmPrimCall (GHC.MO_AtomicRead GHC.W64) [dst] [addr] = do
+  dstr <- marshalTypedCmmLocalReg dst I64
+  addrr <- fst <$> marshalCmmExpr addr
+  pure
+    [ UnresolvedSetLocal
+        { unresolvedLocalReg = dstr,
+          value = Load
+            { signed = False,
+              bytes  = 8,
+              offset = 0,
+              valueType = I64,
+              ptr = wrapInt64 addrr
+            }
+        }
+    ]
+marshalCmmPrimCall (GHC.MO_AtomicWrite GHC.W64) [] [addr,val] = do
+  addrr <- fst <$> marshalCmmExpr addr
+  valr <- fst <$> marshalCmmExpr val
+  pure
+    [ Store
+        { bytes = 8,
+          offset = 0,
+          ptr = wrapInt64 addrr,
+          value = valr,
+          valueType = I64
+        }
+    ]
+marshalCmmPrimCall (GHC.MO_Cmpxchg GHC.W64) [dst] [addr,oldv,newv] = do
+  -- Copied from GHC.Prim:
+  --
+  -- Given an array, an offset in Int units, the expected old value, and
+  -- the new value, perform an atomic compare and swap i.e. write the new
+  -- value if the current value matches the provided old value. Returns
+  -- the value of the element before the operation. Implies a full memory
+  -- barrier.
+  dstr <- marshalTypedCmmLocalReg dst I64
+  addrr <- fst <$> marshalCmmExpr addr
+  oldr <- fst <$> marshalCmmExpr oldv
+  newr <- fst <$> marshalCmmExpr newv
+  let expr1 = UnresolvedSetLocal
+        { unresolvedLocalReg = dstr,
+          value = Load
+            { signed = False,  -- in Cmm everything is unsigned
+              bytes  = 8,
+              offset = 0,      -- StgCmmPrim.doAtomicRMW has done the work
+              valueType = I64,
+              ptr = wrapInt64 addrr
+            }
+        }
+  let expr2 = If
+        { condition = UnresolvedGetLocal dstr `eqInt64` oldr,
+          ifTrue = Store
+            { bytes = 8,
+              offset = 0,
+              ptr = wrapInt64 addrr,
+              value = newr,
+              valueType = I64
+            },
+          ifFalse = Nothing
+        }
+  pure [expr1, expr2]
+-- Uncovered cases
 marshalCmmPrimCall op rs xs =
   liftIO $ throwIO $ UnsupportedCmmInstr $ showSBS $
     GHC.CmmUnsafeForeignCall
       (GHC.PrimTarget op)
       rs
       xs
+
+-- | Marshal an atomic MachOp.
+marshalCmmAtomicMachOpPrimCall ::
+  GHC.AtomicMachOp ->  -- ^ The atomic machop to marshal
+  GHC.LocalReg ->  -- ^ The destination register
+  GHC.CmmExpr ->  -- ^ The address
+  GHC.CmmExpr ->  -- ^ The second operand (I64)
+  CodeGen [Expression]
+marshalCmmAtomicMachOpPrimCall machop dst addr n = do
+  dstr <- marshalTypedCmmLocalReg dst I64
+  addrr <- fst <$> marshalCmmExpr addr
+  nr <- fst <$> marshalCmmExpr n
+  let fn = case machop of
+             GHC.AMO_Add -> addInt64
+             GHC.AMO_Sub -> subInt64
+             GHC.AMO_And -> andInt64
+             GHC.AMO_Nand -> nandInt64
+             GHC.AMO_Or -> orInt64
+             GHC.AMO_Xor -> xorInt64
+  let expr1 = UnresolvedSetLocal
+        { unresolvedLocalReg = dstr,
+          value = Load
+            { signed = False,  -- in Cmm everything is unsigned
+              bytes  = 8,
+              offset = 0,      -- StgCmmPrim.doAtomicRMW has done the work
+              valueType = I64,
+              ptr = wrapInt64 addrr
+            }
+        }
+  let expr2 = Store
+        { bytes = 8,
+          offset = 0,
+          ptr = wrapInt64 addrr,
+          value = fn (UnresolvedGetLocal dstr) nr,
+          valueType = I64
+        }
+  pure [expr1, expr2]
 
 marshalCmmUnsafeCall ::
   GHC.CmmExpr ->

--- a/asterius/src/Asterius/EDSL.hs
+++ b/asterius/src/Asterius/EDSL.hs
@@ -65,6 +65,8 @@ module Asterius.EDSL
     switchI64,
     module Asterius.EDSL.BinaryOp,
     module Asterius.EDSL.UnaryOp,
+    notInt64,
+    nandInt64,
     symbol,
     symbol',
     constI32,
@@ -316,6 +318,14 @@ storeF64 bp o = putLVal $ pointerF64 bp o
 
 storeF32 :: Expression -> Int -> Expression -> EDSL ()
 storeF32 bp o = putLVal $ pointerF32 bp o
+
+-- | Encode not using xor.
+notInt64 :: Expression -> Expression
+notInt64 e = e `xorInt64` constI64 0xFFFFFFFFFFFFFFFF
+
+-- | Encode a nand using a not and an and.
+nandInt64 :: Expression -> Expression -> Expression
+nandInt64 e1 e2 = notInt64 $ andInt64 e1 e2
 
 unTagClosure :: Expression -> Expression
 unTagClosure p = p `andInt64` constI64 0xFFFFFFFFFFFFFFF8


### PR DESCRIPTION
Until now, the `Asterius.CodeGen.marshalCmmPrimCall` would barf (generate a run-time error) if given an atomic `CallishMachOp` [1].

This PR implements code generation for these operations, by translating them non-atomically. Since currently there is no multithreading, this should suffice for now (we might want to revisit this in the future).

[1] That is, one of `AtomicRMW AMO_Add`, `AtomicRMW AMO_Sub`, `AtomicRMW AMO_And`, `AtomicRMW AMO_Nand`, `AtomicRMW AMO_Or`, `AtomicRMW AMO_Xor`, `MO_AtomicRead`, `MO_AtomicWrite`, or `MO_Cmpxchg`.