### PR TITLE
Unconditionally set --low-memory-unused

### DIFF
--- a/asterius/src/Asterius/Internals/MagicNumber.hs
+++ b/asterius/src/Asterius/Internals/MagicNumber.hs
@@ -8,10 +8,10 @@ where
 import Data.Int
 
 dataTag :: Int64
-dataTag = 2097143
+dataTag = 0x00000000001ffff7 -- 2097143
 
 functionTag :: Int64
-functionTag = 2097133
+functionTag = 0x00000000001fffed -- 2097133
 
 invalidAddress :: Int64
-invalidAddress = 0x1fffffffff0000
+invalidAddress = 0x001fffffffff0000

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -303,7 +303,7 @@ ahcDistMain logger task (final_m, report) = do
       Binaryen.c_BinaryenSetDebugInfo $ if verboseErr task then 1 else 0
       Binaryen.c_BinaryenSetOptimizeLevel $ fromIntegral $ optimizeLevel task
       Binaryen.c_BinaryenSetShrinkLevel $ fromIntegral $ shrinkLevel task
-      Binaryen.c_BinaryenSetLowMemoryUnused $ 1
+      Binaryen.c_BinaryenSetLowMemoryUnused 1
       m_ref <-
         Binaryen.marshalModule
           (tailCalls task)

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -303,6 +303,7 @@ ahcDistMain logger task (final_m, report) = do
       Binaryen.c_BinaryenSetDebugInfo $ if verboseErr task then 1 else 0
       Binaryen.c_BinaryenSetOptimizeLevel $ fromIntegral $ optimizeLevel task
       Binaryen.c_BinaryenSetShrinkLevel $ fromIntegral $ shrinkLevel task
+      Binaryen.c_BinaryenSetLowMemoryUnused $ 1
       m_ref <-
         Binaryen.marshalModule
           (tailCalls task)

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -189,5 +189,7 @@ linkStart debug gc_sections verbose_err store root_syms export_funcs =
         debug
         bundled_ffi_state
         merged_m
+        -- reserve 0 for the null function pointer
         (1 .|. functionTag `shiftL` 32)
-        (dataTag `shiftL` 32)
+        -- leave 1KB empty for the --low-memory-unused optimization to work
+        (0x00000400 .|. dataTag `shiftL` 32)

--- a/asterius/src/Asterius/TypeInfer.hs
+++ b/asterius/src/Asterius/TypeInfer.hs
@@ -31,6 +31,7 @@ infer expr = case expr of
   Unary {unaryOp = ConvertSInt64ToFloat64} -> [F64]
   Unary {unaryOp = TruncUFloat64ToInt64} -> [I64]
   Unary {unaryOp = TruncSFloat64ToInt64} -> [I64]
+  Binary {binaryOp = AddInt64} -> [I64]
   Host {} -> [I32]
   Nop -> []
   Unreachable -> []


### PR DESCRIPTION
This patch adjusts the linker to leave the first 1KB memory space empty, and enables the `--low-memory-unused` flag (addressing https://github.com/tweag/asterius/issues/532).