### PR TITLE
Make use of precomputed `Int` and `Char` closures in the runtime

### DIFF
--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -1162,14 +1162,48 @@ rtsMkCharFunction :: BuiltinsOptions -> AsteriusModule
 rtsMkCharFunction _ = runEDSL "rts_mkChar" $ do
   setReturnTypes [I64]
   [i] <- params [I64]
-  p <- call' "allocate" [mainCapability, constI64 2] I64
-  storeI64 p 0 $ symbol "ghczmprim_GHCziTypes_Czh_con_info"
-  storeI64 p 8 i
-  emit p
+  if'
+    [I64]
+    (i `ltUInt64` constI64 256)
+    -- If the character in question is in the range [0..255] we use the
+    -- trick that GHC uses, and instead of generating a heap-allocated Char
+    -- closure, we simply return the address of the statically allocated
+    -- Char. See stg_CHARLIKE_closure in
+    -- ghc-toolkit/boot-libs/rts/StgMiscClosures.cmm
+    -- Case 1: Use static closure
+    (let offset = i `mulInt64` constI64 16
+     in  emit $ symbol "stg_CHARLIKE_closure" `addInt64` offset
+    )
+    -- Otherwise, we fall back to the more inefficient
+    -- approach and generate a dynamic closure.
+    $ do
+        p <- call' "allocate" [mainCapability, constI64 2] I64
+        storeI64 p 0 $ symbol "ghczmprim_GHCziTypes_Czh_con_info"
+        storeI64 p 8 i
+        emit p
 
 rtsMkIntFunction :: BuiltinsOptions -> AsteriusModule
-rtsMkIntFunction opts =
-  rtsMkHelper opts "rts_mkInt" "ghczmprim_GHCziTypes_Izh_con_info"
+rtsMkIntFunction _ = runEDSL "rts_mkInt" $ do
+  setReturnTypes [I64]
+  [i] <- params [I64]
+  if'
+    [I64]
+    ((i `leSInt64` constI64 16) `andInt64` (i `geSInt64` constI64 0xFFFFFFFFFFFFFFF0)) -- -16
+    -- If the integer in question is in the range [-16..16] we use the
+    -- trick that GHC uses, and instead of generating a heap-allocated Int
+    -- closure, we simply return the address of the statically allocated
+    -- Int. See stg_INTLIKE_closure in
+    -- ghc-toolkit/boot-libs/rts/StgMiscClosures.cmm
+    (let offset = (i `addInt64` constI64 16) `mulInt64` constI64 16
+     in  emit $ symbol "stg_INTLIKE_closure" `addInt64` offset
+    )
+    -- Otherwise, we fall back to the more inefficient
+    -- approach and generate a dynamic closure.
+    $ do
+        p <- call' "allocate" [mainCapability, constI64 2] I64
+        storeI64 p 0 $ symbol "ghczmprim_GHCziTypes_Izh_con_info"
+        storeI64 p 8 i
+        emit p
 
 rtsMkWordFunction :: BuiltinsOptions -> AsteriusModule
 rtsMkWordFunction opts =

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -1187,7 +1187,7 @@ rtsMkIntFunction _ = runEDSL "rts_mkInt" $ do
   [i] <- params [I64]
   if'
     [I64]
-    ((i `leSInt64` constI64 16) `andInt32` (i `geSInt64` constI64 0xFFFFFFFFFFFFFFF0))
+    ((i `leSInt64` constI64 16) `andInt32` (i `geSInt64` constI64 (-16)))
     -- If the integer in question is in the range [-16..16] we use the
     -- trick that GHC uses, and instead of generating a heap-allocated Int
     -- closure, we simply return the address of the statically allocated

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -1188,11 +1188,11 @@ rtsMkIntFunction _ = runEDSL "rts_mkInt" $ do
   if'
     [I64]
     ((i `leSInt64` constI64 16) `andInt64` (i `geSInt64` constI64 0xFFFFFFFFFFFFFFF0))
-          -- If the integer in question is in the range [-16..16] we use the
-          -- trick that GHC uses, and instead of generating a heap-allocated Int
-          -- closure, we simply return the address of the statically allocated
-          -- Int. See stg_INTLIKE_closure in
-          -- ghc-toolkit/boot-libs/rts/StgMiscClosures.cmm
+    -- If the integer in question is in the range [-16..16] we use the
+    -- trick that GHC uses, and instead of generating a heap-allocated Int
+    -- closure, we simply return the address of the statically allocated
+    -- Int. See stg_INTLIKE_closure in
+    -- ghc-toolkit/boot-libs/rts/StgMiscClosures.cmm
     ( let offset = (i `addInt64` constI64 16) `mulInt64` constI64 16
        in emit $ symbol "stg_INTLIKE_closure" `addInt64` offset
     )

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -1187,7 +1187,7 @@ rtsMkIntFunction _ = runEDSL "rts_mkInt" $ do
   [i] <- params [I64]
   if'
     [I64]
-    ((i `leSInt64` constI64 16) `andInt64` (i `geSInt64` constI64 0xFFFFFFFFFFFFFFF0))
+    ((i `leSInt64` constI64 16) `andInt32` (i `geSInt64` constI64 0xFFFFFFFFFFFFFFF0))
     -- If the integer in question is in the range [-16..16] we use the
     -- trick that GHC uses, and instead of generating a heap-allocated Int
     -- closure, we simply return the address of the statically allocated

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -1171,16 +1171,16 @@ rtsMkCharFunction _ = runEDSL "rts_mkChar" $ do
     -- Char. See stg_CHARLIKE_closure in
     -- ghc-toolkit/boot-libs/rts/StgMiscClosures.cmm
     -- Case 1: Use static closure
-    (let offset = i `mulInt64` constI64 16
-     in  emit $ symbol "stg_CHARLIKE_closure" `addInt64` offset
+    ( let offset = i `mulInt64` constI64 16
+       in emit $ symbol "stg_CHARLIKE_closure" `addInt64` offset
     )
     -- Otherwise, we fall back to the more inefficient
     -- approach and generate a dynamic closure.
     $ do
-        p <- call' "allocate" [mainCapability, constI64 2] I64
-        storeI64 p 0 $ symbol "ghczmprim_GHCziTypes_Czh_con_info"
-        storeI64 p 8 i
-        emit p
+      p <- call' "allocate" [mainCapability, constI64 2] I64
+      storeI64 p 0 $ symbol "ghczmprim_GHCziTypes_Czh_con_info"
+      storeI64 p 8 i
+      emit p
 
 rtsMkIntFunction :: BuiltinsOptions -> AsteriusModule
 rtsMkIntFunction _ = runEDSL "rts_mkInt" $ do
@@ -1189,21 +1189,21 @@ rtsMkIntFunction _ = runEDSL "rts_mkInt" $ do
   if'
     [I64]
     ((i `leSInt64` constI64 16) `andInt64` (i `geSInt64` constI64 0xFFFFFFFFFFFFFFF0)) -- -16
-    -- If the integer in question is in the range [-16..16] we use the
-    -- trick that GHC uses, and instead of generating a heap-allocated Int
-    -- closure, we simply return the address of the statically allocated
-    -- Int. See stg_INTLIKE_closure in
-    -- ghc-toolkit/boot-libs/rts/StgMiscClosures.cmm
-    (let offset = (i `addInt64` constI64 16) `mulInt64` constI64 16
-     in  emit $ symbol "stg_INTLIKE_closure" `addInt64` offset
+          -- If the integer in question is in the range [-16..16] we use the
+          -- trick that GHC uses, and instead of generating a heap-allocated Int
+          -- closure, we simply return the address of the statically allocated
+          -- Int. See stg_INTLIKE_closure in
+          -- ghc-toolkit/boot-libs/rts/StgMiscClosures.cmm
+    ( let offset = (i `addInt64` constI64 16) `mulInt64` constI64 16
+       in emit $ symbol "stg_INTLIKE_closure" `addInt64` offset
     )
     -- Otherwise, we fall back to the more inefficient
     -- approach and generate a dynamic closure.
     $ do
-        p <- call' "allocate" [mainCapability, constI64 2] I64
-        storeI64 p 0 $ symbol "ghczmprim_GHCziTypes_Izh_con_info"
-        storeI64 p 8 i
-        emit p
+      p <- call' "allocate" [mainCapability, constI64 2] I64
+      storeI64 p 0 $ symbol "ghczmprim_GHCziTypes_Izh_con_info"
+      storeI64 p 8 i
+      emit p
 
 rtsMkWordFunction :: BuiltinsOptions -> AsteriusModule
 rtsMkWordFunction opts =

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -1170,7 +1170,6 @@ rtsMkCharFunction _ = runEDSL "rts_mkChar" $ do
     -- closure, we simply return the address of the statically allocated
     -- Char. See stg_CHARLIKE_closure in
     -- ghc-toolkit/boot-libs/rts/StgMiscClosures.cmm
-    -- Case 1: Use static closure
     ( let offset = i `mulInt64` constI64 16
        in emit $ symbol "stg_CHARLIKE_closure" `addInt64` offset
     )
@@ -1188,7 +1187,7 @@ rtsMkIntFunction _ = runEDSL "rts_mkInt" $ do
   [i] <- params [I64]
   if'
     [I64]
-    ((i `leSInt64` constI64 16) `andInt64` (i `geSInt64` constI64 0xFFFFFFFFFFFFFFF0)) -- -16
+    ((i `leSInt64` constI64 16) `andInt64` (i `geSInt64` constI64 0xFFFFFFFFFFFFFFF0))
           -- If the integer in question is in the range [-16..16] we use the
           -- trick that GHC uses, and instead of generating a heap-allocated Int
           -- closure, we simply return the address of the statically allocated


### PR DESCRIPTION
This PR addresses https://github.com/tweag/asterius/issues/331.