### PR TITLE
Fix wasm-toolkit regression

### DIFF
--- a/asterius/src/Asterius/TypeInfer.hs
+++ b/asterius/src/Asterius/TypeInfer.hs
@@ -31,6 +31,7 @@ infer expr = case expr of
   Unary {unaryOp = ConvertSInt64ToFloat64} -> [F64]
   Unary {unaryOp = TruncUFloat64ToInt64} -> [I64]
   Unary {unaryOp = TruncSFloat64ToInt64} -> [I64]
+  Binary {binaryOp = AddInt64} -> [I64]
   Host {} -> [I32]
   Nop -> []
   Unreachable -> []


### PR DESCRIPTION
#534 introduced a hidden regression for the `wasm-toolkit` backend. `wasm-toolkit` relies on a type inference function; the type inference doesn't implement a full inference for all the Asterius IR, and assumes the shape of `Expression`s passed to it. We add one particular case to fix the `wasm-toolkit` test for now, but in the longer term we should either fix the inference or drop it.