### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Create a bug report to help us fix it.
+labels: 'type: bug'
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment**
+ - OS name + version:
+ - GHC version:
+ - Version of Asterius:
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for this project.
+labels: 'type: feature request'
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
I noticed that quite a few tickets (for example several of those
marked as "good first issues") are not well formed feature requests or
bug reports. Feature requests should make clear what problem the
author wants to solve. Bug reports should make clear what is observed
and what is expected.

The templates used here are adapted from those in tweag/rules_haskell,
themselves adapted from those in bazelbuild/bazel. They're short and
have withstood the test of time in those two projects.