### PR TITLE
Use FastString for symbols

### DIFF
--- a/asterius/app/ahc-ld.hs
+++ b/asterius/app/ahc-ld.hs
@@ -29,11 +29,11 @@ parseLinkTask args = do
           find ("--output-ir=" `isPrefixOf`) args
             >>= stripPrefix "--output-ir=",
         rootSymbols =
-          map (EntitySymbol . fromString) $
+          map (mkEntitySymbol . fromString) $
             str_args "--extra-root-symbol=",
         exportFunctions =
           ("main" :)
-            $ map (EntitySymbol . fromString)
+            $ map (mkEntitySymbol . fromString)
             $ str_args "--export-function="
       }
   where

--- a/asterius/app/ahc-ld.hs
+++ b/asterius/app/ahc-ld.hs
@@ -29,11 +29,11 @@ parseLinkTask args = do
           find ("--output-ir=" `isPrefixOf`) args
             >>= stripPrefix "--output-ir=",
         rootSymbols =
-          map (AsteriusEntitySymbol . fromString) $
+          map (EntitySymbol . fromString) $
             str_args "--extra-root-symbol=",
         exportFunctions =
           ("main" :)
-            $ map (AsteriusEntitySymbol . fromString)
+            $ map (EntitySymbol . fromString)
             $ str_args "--export-function="
       }
   where

--- a/asterius/app/ahc-ld.hs
+++ b/asterius/app/ahc-ld.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE ViewPatterns #-}
 
 import Asterius.Ld
-import Asterius.Types
 import Data.List
 import Data.Maybe
 import Data.String
@@ -29,11 +28,11 @@ parseLinkTask args = do
           find ("--output-ir=" `isPrefixOf`) args
             >>= stripPrefix "--output-ir=",
         rootSymbols =
-          map (mkEntitySymbol . fromString) $
+          map fromString $
             str_args "--extra-root-symbol=",
         exportFunctions =
           ("main" :)
-            $ map (mkEntitySymbol . fromString)
+            $ map fromString
             $ str_args "--export-function="
       }
   where

--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -220,7 +220,7 @@ marshalFunctionType FunctionType {..} = flip runContT pure $ do
 
 -- TODO: there is a similar definition in Asterius.Backends.WasmToolkit. Maybe
 -- we should just move shared stuff into Asterius.Types (or another shared file).
-type SymbolMap = M.Map AsteriusEntitySymbol Int64
+type SymbolMap = M.Map EntitySymbol Int64
 
 -- | Environment used during marshaling of Asterius' types to Binaryen.
 data MarshalEnv
@@ -584,7 +584,7 @@ marshalMemoryExport m MemoryExport {..} = flip runContT pure $ do
   lift $ c_BinaryenAddMemoryExport m inp enp
 
 marshalModule ::
-  Bool -> M.Map AsteriusEntitySymbol Int64 -> Module -> IO BinaryenModuleRef
+  Bool -> M.Map EntitySymbol Int64 -> Module -> IO BinaryenModuleRef
 marshalModule tail_calls sym_map hs_mod@Module {..} = do
   let fts = generateWasmFunctionTypeSet hs_mod
   m <- c_BinaryenModuleCreate

--- a/asterius/src/Asterius/Backends/WasmToolkit.hs
+++ b/asterius/src/Asterius/Backends/WasmToolkit.hs
@@ -409,7 +409,7 @@ marshalBinaryOp op = case op of
 
 -- ----------------------------------------------------------------------------
 
-type SymbolMap = Map.Map AsteriusEntitySymbol Int64
+type SymbolMap = Map.Map EntitySymbol Int64
 
 -- | Environment used during the elaboration of Asterius' types to WebAssembly.
 data MarshalEnv
@@ -726,7 +726,7 @@ makeInstructionsMaybe m_expr = case m_expr of
 makeCodeSection ::
   MonadError MarshalError m =>
   Bool ->
-  Map.Map AsteriusEntitySymbol Int64 ->
+  Map.Map EntitySymbol Int64 ->
   Module ->
   ModuleSymbolTable ->
   m Wasm.Section
@@ -770,7 +770,7 @@ makeDataSection Module {..} _module_symtable = do
 makeModule ::
   MonadError MarshalError m =>
   Bool ->
-  Map.Map AsteriusEntitySymbol Int64 ->
+  Map.Map EntitySymbol Int64 ->
   Module ->
   m Wasm.Module
 makeModule tail_calls sym_map m = do

--- a/asterius/src/Asterius/Backends/WasmToolkit.hs
+++ b/asterius/src/Asterius/Backends/WasmToolkit.hs
@@ -34,6 +34,7 @@ import Control.Exception
 import Control.Monad.Except
 import Control.Monad.Reader
 import Data.Bits
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Short as SBS
 import Data.Coerce
 import Data.Int
@@ -58,7 +59,7 @@ instance Exception MarshalError
 data ModuleSymbolTable
   = ModuleSymbolTable
       { functionTypeSymbols :: Map.Map FunctionType Wasm.FunctionTypeIndex,
-        functionSymbols :: Map.Map SBS.ShortByteString Wasm.FunctionIndex
+        functionSymbols :: Map.Map BS.ByteString Wasm.FunctionIndex
       }
 
 makeModuleSymbolTable ::
@@ -110,8 +111,8 @@ makeImportSection Module {..} ModuleSymbolTable {..} = pure Wasm.ImportSection
   { imports =
       ( case memoryImport of
           MemoryImport {..} -> Wasm.Import
-            { moduleName = coerce externalModuleName,
-              importName = coerce externalBaseName,
+            { moduleName = coerce $ SBS.toShort externalModuleName,
+              importName = coerce $ SBS.toShort externalBaseName,
               importDescription = Wasm.ImportMemory $ Wasm.MemoryType $ Wasm.Limits
                 { minLimit =
                     fromIntegral $
@@ -123,8 +124,8 @@ makeImportSection Module {..} ModuleSymbolTable {..} = pure Wasm.ImportSection
       )
         : ( case tableImport of
               TableImport {..} -> Wasm.Import
-                { moduleName = coerce externalModuleName,
-                  importName = coerce externalBaseName,
+                { moduleName = coerce $ SBS.toShort externalModuleName,
+                  importName = coerce $ SBS.toShort externalBaseName,
                   importDescription = Wasm.ImportTable $ Wasm.TableType Wasm.AnyFunc $ Wasm.Limits
                     { minLimit = fromIntegral tableSlots,
                       maxLimit = Nothing
@@ -132,8 +133,8 @@ makeImportSection Module {..} ModuleSymbolTable {..} = pure Wasm.ImportSection
                 }
           )
         : [ Wasm.Import
-              { moduleName = coerce externalModuleName,
-                importName = coerce externalBaseName,
+              { moduleName = coerce $ SBS.toShort externalModuleName,
+                importName = coerce $ SBS.toShort externalBaseName,
                 importDescription =
                   Wasm.ImportFunction $
                     functionTypeSymbols
@@ -157,7 +158,7 @@ makeExportSection ::
 makeExportSection Module {..} ModuleSymbolTable {..} = pure Wasm.ExportSection
   { exports =
       [ Wasm.Export
-          { exportName = coerce externalName,
+          { exportName = coerce $ SBS.toShort externalName,
             exportDescription =
               Wasm.ExportFunction $
                 functionSymbols
@@ -168,7 +169,7 @@ makeExportSection Module {..} ModuleSymbolTable {..} = pure Wasm.ExportSection
         <> ( case memoryExport of
                MemoryExport {..} ->
                  [ Wasm.Export
-                     { exportName = coerce externalName,
+                     { exportName = coerce $ SBS.toShort externalName,
                        exportDescription =
                          Wasm.ExportMemory $
                            Wasm.MemoryIndex 0
@@ -178,7 +179,7 @@ makeExportSection Module {..} ModuleSymbolTable {..} = pure Wasm.ExportSection
         <> ( case tableExport of
                TableExport {..} ->
                  [ Wasm.Export
-                     { exportName = coerce externalName,
+                     { exportName = coerce $ SBS.toShort externalName,
                        exportDescription =
                          Wasm.ExportTable $
                            Wasm.TableIndex 0
@@ -214,7 +215,7 @@ data DeBruijnContext
         currentLevel :: Word32,
         -- | Set of all named labels currently in scope (named labels are only
         -- introduced by block or loop instructions).
-        capturedLevels :: Map.Map SBS.ShortByteString Word32
+        capturedLevels :: Map.Map BS.ByteString Word32
       }
 
 -- | Initial (empty) de Bruijn context.
@@ -223,17 +224,17 @@ emptyDeBruijnContext =
   DeBruijnContext {currentLevel = 0, capturedLevels = mempty}
 
 -- | Add a new label to the context.
-bindLabel :: SBS.ShortByteString -> DeBruijnContext -> DeBruijnContext
+bindLabel :: BS.ByteString -> DeBruijnContext -> DeBruijnContext
 bindLabel k DeBruijnContext {..} = DeBruijnContext
   { currentLevel = succ currentLevel,
     capturedLevels =
-      if SBS.null k
+      if BS.null k
         then capturedLevels
         else Map.insert k currentLevel capturedLevels
   }
 
 -- | Lookup a label (by name) in the de Bruijn context.
-extractLabel :: DeBruijnContext -> SBS.ShortByteString -> Wasm.LabelIndex
+extractLabel :: DeBruijnContext -> BS.ByteString -> Wasm.LabelIndex
 extractLabel DeBruijnContext {..} k =
   coerce $ currentLevel - capturedLevels ! k - 1
 
@@ -440,7 +441,7 @@ askModuleSymbolTable = reader envModuleSymbolTable
 
 -- | Add a label to the local environment. Used to by control constructs
 -- (block, if, etc.).
-bindLocalLabel :: MonadReader MarshalEnv m => SBS.ShortByteString -> m a -> m a
+bindLocalLabel :: MonadReader MarshalEnv m => BS.ByteString -> m a -> m a
 bindLocalLabel label = local $ \env ->
   env {envDeBruijnContext = bindLabel label $ envDeBruijnContext env}
 
@@ -448,7 +449,7 @@ bindLocalLabel label = local $ \env ->
 -- variant of function 'extractLabel'.
 lookupLabel ::
   MonadReader MarshalEnv m =>
-  SBS.ShortByteString ->
+  BS.ByteString ->
   m Wasm.LabelIndex
 lookupLabel label = asks ((`extractLabel` label) . envDeBruijnContext)
 
@@ -467,7 +468,7 @@ makeInstructions ::
 makeInstructions expr =
   case expr of
     Block {..}
-      | SBS.null name ->
+      | BS.null name ->
         fmap mconcat $ for bodys makeInstructions
       | otherwise -> do
         bs <- bindLocalLabel name $ for bodys makeInstructions
@@ -514,7 +515,7 @@ makeInstructions expr =
           }
     Call {..} -> do
       ModuleSymbolTable {..} <- askModuleSymbolTable
-      case Map.lookup (coerce target) functionSymbols of
+      case Map.lookup (entityName target) functionSymbols of
         Just i -> do
           xs <-
             for
@@ -631,7 +632,7 @@ makeInstructions expr =
       tail_calls <- areTailCallsOn
       if tail_calls
         -- Case 1: Tail calls are on
-        then case Map.lookup (coerce returnCallTarget64) functionSymbols of
+        then case Map.lookup (entityName returnCallTarget64) functionSymbols of
           Just i -> pure $
             DList.singleton Wasm.ReturnCall {returnCallFunctionIndex = i}
           _
@@ -763,7 +764,7 @@ makeDataSection Module {..} _module_symtable = do
   segs <- for memorySegments $ \DataSegment {..} -> pure Wasm.DataSegment
     { memoryIndex = Wasm.MemoryIndex 0,
       memoryOffset = Wasm.Expression {instructions = [Wasm.I32Const offset]},
-      memoryInitialBytes = content
+      memoryInitialBytes = SBS.toShort content
     }
   pure Wasm.DataSection {dataSegments = segs}
 

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -687,11 +687,11 @@ rtsFunctionExports debug =
 emitErrorMessage :: [ValueType] -> SBS.ShortByteString -> Expression
 emitErrorMessage vts ev = Barf {barfMessage = ev, barfReturnTypes = vts}
 
-byteStringCBits :: [(AsteriusEntitySymbol, (FunctionImport, Function))]
+byteStringCBits :: [(EntitySymbol, (FunctionImport, Function))]
 byteStringCBits =
   map
     ( \(func_sym, param_vts, ret_vts) ->
-        ( AsteriusEntitySymbol func_sym,
+        ( EntitySymbol func_sym,
           generateRTSWrapper "bytestring" func_sym param_vts ret_vts
         )
     )
@@ -711,11 +711,11 @@ byteStringCBits =
       ("_hs_bytestring_long_long_uint_hex", [I64, I64], [I64])
     ]
 
-textCBits :: [(AsteriusEntitySymbol, (FunctionImport, Function))]
+textCBits :: [(EntitySymbol, (FunctionImport, Function))]
 textCBits =
   map
     ( \(func_sym, param_vts, ret_vts) ->
-        ( AsteriusEntitySymbol func_sym,
+        ( EntitySymbol func_sym,
           generateRTSWrapper "text" func_sym param_vts ret_vts
         )
     )
@@ -725,11 +725,11 @@ textCBits =
       ("_hs_text_encode_utf8", [I64, I64, I64, I64], [])
     ]
 
-floatCBits :: [(AsteriusEntitySymbol, (FunctionImport, Function))]
+floatCBits :: [(EntitySymbol, (FunctionImport, Function))]
 floatCBits =
   map
     ( \(func_sym, param_vts, ret_vts) ->
-        ( AsteriusEntitySymbol func_sym,
+        ( EntitySymbol func_sym,
           generateRTSWrapper "floatCBits" func_sym param_vts ret_vts
         )
     )
@@ -794,7 +794,7 @@ generateRTSWrapper mod_sym func_sym param_vts ret_vts =
       [I64] -> ([F64], truncUFloat64ToInt64)
       _ -> (ret_vts, id)
 
-generateWrapperFunction :: AsteriusEntitySymbol -> Function -> Function
+generateWrapperFunction :: EntitySymbol -> Function -> Function
 generateWrapperFunction func_sym Function {functionType = FunctionType {..}} =
   Function
     { functionType = FunctionType
@@ -1019,7 +1019,7 @@ createStrictIOThreadFunction _ =
 genAllocateFunction ::
   BuiltinsOptions ->
   -- Name of the allocation function
-  AsteriusEntitySymbol ->
+  EntitySymbol ->
   -- Module representing the function
   AsteriusModule
 genAllocateFunction (BuiltinsOptions {}) n = runEDSL n $ do
@@ -1127,9 +1127,9 @@ makeStableNameWrapperFunction _ = runEDSL "makeStableName" $ do
 rtsMkHelper ::
   BuiltinsOptions ->
   -- Name of the function to be built
-  AsteriusEntitySymbol ->
+  EntitySymbol ->
   -- Mangled name of the primop constructor
-  AsteriusEntitySymbol ->
+  EntitySymbol ->
   AsteriusModule
 rtsMkHelper _ n con_sym = runEDSL n $ do
   setReturnTypes [I64]
@@ -1240,7 +1240,7 @@ rtsGetDoubleFunction _ = runEDSL "rts_getDouble" $ do
 -- named differently
 generateRtsGetIntFunction ::
   BuiltinsOptions ->
-  AsteriusEntitySymbol -> -- Name of the function
+  EntitySymbol -> -- Name of the function
   AsteriusModule
 generateRtsGetIntFunction _ n = runEDSL n $ do
   setReturnTypes [I64]
@@ -1386,11 +1386,11 @@ barfFunction _ = runEDSL "barf" $ do
 -- unsigned.   This is OK for ASCII code, since the ints we have will not be
 -- larger than 2^15.  However, for larger numbers, it would "overflow", and
 -- would treat large unsigned  numbers as negative signed numbers.
-unicodeCBits :: [(AsteriusEntitySymbol, (FunctionImport, Function))]
+unicodeCBits :: [(EntitySymbol, (FunctionImport, Function))]
 unicodeCBits =
   map
     ( \(func_sym, param_vts, ret_vts) ->
-        ( AsteriusEntitySymbol func_sym,
+        ( EntitySymbol func_sym,
           generateRTSWrapper "Unicode" func_sym param_vts ret_vts
         )
     )
@@ -1494,7 +1494,7 @@ writeFunction _ =
 getF64GlobalRegFunction ::
   BuiltinsOptions ->
   -- Name of the function to be created
-  AsteriusEntitySymbol ->
+  EntitySymbol ->
   -- Global register to be returned
   UnresolvedGlobalReg ->
   AsteriusModule -- Module containing the function

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -247,7 +247,7 @@ generateRtsAsteriusDebugModule opts =
 rtsFunctionImports :: Bool -> [FunctionImport]
 rtsFunctionImports debug =
   [ FunctionImport
-      { internalName = "__asterius_" <> op <> "_" <> showSBS ft,
+      { internalName = "__asterius_" <> op <> "_" <> showBS ft,
         externalModuleName = "Math",
         externalBaseName = op,
         functionType = FunctionType {paramTypes = [ft], returnTypes = [ft]}
@@ -268,7 +268,7 @@ rtsFunctionImports debug =
         ]
   ]
     <> [ FunctionImport
-           { internalName = "__asterius_" <> op <> "_" <> showSBS ft,
+           { internalName = "__asterius_" <> op <> "_" <> showBS ft,
              externalModuleName = "Math",
              externalBaseName = op,
              functionType = FunctionType

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -33,7 +33,7 @@ import Asterius.EDSL
 import Asterius.Internals
 import Asterius.Internals.MagicNumber
 import Asterius.Types
-import qualified Data.ByteString.Short as SBS
+import qualified Data.ByteString as BS
 import Data.Foldable
 import qualified Data.Map.Strict as Map
 import Data.String
@@ -61,7 +61,7 @@ defaultBuiltinsOptions = BuiltinsOptions
 
 rtsAsteriusModuleSymbol :: AsteriusModuleSymbol
 rtsAsteriusModuleSymbol = AsteriusModuleSymbol
-  { unitId = SBS.toShort $ GHC.fs_bs $ GHC.unitIdFS GHC.rtsUnitId,
+  { unitId = GHC.fs_bs $ GHC.unitIdFS GHC.rtsUnitId,
     moduleName = ["Asterius"]
   }
 
@@ -74,7 +74,7 @@ rtsAsteriusModule opts =
               AsteriusStatics
                 { staticsType = Bytes,
                   asteriusStatics =
-                    [ Serialized $ SBS.pack $
+                    [ Serialized $ BS.pack $
                         replicate
                           (8 * roundup_bytes_to_words sizeof_Capability)
                           0
@@ -129,7 +129,7 @@ rtsAsteriusModule opts =
             ( "__asterius_i64_slot",
               AsteriusStatics
                 { staticsType = Bytes,
-                  asteriusStatics = [Serialized $ SBS.pack $ replicate 8 0]
+                  asteriusStatics = [Serialized $ BS.pack $ replicate 8 0]
                 }
             )
           ],
@@ -684,14 +684,14 @@ rtsFunctionExports debug =
       }
   ]
 
-emitErrorMessage :: [ValueType] -> SBS.ShortByteString -> Expression
+emitErrorMessage :: [ValueType] -> BS.ByteString -> Expression
 emitErrorMessage vts ev = Barf {barfMessage = ev, barfReturnTypes = vts}
 
 byteStringCBits :: [(EntitySymbol, (FunctionImport, Function))]
 byteStringCBits =
   map
     ( \(func_sym, param_vts, ret_vts) ->
-        ( EntitySymbol func_sym,
+        ( mkEntitySymbol func_sym,
           generateRTSWrapper "bytestring" func_sym param_vts ret_vts
         )
     )
@@ -715,7 +715,7 @@ textCBits :: [(EntitySymbol, (FunctionImport, Function))]
 textCBits =
   map
     ( \(func_sym, param_vts, ret_vts) ->
-        ( EntitySymbol func_sym,
+        ( mkEntitySymbol func_sym,
           generateRTSWrapper "text" func_sym param_vts ret_vts
         )
     )
@@ -729,7 +729,7 @@ floatCBits :: [(EntitySymbol, (FunctionImport, Function))]
 floatCBits =
   map
     ( \(func_sym, param_vts, ret_vts) ->
-        ( EntitySymbol func_sym,
+        ( mkEntitySymbol func_sym,
           generateRTSWrapper "floatCBits" func_sym param_vts ret_vts
         )
     )
@@ -750,8 +750,8 @@ floatCBits =
     ]
 
 generateRTSWrapper ::
-  SBS.ShortByteString ->
-  SBS.ShortByteString ->
+  BS.ByteString ->
+  BS.ByteString ->
   [ValueType] ->
   [ValueType] ->
   (FunctionImport, Function)
@@ -1390,7 +1390,7 @@ unicodeCBits :: [(EntitySymbol, (FunctionImport, Function))]
 unicodeCBits =
   map
     ( \(func_sym, param_vts, ret_vts) ->
-        ( EntitySymbol func_sym,
+        ( mkEntitySymbol func_sym,
           generateRTSWrapper "Unicode" func_sym param_vts ret_vts
         )
     )

--- a/asterius/src/Asterius/Builtins/Blackhole.hs
+++ b/asterius/src/Asterius/Builtins/Blackhole.hs
@@ -7,7 +7,7 @@ where
 
 import Asterius.EDSL
 import Asterius.Types
-import qualified Data.ByteString.Short as SBS
+import qualified Data.ByteString as BS
 import Data.List
 import Language.Haskell.GHC.Toolkit.Constants
 
@@ -113,5 +113,5 @@ updateThunk = runEDSL "updateThunk" $ do
 checkSymbol :: Expression -> [EntitySymbol] -> Expression
 checkSymbol e syms = foldl1' orInt32 $ map ((e `eqInt64`) . symbol) syms
 
-barf :: SBS.ShortByteString -> EDSL ()
+barf :: BS.ByteString -> EDSL ()
 barf msg = emit Barf {barfMessage = msg, barfReturnTypes = []}

--- a/asterius/src/Asterius/Builtins/Blackhole.hs
+++ b/asterius/src/Asterius/Builtins/Blackhole.hs
@@ -110,7 +110,7 @@ updateThunk = runEDSL "updateThunk" $ do
           putLVal msg_p $ loadI64 msg offset_MessageBlackHole_link
     )
 
-checkSymbol :: Expression -> [AsteriusEntitySymbol] -> Expression
+checkSymbol :: Expression -> [EntitySymbol] -> Expression
 checkSymbol e syms = foldl1' orInt32 $ map ((e `eqInt64`) . symbol) syms
 
 barf :: SBS.ShortByteString -> EDSL ()

--- a/asterius/src/Asterius/Builtins/Main.hs
+++ b/asterius/src/Asterius/Builtins/Main.hs
@@ -8,7 +8,6 @@ where
 
 import Asterius.Types
 import qualified Data.Map.Strict as M
-import Language.Haskell.GHC.Toolkit.Constants
 
 mainBuiltins :: AsteriusModule
 mainBuiltins =

--- a/asterius/src/Asterius/Builtins/Posix.hs
+++ b/asterius/src/Asterius/Builtins/Posix.hs
@@ -17,8 +17,7 @@ import Asterius.Internals.Session
 import Asterius.Types
 import Control.Exception
 import Control.Monad.IO.Class
-import qualified Data.ByteString.Short as SBS
-import Data.Coerce
+import qualified Data.ByteString as BS
 import Data.Foldable
 import qualified Data.Map.Strict as M
 import qualified DynFlags as GHC
@@ -315,21 +314,21 @@ posixUnlockFile = runEDSL "unlockFile" $ do
   emit $ constI64 0
 
 {-# NOINLINE unixUnitId #-}
-unixUnitId :: SBS.ShortByteString
+unixUnitId :: BS.ByteString
 unixUnitId = unsafePerformIO $ fakeSession $ do
   dflags <- GHC.getDynFlags
   let Just comp_id = GHC.lookupPackageName dflags (GHC.PackageName "unix")
       GHC.InstalledUnitId inst_unit_id =
         GHC.componentIdToInstalledUnitId comp_id
-  liftIO $ evaluate $ SBS.toShort $ GHC.fastZStringToByteString $
+  liftIO $ evaluate $ GHC.fastZStringToByteString $
     GHC.zEncodeFS
       inst_unit_id
 
 posixOpendir :: AsteriusModule
 posixOpendir =
   runEDSL
-    ( "ghczuwrapperZC0ZC"
-        <> coerce unixUnitId
+    ( mkEntitySymbol $ "ghczuwrapperZC0ZC"
+        <> unixUnitId
         <> "ZCSystemziPosixziDirectoryZCopendir"
     )
     $ do

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -73,10 +73,10 @@ runCodeGen ::
 runCodeGen (unCodeGen -> CodeGen m) dflags def_mod =
   runReaderT m (dflags, asmPpr dflags def_mod <> "_")
 
-marshalCLabel :: GHC.CLabel -> CodeGen AsteriusEntitySymbol
+marshalCLabel :: GHC.CLabel -> CodeGen EntitySymbol
 marshalCLabel clbl = do
   (dflags, def_mod_prefix) <- ask
-  pure AsteriusEntitySymbol
+  pure EntitySymbol
     { entityName =
         fromString $
           if GHC.externallyVisibleCLabel clbl
@@ -156,7 +156,7 @@ marshalCmmStatic st = case st of
   GHC.CmmString s -> pure $ Serialized $ SBS.pack $ s <> [0]
 
 marshalCmmSectionType ::
-  AsteriusEntitySymbol -> GHC.Section -> AsteriusStaticsType
+  EntitySymbol -> GHC.Section -> AsteriusStaticsType
 marshalCmmSectionType sym sec@(GHC.Section _ clbl)
   | GHC.isGcPtrLabel clbl = Closure
   | "_info" `BS.isSuffixOf` SBS.fromShort (entityName sym) = InfoTable
@@ -164,7 +164,7 @@ marshalCmmSectionType sym sec@(GHC.Section _ clbl)
   | otherwise = Bytes
 
 marshalCmmData ::
-  AsteriusEntitySymbol ->
+  EntitySymbol ->
   GHC.Section ->
   GHC.CmmStatics ->
   CodeGen AsteriusStatics

--- a/asterius/src/Asterius/CodeGen/Droppable.hs
+++ b/asterius/src/Asterius/CodeGen/Droppable.hs
@@ -7,6 +7,6 @@ where
 
 import Asterius.Types
 
-ccallResultDroppable :: AsteriusEntitySymbol -> [ValueType]
+ccallResultDroppable :: EntitySymbol -> [ValueType]
 ccallResultDroppable sym | sym == "memset" || sym == "memcpy" = [I64]
 ccallResultDroppable _ = []

--- a/asterius/src/Asterius/EDSL.hs
+++ b/asterius/src/Asterius/EDSL.hs
@@ -378,7 +378,7 @@ newtype Label
 
 newLabel :: EDSL Label
 newLabel = EDSL $ state $ \s@EDSLState {..} ->
-  (Label $ showSBS labelNum, s {labelNum = succ labelNum})
+  (Label $ showBS labelNum, s {labelNum = succ labelNum})
 
 newScope :: EDSL () -> EDSL (DList Expression)
 newScope m = do

--- a/asterius/src/Asterius/EDSL.hs
+++ b/asterius/src/Asterius/EDSL.hs
@@ -118,7 +118,7 @@ data EDSLState
         labelNum :: Int,
         exprBuf :: DList Expression,
         -- | Static variables to be added into the module
-        staticsBuf :: [(AsteriusEntitySymbol, AsteriusStatics)]
+        staticsBuf :: [(EntitySymbol, AsteriusStatics)]
       }
 
 initialEDSLState :: EDSLState
@@ -165,7 +165,7 @@ bundleExpressions vts el = case el of
 -- given its name and a builder.
 runEDSL ::
   -- | Function name
-  AsteriusEntitySymbol ->
+  EntitySymbol ->
   -- | Builder
   EDSL () ->
   -- | Final module
@@ -330,10 +330,10 @@ nandInt64 e1 e2 = notInt64 $ andInt64 e1 e2
 unTagClosure :: Expression -> Expression
 unTagClosure p = p `andInt64` constI64 0xFFFFFFFFFFFFFFF8
 
-call :: AsteriusEntitySymbol -> [Expression] -> EDSL ()
+call :: EntitySymbol -> [Expression] -> EDSL ()
 call f xs = emit Call {target = f, operands = xs, callReturnTypes = []}
 
-call' :: AsteriusEntitySymbol -> [Expression] -> ValueType -> EDSL Expression
+call' :: EntitySymbol -> [Expression] -> ValueType -> EDSL Expression
 call' f xs vt = do
   lr <- mutLocal vt
   putLVal lr Call {target = f, operands = xs, callReturnTypes = [vt]}
@@ -469,7 +469,7 @@ switchI64 cond make_clauses = block' [] $ \switch_lbl ->
 -- >    storei64 x 0 (constI32 32)
 allocStaticBytes ::
   -- | Name of the static region
-  AsteriusEntitySymbol ->
+  EntitySymbol ->
   -- | Initializer
   AsteriusStatic ->
   -- | Expression to access the static, referenced by name.
@@ -483,10 +483,10 @@ allocStaticBytes n v = EDSL $ state $ \st ->
           }
    in (symbol n, st')
 
-symbol :: AsteriusEntitySymbol -> Expression
+symbol :: EntitySymbol -> Expression
 symbol = flip symbol' 0
 
-symbol' :: AsteriusEntitySymbol -> Int -> Expression
+symbol' :: EntitySymbol -> Int -> Expression
 symbol' sym o = Symbol {unresolvedSymbol = sym, symbolOffset = o}
 
 constI32 :: Int -> Expression

--- a/asterius/src/Asterius/EDSL.hs
+++ b/asterius/src/Asterius/EDSL.hs
@@ -89,9 +89,8 @@ import Asterius.Passes.All
 import Asterius.Passes.Barf
 import Asterius.Passes.GlobalRegs
 import Asterius.Types
-import Control.Monad.Fail
 import Control.Monad.State.Strict
-import qualified Data.ByteString.Short as SBS
+import qualified Data.ByteString as BS
 import qualified Data.Map.Lazy as LM
 import Data.Monoid
 import Data.Traversable
@@ -342,7 +341,7 @@ call' f xs vt = do
 -- | Call a function with no return value
 callImport ::
   -- | Function name
-  SBS.ShortByteString ->
+  BS.ByteString ->
   -- | Parameter list
   [Expression] ->
   EDSL ()
@@ -352,7 +351,7 @@ callImport f xs =
 -- | Call a function with a return value
 callImport' ::
   -- | Function name
-  SBS.ShortByteString ->
+  BS.ByteString ->
   -- | Arguments
   [Expression] ->
   -- | Return type of function
@@ -374,7 +373,7 @@ callIndirect f = emit CallIndirect
 
 newtype Label
   = Label
-      { unLabel :: SBS.ShortByteString
+      { unLabel :: BS.ByteString
       }
 
 newLabel :: EDSL Label
@@ -462,7 +461,7 @@ switchI64 cond make_clauses = block' [] $ \switch_lbl ->
 --
 -- >  runEDSL $ do
 -- >    x <- allocStaticBytes "x"
--- >          (Serialized $ SBS.pack $ replicate 8 1)
+-- >          (Serialized $ BS.pack $ replicate 8 1)
 -- >    loadi64 x 0
 -- >
 -- >    y <- allocStaticBytes "y" (Uninitialized 8)

--- a/asterius/src/Asterius/Foreign/ExportStatic.hs
+++ b/asterius/src/Asterius/Foreign/ExportStatic.hs
@@ -19,7 +19,7 @@ import Data.List
 import qualified Data.Map.Strict as M
 
 genExportStaticObj ::
-  FFIMarshalState -> M.Map AsteriusEntitySymbol Int64 -> Builder
+  FFIMarshalState -> M.Map EntitySymbol Int64 -> Builder
 genExportStaticObj FFIMarshalState {..} sym_map =
   "["
     <> mconcat
@@ -32,9 +32,9 @@ genExportStaticObj FFIMarshalState {..} sym_map =
     <> "]"
 
 genExportStaticFunc ::
-  AsteriusEntitySymbol ->
+  EntitySymbol ->
   FFIExportDecl ->
-  M.Map AsteriusEntitySymbol Int64 ->
+  M.Map EntitySymbol Int64 ->
   Builder
 genExportStaticFunc k FFIExportDecl {ffiFunctionType = FFIFunctionType {..}, ..} sym_map =
   "[\""

--- a/asterius/src/Asterius/Foreign/ExportStatic.hs
+++ b/asterius/src/Asterius/Foreign/ExportStatic.hs
@@ -12,7 +12,6 @@ import Asterius.Internals ((!))
 import Asterius.Types
 import Data.Bits
 import Data.ByteString.Builder
-import Data.Coerce
 import Data.Foldable
 import Data.Int
 import Data.List
@@ -38,7 +37,7 @@ genExportStaticFunc ::
   Builder
 genExportStaticFunc k FFIExportDecl {ffiFunctionType = FFIFunctionType {..}, ..} sym_map =
   "[\""
-    <> shortByteString (coerce k)
+    <> byteString (entityName k)
     <> "\",0x"
     <> int64HexFixed (sym_map ! ffiExportClosure)
     <> ",0x"

--- a/asterius/src/Asterius/Foreign/Internals.hs
+++ b/asterius/src/Asterius/Foreign/Internals.hs
@@ -16,7 +16,6 @@ import Asterius.Internals.Name
 import Asterius.Types
 import Asterius.TypesConv
 import Control.Monad.IO.Class
-import qualified Data.ByteString.Short as SBS
 import Data.IORef
 import qualified Data.Map.Strict as M
 import Data.String
@@ -164,9 +163,7 @@ processFFIExport hook_state_ref norm_sig_ty export_id (GHC.CExport (GHC.unLoc ->
           Just r -> r
           _ -> GHC.panicDoc "processFFIExport" $ GHC.ppr norm_sig_ty
         new_k =
-          EntitySymbol
-            { entityName = SBS.toShort $ GHC.fastStringToByteString lbl
-            }
+          mkEntitySymbol $ GHC.fastStringToByteString lbl
         export_closure = idClosureSymbol dflags export_id
         new_decl =
           FFIExportDecl

--- a/asterius/src/Asterius/Foreign/Internals.hs
+++ b/asterius/src/Asterius/Foreign/Internals.hs
@@ -164,7 +164,7 @@ processFFIExport hook_state_ref norm_sig_ty export_id (GHC.CExport (GHC.unLoc ->
           Just r -> r
           _ -> GHC.panicDoc "processFFIExport" $ GHC.ppr norm_sig_ty
         new_k =
-          AsteriusEntitySymbol
+          EntitySymbol
             { entityName = SBS.toShort $ GHC.fastStringToByteString lbl
             }
         export_closure = idClosureSymbol dflags export_id

--- a/asterius/src/Asterius/Foreign/SupportedTypes.hs
+++ b/asterius/src/Asterius/Foreign/SupportedTypes.hs
@@ -11,7 +11,7 @@ module Asterius.Foreign.SupportedTypes
 where
 
 import Asterius.Types
-import qualified Data.ByteString.Short as SBS
+import qualified Data.ByteString as BS
 import qualified ErrUtils as GHC
 import qualified GhcPlugins as GHC
 import qualified PrelNames as GHC
@@ -69,7 +69,7 @@ ffiBoxedValueTypeList =
         | vt@FFIValueType {..} <-
             GHC.nameEnvElts ffiBoxedValueTypeMap0
               <> GHC.nameEnvElts ffiBoxedValueTypeMap1,
-          not $ SBS.null hsTyCon
+          not $ BS.null hsTyCon
       ]
 
 ffiBoxedValueTypeMap0,

--- a/asterius/src/Asterius/GHCi/Internals.hs
+++ b/asterius/src/Asterius/GHCi/Internals.hs
@@ -334,7 +334,7 @@ asteriusRunTH hsc_env _ _ q ty _ s ahc_dist_input =
     let runner_closure =
           deRefJSVal i <> ".symbolTable."
             <> coerce
-              (shortByteString (coerce runner_sym))
+              (byteString (entityName runner_sym))
         hv_closure = "0x" <> JSCode (word64Hex q)
         applied_closure =
           deRefJSVal i
@@ -362,7 +362,7 @@ asteriusRunModFinalizers hsc_env s i = do
   let run_mod_fin_closure =
         deRefJSVal i <> ".symbolTable."
           <> coerce
-            (shortByteString (coerce run_mod_fin_sym))
+            (byteString (entityName run_mod_fin_sym))
       tid =
         deRefJSVal i <> ".exports.rts_evalLazyIO(" <> run_mod_fin_closure <> ")"
   (_ :: IO ()) <- eval' s tid

--- a/asterius/src/Asterius/GHCi/Internals.hs
+++ b/asterius/src/Asterius/GHCi/Internals.hs
@@ -88,7 +88,7 @@ data GHCiState
       { ghciUniqSupply :: GHC.UniqSupply,
         ghciLibs :: AsteriusModule,
         ghciObjs :: M.Map FilePath AsteriusModule,
-        ghciCompiledCoreExprs :: IM.IntMap (AsteriusEntitySymbol, AsteriusModule),
+        ghciCompiledCoreExprs :: IM.IntMap (EntitySymbol, AsteriusModule),
         ghciLastCompiledCoreExpr :: Int,
         ghciJSSession :: ~(JSSession, Pipe, JSVal)
       }
@@ -477,7 +477,7 @@ linkGhci hsc_env =
     Just ghci_comp_id =
       GHC.lookupPackageName (GHC.hsc_dflags hsc_env) (GHC.PackageName "ghci")
 
-ghciClosureSymbol :: GHC.HscEnv -> String -> String -> AsteriusEntitySymbol
+ghciClosureSymbol :: GHC.HscEnv -> String -> String -> EntitySymbol
 ghciClosureSymbol hsc_env = fakeClosureSymbol (GHC.hsc_dflags hsc_env) "ghci"
 
 intToRemoteRef :: Int -> GHC.RemoteRef a

--- a/asterius/src/Asterius/Internals.hs
+++ b/asterius/src/Asterius/Internals.hs
@@ -9,8 +9,8 @@ module Asterius.Internals
     encodeFile,
     decodeFile,
     tryDecodeFile,
-    showSBS,
-    c8SBS,
+    showBS,
+    c8BS,
     (!),
   )
 where
@@ -66,13 +66,13 @@ tryDecodeFile p = do
     Right (Left err) -> Left $ toException $ userError $ show err
     Right (Right v) -> Right v
 
-{-# INLINE showSBS #-}
-showSBS :: Show a => a -> BS.ByteString
-showSBS = fromString . show
+{-# INLINE showBS #-}
+showBS :: Show a => a -> BS.ByteString
+showBS = fromString . show
 
-{-# INLINE c8SBS #-}
-c8SBS :: BS.ByteString -> String
-c8SBS = CBS.unpack
+{-# INLINE c8BS #-}
+c8BS :: BS.ByteString -> String
+c8BS = CBS.unpack
 
 {-# INLINE (!) #-}
 (!) :: (HasCallStack, Ord k, Show k) => LM.Map k v -> k -> v

--- a/asterius/src/Asterius/Internals/Barf.hs
+++ b/asterius/src/Asterius/Internals/Barf.hs
@@ -7,7 +7,7 @@ where
 
 import Asterius.Types
 
-barf :: AsteriusEntitySymbol -> [ValueType] -> Expression
+barf :: EntitySymbol -> [ValueType] -> Expression
 barf sym [] = Call
   { target = "barf",
     operands =

--- a/asterius/src/Asterius/Internals/Name.hs
+++ b/asterius/src/Asterius/Internals/Name.hs
@@ -4,7 +4,7 @@ module Asterius.Internals.Name
   )
 where
 
-import Asterius.Types (AsteriusEntitySymbol)
+import Asterius.Types (EntitySymbol)
 import Asterius.TypesConv
 import qualified CLabel as GHC
 import Data.String
@@ -35,7 +35,7 @@ fakeName dflags pkg_name mod_name occ_name = name
     name = GHC.mkExternalName dummy_uniq m occ_name GHC.noSrcSpan
 
 fakeClosureSymbol ::
-  GHC.DynFlags -> String -> String -> String -> AsteriusEntitySymbol
+  GHC.DynFlags -> String -> String -> String -> EntitySymbol
 fakeClosureSymbol dflags pkg_name mod_name occ_name = sym
   where
     name =
@@ -47,7 +47,7 @@ fakeClosureSymbol dflags pkg_name mod_name occ_name = sym
     clbl = GHC.mkClosureLabel name GHC.MayHaveCafRefs
     sym = fromString $ asmPpr dflags clbl
 
-idClosureSymbol :: GHC.DynFlags -> GHC.Id -> AsteriusEntitySymbol
+idClosureSymbol :: GHC.DynFlags -> GHC.Id -> EntitySymbol
 idClosureSymbol dflags n =
   fromString $ asmPpr dflags $
     GHC.mkClosureLabel

--- a/asterius/src/Asterius/JSFFI.hs
+++ b/asterius/src/Asterius/JSFFI.hs
@@ -108,7 +108,7 @@ generateImplicitCastExpression signed src_ts dest_ts src_expr =
             <> show dest_ts
 
 generateFFIImportWrapperFunction ::
-  GHC.DynFlags -> AsteriusEntitySymbol -> FFIImportDecl -> Function
+  GHC.DynFlags -> EntitySymbol -> FFIImportDecl -> Function
 generateFFIImportWrapperFunction dflags k imp_decl@FFIImportDecl {..}
   | is_unsafe =
     Function
@@ -165,7 +165,7 @@ recoverCmmType dflags FFIValueType {..} = case ffiValueTypeRep of
   FFIDoubleRep -> GHC.f64
 
 asyncImportWrapper ::
-  GHC.DynFlags -> AsteriusEntitySymbol -> FFIImportDecl -> Function
+  GHC.DynFlags -> EntitySymbol -> FFIImportDecl -> Function
 asyncImportWrapper dflags k FFIImportDecl {..} =
   Function
     { functionType = wrapper_func_type,

--- a/asterius/src/Asterius/JSGen/Constants.hs
+++ b/asterius/src/Asterius/JSGen/Constants.hs
@@ -157,7 +157,7 @@ rtsConstants =
            mconcat
              ( intersperse
                  ","
-                 [ "\"" <> shortByteString hsTyCon <> "\""
+                 [ "\"" <> byteString hsTyCon <> "\""
                    | FFIValueType {..} <- ffiBoxedValueTypeList
                  ]
              ),

--- a/asterius/src/Asterius/JSGen/SPT.hs
+++ b/asterius/src/Asterius/JSGen/SPT.hs
@@ -14,8 +14,8 @@ import qualified Data.Map.Strict as M
 import Data.Word
 
 genSPT ::
-  M.Map AsteriusEntitySymbol Int64 ->
-  M.Map AsteriusEntitySymbol (Word64, Word64) ->
+  M.Map EntitySymbol Int64 ->
+  M.Map EntitySymbol (Word64, Word64) ->
   Builder
 genSPT sym_map spt_entries =
   "new Map(["

--- a/asterius/src/Asterius/JSRun/NonMain.hs
+++ b/asterius/src/Asterius/JSRun/NonMain.hs
@@ -15,7 +15,7 @@ import Asterius.Main (ahcDistMain)
 import Asterius.Main.Task
 import Asterius.Resolve
 import Asterius.Types
-  ( AsteriusEntitySymbol,
+  ( EntitySymbol,
     AsteriusModule,
     Module,
   )
@@ -23,7 +23,7 @@ import Data.String
 import Language.JavaScript.Inline.Core
 import System.FilePath
 
-linkNonMain :: AsteriusModule -> [AsteriusEntitySymbol] -> (Module, LinkReport)
+linkNonMain :: AsteriusModule -> [EntitySymbol] -> (Module, LinkReport)
 linkNonMain store_m extra_syms = (m, link_report)
   where
     (_, m, link_report) =
@@ -45,7 +45,7 @@ linkNonMain store_m extra_syms = (m, link_report)
         store_m
 
 distNonMain ::
-  FilePath -> [AsteriusEntitySymbol] -> (Module, LinkReport) -> IO ()
+  FilePath -> [EntitySymbol] -> (Module, LinkReport) -> IO ()
 distNonMain p extra_syms =
   ahcDistMain
     putStrLn
@@ -64,7 +64,7 @@ distNonMain p extra_syms =
 newAsteriusInstanceNonMain ::
   JSSession ->
   FilePath ->
-  [AsteriusEntitySymbol] ->
+  [EntitySymbol] ->
   AsteriusModule ->
   IO JSVal
 newAsteriusInstanceNonMain s p extra_syms m = do

--- a/asterius/src/Asterius/Ld.hs
+++ b/asterius/src/Asterius/Ld.hs
@@ -102,7 +102,7 @@ linkModules LinkTask {..} m =
           rtsUsedSymbols,
           rtsPrivateSymbols,
           Set.fromList
-            [ EntitySymbol {entityName = internalName}
+            [ mkEntitySymbol internalName
               | FunctionExport {..} <- rtsFunctionExports debug
             ]
         ]

--- a/asterius/src/Asterius/Ld.hs
+++ b/asterius/src/Asterius/Ld.hs
@@ -32,7 +32,7 @@ data LinkTask
         linkModule :: AsteriusModule,
         hasMain, debug, gcSections, verboseErr :: Bool,
         outputIR :: Maybe FilePath,
-        rootSymbols, exportFunctions :: [AsteriusEntitySymbol]
+        rootSymbols, exportFunctions :: [EntitySymbol]
       }
   deriving (Show)
 
@@ -45,7 +45,7 @@ loadTheWorld LinkTask {..} = do
 
 -- | The *_info are generated from Cmm using the INFO_TABLE macro.
 -- For example, see StgMiscClosures.cmm / Exception.cmm
-rtsUsedSymbols :: Set AsteriusEntitySymbol
+rtsUsedSymbols :: Set EntitySymbol
 rtsUsedSymbols =
   Set.fromList
     [ "barf",
@@ -75,7 +75,7 @@ rtsUsedSymbols =
       "stg_WEAK_info"
     ]
 
-rtsPrivateSymbols :: Set AsteriusEntitySymbol
+rtsPrivateSymbols :: Set EntitySymbol
 rtsPrivateSymbols =
   Set.fromList
     [ "base_AsteriusziTopHandler_runIO_closure",
@@ -102,7 +102,7 @@ linkModules LinkTask {..} m =
           rtsUsedSymbols,
           rtsPrivateSymbols,
           Set.fromList
-            [ AsteriusEntitySymbol {entityName = internalName}
+            [ EntitySymbol {entityName = internalName}
               | FunctionExport {..} <- rtsFunctionExports debug
             ]
         ]

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -260,10 +260,10 @@ ahcLink task = do
     ]
       <> concat [["-no-hs-main", "-optl--no-main"] | not $ hasMain task]
       <> ["-optl--debug" | debug task]
-      <> [ "-optl--extra-root-symbol=" <> c8SBS (entityName root_sym)
+      <> [ "-optl--extra-root-symbol=" <> c8BS (entityName root_sym)
            | root_sym <- extraRootSymbols task
          ]
-      <> [ "-optl--export-function=" <> c8SBS (entityName export_func)
+      <> [ "-optl--export-function=" <> c8BS (entityName export_func)
            | export_func <- exportFunctions task
          ]
       <> ["-optl--no-gc-sections" | not (gcSections task)]

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -26,7 +26,7 @@ import Asterius.Ld (rtsUsedSymbols)
 import Asterius.Main.Task
 import Asterius.Resolve
 import Asterius.Types
-  ( AsteriusEntitySymbol (..),
+  ( EntitySymbol (..),
     Module,
   )
 import qualified Bindings.Binaryen.Raw as Binaryen
@@ -139,7 +139,7 @@ genPackageJSON task =
   where
     base_name = string7 (outputBaseName task)
 
-genSymbolDict :: M.Map AsteriusEntitySymbol Int64 -> Builder
+genSymbolDict :: M.Map EntitySymbol Int64 -> Builder
 genSymbolDict sym_map =
   "Object.freeze({"
     <> mconcat

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -26,8 +26,9 @@ import Asterius.Ld (rtsUsedSymbols)
 import Asterius.Main.Task
 import Asterius.Resolve
 import Asterius.Types
-  ( EntitySymbol (..),
+  ( EntitySymbol,
     Module,
+    entityName,
   )
 import qualified Bindings.Binaryen.Raw as Binaryen
 import Control.Monad
@@ -145,7 +146,7 @@ genSymbolDict sym_map =
     <> mconcat
       ( intersperse
           ","
-          [ "\"" <> shortByteString (entityName sym) <> "\":" <> intHex sym_idx
+          [ "\"" <> byteString (entityName sym) <> "\":" <> intHex sym_idx
             | (sym, sym_idx) <- M.toList sym_map
           ]
       )
@@ -363,7 +364,7 @@ ahcDistMain logger task (final_m, report) = do
             logger "[INFO] Running binaryen optimization"
             Binaryen.c_BinaryenModuleOptimize m_ref
             flip runContT pure $ do
-              lim_segs <- marshalSBS "limit-segments"
+              lim_segs <- marshalBS "limit-segments"
               (lim_segs_p, _) <- marshalV [lim_segs]
               lift $ Binaryen.c_BinaryenModuleRunPasses m_ref lim_segs_p 1
             b <- Binaryen.serializeModule m_ref

--- a/asterius/src/Asterius/Main/Task.hs
+++ b/asterius/src/Asterius/Main/Task.hs
@@ -30,7 +30,7 @@ module Asterius.Main.Task
   )
 where
 
-import Asterius.Types (AsteriusEntitySymbol)
+import Asterius.Types (EntitySymbol)
 
 data Target
   = Node
@@ -53,7 +53,7 @@ data Task
         outputBaseName :: String,
         hasMain, tailCalls, gcSections, bundle, debug, outputIR, run, verboseErr, yolo, consoleHistory :: Bool,
         extraGHCFlags :: [String],
-        exportFunctions, extraRootSymbols :: [AsteriusEntitySymbol],
+        exportFunctions, extraRootSymbols :: [EntitySymbol],
         gcThreshold :: Int
       }
 

--- a/asterius/src/Asterius/MemoryTrap.hs
+++ b/asterius/src/Asterius/MemoryTrap.hs
@@ -21,7 +21,7 @@ addMemoryTrap m =
   let new_function_map = M.mapWithKey addMemoryTrapDeep (functionMap m)
    in m {functionMap = new_function_map}
 
-addMemoryTrapDeep :: Data a => AsteriusEntitySymbol -> a -> a
+addMemoryTrapDeep :: Data a => EntitySymbol -> a -> a
 addMemoryTrapDeep sym = w
   where
     w :: Data a => a -> a

--- a/asterius/src/Asterius/Passes/Barf.hs
+++ b/asterius/src/Asterius/Passes/Barf.hs
@@ -10,7 +10,7 @@ where
 import Asterius.Types
 import Control.Monad.State.Strict
 import qualified Data.ByteString.Char8 as CBS
-import qualified Data.ByteString.Short as SBS
+import qualified Data.ByteString as BS
 import Data.Data
   ( Data,
     gmapM,
@@ -51,7 +51,7 @@ processBarf sym f =
                 }
           put (succ i, M.insert i_sym ss sm_acc)
           pure Block
-            { name = SBS.empty,
+            { name = BS.empty,
               bodys =
                 [ Call
                     { target = "barf",
@@ -73,4 +73,4 @@ processBarf sym f =
         go = gmapM w t
     sym_str = unpack (entityName sym)
     p = "__asterius_barf_" <> sym_str <> "_"
-    unpack = CBS.unpack . SBS.fromShort
+    unpack = CBS.unpack

--- a/asterius/src/Asterius/Passes/Barf.hs
+++ b/asterius/src/Asterius/Passes/Barf.hs
@@ -21,7 +21,7 @@ import Data.Word
 import qualified Encoding as GHC
 import Type.Reflection
 
-processBarf :: AsteriusEntitySymbol -> Function -> AsteriusModule
+processBarf :: EntitySymbol -> Function -> AsteriusModule
 processBarf sym f =
   mempty
     { staticsMap = sm,
@@ -32,7 +32,7 @@ processBarf sym f =
     w ::
       Data a =>
       a ->
-      State (Word64, M.Map AsteriusEntitySymbol AsteriusStatics) a
+      State (Word64, M.Map EntitySymbol AsteriusStatics) a
     w t = case eqTypeRep (typeOf t) (typeRep :: TypeRep Expression) of
       Just HRefl -> case t of
         Barf {..} -> do

--- a/asterius/src/Asterius/Passes/DataSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/DataSymbolTable.hs
@@ -38,7 +38,7 @@ unTag = (.&. 0xFFFFFFFF)
 
 {-# INLINEABLE makeDataSymbolTable #-}
 makeDataSymbolTable ::
-  AsteriusModule -> Int64 -> (Map AsteriusEntitySymbol Int64, Int64)
+  AsteriusModule -> Int64 -> (Map EntitySymbol Int64, Int64)
 makeDataSymbolTable AsteriusModule {..} l =
   swap $
     Map.mapAccum
@@ -50,7 +50,7 @@ makeDataSymbolTable AsteriusModule {..} l =
 {-# INLINEABLE makeMemory #-}
 makeMemory ::
   AsteriusModule ->
-  Map AsteriusEntitySymbol Int64 ->
+  Map EntitySymbol Int64 ->
   Int64 ->
   (BinaryenIndex, [DataSegment])
 makeMemory AsteriusModule {..} sym_map last_addr =

--- a/asterius/src/Asterius/Passes/DataSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/DataSymbolTable.hs
@@ -12,7 +12,7 @@ import Asterius.Internals
 import Asterius.Internals.MagicNumber
 import Asterius.Types
 import Data.Bits
-import qualified Data.ByteString.Short as SBS
+import qualified Data.ByteString as BS
 import Data.Foldable
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -29,7 +29,7 @@ sizeofStatics =
       ( Sum . \case
           SymbolStatic {} -> 8
           Uninitialized x -> x
-          Serialized buf -> SBS.length buf
+          Serialized buf -> BS.length buf
       )
     . asteriusStatics
 
@@ -74,7 +74,7 @@ makeMemory AsteriusModule {..} sym_map last_addr =
                           static_addr
                         )
                         where
-                          static_addr = static_tail_addr - fromIntegral (SBS.length buf)
+                          static_addr = static_tail_addr - fromIntegral (BS.length buf)
                    in case static of
                         SymbolStatic sym o ->
                           flush_static_segs

--- a/asterius/src/Asterius/Passes/FunctionSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/FunctionSymbolTable.hs
@@ -8,7 +8,6 @@ where
 
 import Asterius.Types
 import Data.Bits
-import Data.Coerce
 import Data.Int
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -23,6 +22,6 @@ makeFunctionSymbolTable AsteriusModule {..} func_start_addr =
 {-# INLINEABLE makeFunctionTable #-}
 makeFunctionTable :: Map EntitySymbol Int64 -> Int64 -> FunctionTable
 makeFunctionTable func_sym_map func_start_addr = FunctionTable
-  { tableFunctionNames = coerce $ Map.keys func_sym_map,
+  { tableFunctionNames = map entityName $ Map.keys func_sym_map,
     tableOffset = fromIntegral $ func_start_addr .&. 0xFFFFFFFF
   }

--- a/asterius/src/Asterius/Passes/FunctionSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/FunctionSymbolTable.hs
@@ -16,12 +16,12 @@ import Data.Tuple
 
 {-# INLINEABLE makeFunctionSymbolTable #-}
 makeFunctionSymbolTable ::
-  AsteriusModule -> Int64 -> (Map AsteriusEntitySymbol Int64, Int64)
+  AsteriusModule -> Int64 -> (Map EntitySymbol Int64, Int64)
 makeFunctionSymbolTable AsteriusModule {..} func_start_addr =
   swap $ Map.mapAccum (\a _ -> (succ a, a)) func_start_addr functionMap
 
 {-# INLINEABLE makeFunctionTable #-}
-makeFunctionTable :: Map AsteriusEntitySymbol Int64 -> Int64 -> FunctionTable
+makeFunctionTable :: Map EntitySymbol Int64 -> Int64 -> FunctionTable
 makeFunctionTable func_sym_map func_start_addr = FunctionTable
   { tableFunctionNames = coerce $ Map.keys func_sym_map,
     tableOffset = fromIntegral $ func_start_addr .&. 0xFFFFFFFF

--- a/asterius/src/Asterius/Passes/GCSections.hs
+++ b/asterius/src/Asterius/Passes/GCSections.hs
@@ -21,8 +21,8 @@ import Type.Reflection
 gcSections ::
   Bool ->
   AsteriusModule ->
-  S.Set AsteriusEntitySymbol ->
-  [AsteriusEntitySymbol] ->
+  S.Set EntitySymbol ->
+  [EntitySymbol] ->
   AsteriusModule
 gcSections verbose_err store_mod root_syms export_funcs =
   final_m
@@ -57,14 +57,14 @@ gcSections verbose_err store_mod root_syms export_funcs =
             ( \i_staging_sym (i_child_syms_acc, o_m_acc) ->
                 case LM.lookup i_staging_sym (staticsMap store_mod) of
                   Just ss ->
-                    ( collectAsteriusEntitySymbols ss <> i_child_syms_acc,
+                    ( collectEntitySymbols ss <> i_child_syms_acc,
                       o_m_acc
                         { staticsMap = LM.insert i_staging_sym ss (staticsMap o_m_acc)
                         }
                     )
                   _ -> case LM.lookup i_staging_sym (functionMap store_mod) of
                     Just func ->
-                      ( collectAsteriusEntitySymbols func <> i_child_syms_acc,
+                      ( collectEntitySymbols func <> i_child_syms_acc,
                         o_m_acc
                           { functionMap =
                               LM.insert
@@ -104,9 +104,9 @@ gcSections verbose_err store_mod root_syms export_funcs =
             i_staging_syms
         o_staging_syms = i_child_syms `S.difference` o_acc_syms
 
-collectAsteriusEntitySymbols :: Data a => a -> S.Set AsteriusEntitySymbol
-collectAsteriusEntitySymbols t
-  | Just HRefl <- eqTypeRep (typeOf t) (typeRep @AsteriusEntitySymbol) =
+collectEntitySymbols :: Data a => a -> S.Set EntitySymbol
+collectEntitySymbols t
+  | Just HRefl <- eqTypeRep (typeOf t) (typeRep @EntitySymbol) =
     S.singleton t
   | otherwise =
-    gmapQl (<>) S.empty collectAsteriusEntitySymbols t
+    gmapQl (<>) S.empty collectEntitySymbols t

--- a/asterius/src/Asterius/Passes/Tracing.hs
+++ b/asterius/src/Asterius/Passes/Tracing.hs
@@ -16,7 +16,6 @@ import Asterius.Internals
 import Asterius.TypeInfer
 import Asterius.Types
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Short as SBS
 import Data.Char
 import Data.Data
   ( Data,
@@ -35,7 +34,7 @@ addTracingModule ::
   Function ->
   m Function
 addTracingModule func_sym_map func_sym func@Function {functionType = func_type}
-  | "__asterius" `BS.isPrefixOf` SBS.fromShort (entityName func_sym) =
+  | "__asterius" `BS.isPrefixOf` entityName func_sym =
     pure func
   | otherwise =
     f func
@@ -121,7 +120,7 @@ addTracingModule func_sym_map func_sym func@Function {functionType = func_type}
                       )
             pure CFG {graph = g {blockMap = new_block_map}}
             where
-              lbl_to_idx = ConstI32 . read . map (chr . fromIntegral) . SBS.unpack
+              lbl_to_idx = ConstI32 . read . map (chr . fromIntegral) . BS.unpack
           SetLocal {..}
             | ((index_int < param_num) && (params !! index_int == I64))
                 || ( (index_int >= param_num)

--- a/asterius/src/Asterius/Passes/Tracing.hs
+++ b/asterius/src/Asterius/Passes/Tracing.hs
@@ -30,8 +30,8 @@ import Type.Reflection
 {-# INLINEABLE addTracingModule #-}
 addTracingModule ::
   Monad m =>
-  M.Map AsteriusEntitySymbol Int64 ->
-  AsteriusEntitySymbol ->
+  M.Map EntitySymbol Int64 ->
+  EntitySymbol ->
   Function ->
   m Function
 addTracingModule func_sym_map func_sym func@Function {functionType = func_type}

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -21,7 +21,6 @@ import Asterius.Passes.GCSections
 import Asterius.Types
 import Data.Binary
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Short as SBS
 import qualified Data.Map.Lazy as LM
 import qualified Data.Set as S
 import Foreign
@@ -178,7 +177,7 @@ linkStart debug gc_sections verbose_err store root_syms export_funcs =
                 ( \sym _ ->
                     not
                       ( "__asterius_barf_"
-                          `BS.isPrefixOf` SBS.fromShort (entityName sym)
+                          `BS.isPrefixOf` entityName sym
                       )
                 )
                 $ staticsMap merged_m1

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -26,7 +26,6 @@ import qualified Data.Set as S
 import Foreign
 import GHC.Generics
 import Language.Haskell.GHC.Toolkit.Constants
-import Unsafe.Coerce
 
 unresolvedGlobalRegType :: UnresolvedGlobalReg -> ValueType
 unresolvedGlobalRegType gr = case gr of
@@ -104,7 +103,7 @@ resolveAsteriusModule debug bundled_ffi_state m_globals_resolved func_start_addr
     all_sym_map = func_sym_map <> ss_sym_map
     func_imports =
       rtsFunctionImports debug <> generateFFIFunctionImports bundled_ffi_state
-    new_function_map = unsafeCoerce $ functionMap m_globals_resolved
+    new_function_map = LM.mapKeys entityName $ functionMap m_globals_resolved
     (initial_pages, segs) =
       makeMemory m_globals_resolved all_sym_map last_data_addr
     initial_mblocks =

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -37,10 +37,10 @@ unresolvedGlobalRegType gr = case gr of
 
 data LinkReport
   = LinkReport
-      { staticsSymbolMap, functionSymbolMap :: LM.Map AsteriusEntitySymbol Int64,
+      { staticsSymbolMap, functionSymbolMap :: LM.Map EntitySymbol Int64,
         infoTableSet :: [Int64],
         tableSlots, staticMBlocks :: Int,
-        sptEntries :: LM.Map AsteriusEntitySymbol (Word64, Word64),
+        sptEntries :: LM.Map EntitySymbol (Word64, Word64),
         bundledFFIMarshalState :: FFIMarshalState
       }
   deriving (Generic, Show)
@@ -74,7 +74,7 @@ instance Monoid LinkReport where
       }
 
 makeInfoTableSet ::
-  AsteriusModule -> LM.Map AsteriusEntitySymbol Int64 -> [Int64]
+  AsteriusModule -> LM.Map EntitySymbol Int64 -> [Int64]
 makeInfoTableSet AsteriusModule {..} sym_map =
   LM.elems $ LM.restrictKeys sym_map $ LM.keysSet $
     LM.filter
@@ -88,8 +88,8 @@ resolveAsteriusModule ::
   Int64 ->
   Int64 ->
   ( Module,
-    LM.Map AsteriusEntitySymbol Int64,
-    LM.Map AsteriusEntitySymbol Int64,
+    LM.Map EntitySymbol Int64,
+    LM.Map EntitySymbol Int64,
     Int,
     Int
   )
@@ -146,8 +146,8 @@ linkStart ::
   Bool ->
   Bool ->
   AsteriusModule ->
-  S.Set AsteriusEntitySymbol ->
-  [AsteriusEntitySymbol] ->
+  S.Set EntitySymbol ->
+  [EntitySymbol] ->
   (AsteriusModule, Module, LinkReport)
 linkStart debug gc_sections verbose_err store root_syms export_funcs =
   ( merged_m,

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -15,7 +15,7 @@ module Asterius.Types
     AsteriusStatics (..),
     AsteriusModule (..),
     AsteriusModuleSymbol (..),
-    AsteriusEntitySymbol (..),
+    EntitySymbol (..),
     UnresolvedLocalReg (..),
     UnresolvedGlobalReg (..),
     ValueType (..),
@@ -78,7 +78,7 @@ instance Binary AsteriusCodeGenError
 instance Exception AsteriusCodeGenError
 
 data AsteriusStatic
-  = SymbolStatic AsteriusEntitySymbol Int
+  = SymbolStatic EntitySymbol Int
   | Uninitialized Int
   | Serialized SBS.ShortByteString
   deriving (Eq, Ord, Show, Generic, Data)
@@ -105,10 +105,10 @@ instance Binary AsteriusStatics
 
 data AsteriusModule
   = AsteriusModule
-      { staticsMap :: LM.Map AsteriusEntitySymbol AsteriusStatics,
-        staticsErrorMap :: LM.Map AsteriusEntitySymbol AsteriusCodeGenError,
-        functionMap :: LM.Map AsteriusEntitySymbol Function,
-        sptMap :: LM.Map AsteriusEntitySymbol (Word64, Word64),
+      { staticsMap :: LM.Map EntitySymbol AsteriusStatics,
+        staticsErrorMap :: LM.Map EntitySymbol AsteriusCodeGenError,
+        functionMap :: LM.Map EntitySymbol Function,
+        sptMap :: LM.Map EntitySymbol (Word64, Word64),
         ffiMarshalState :: FFIMarshalState
       }
   deriving (Eq, Show, Generic, Data)
@@ -149,15 +149,15 @@ data AsteriusModuleSymbol
 
 instance Binary AsteriusModuleSymbol
 
-newtype AsteriusEntitySymbol
-  = AsteriusEntitySymbol
+newtype EntitySymbol
+  = EntitySymbol
       { entityName :: SBS.ShortByteString
       }
   deriving (Eq, Ord, IsString, Binary, Semigroup)
 
-deriving newtype instance Show AsteriusEntitySymbol
+deriving newtype instance Show EntitySymbol
 
-deriving instance Data AsteriusEntitySymbol
+deriving instance Data EntitySymbol
 
 data UnresolvedLocalReg
   = UniqueLocalReg Int ValueType
@@ -371,7 +371,7 @@ data Expression
         condition :: Expression
       }
   | Call
-      { target :: AsteriusEntitySymbol,
+      { target :: EntitySymbol,
         operands :: [Expression],
         callReturnTypes :: [ValueType]
       }
@@ -425,7 +425,7 @@ data Expression
       { dropValue :: Expression
       }
   | ReturnCall
-      { returnCallTarget64 :: AsteriusEntitySymbol
+      { returnCallTarget64 :: EntitySymbol
       }
   | ReturnCallIndirect
       { returnCallIndirectTarget64 :: Expression
@@ -440,7 +440,7 @@ data Expression
       { graph :: RelooperRun
       }
   | Symbol
-      { unresolvedSymbol :: AsteriusEntitySymbol,
+      { unresolvedSymbol :: EntitySymbol,
         symbolOffset :: Int
       }
   | UnresolvedGetLocal
@@ -648,7 +648,7 @@ instance Binary FFIImportDecl
 data FFIExportDecl
   = FFIExportDecl
       { ffiFunctionType :: FFIFunctionType,
-        ffiExportClosure :: AsteriusEntitySymbol
+        ffiExportClosure :: EntitySymbol
       }
   deriving (Eq, Show, Generic, Data)
 
@@ -656,8 +656,8 @@ instance Binary FFIExportDecl
 
 data FFIMarshalState
   = FFIMarshalState
-      { ffiImportDecls :: LM.Map AsteriusEntitySymbol FFIImportDecl,
-        ffiExportDecls :: LM.Map AsteriusEntitySymbol FFIExportDecl
+      { ffiImportDecls :: LM.Map EntitySymbol FFIImportDecl,
+        ffiExportDecls :: LM.Map EntitySymbol FFIExportDecl
       }
   deriving (Eq, Show, Data)
 

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -2,9 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE StrictData #-}
 
 module Asterius.Types
@@ -15,7 +13,9 @@ module Asterius.Types
     AsteriusStatics (..),
     AsteriusModule (..),
     AsteriusModuleSymbol (..),
-    EntitySymbol (..),
+    EntitySymbol,
+    entityName,
+    mkEntitySymbol,
     UnresolvedLocalReg (..),
     UnresolvedGlobalReg (..),
     ValueType (..),
@@ -49,26 +49,26 @@ module Asterius.Types
 where
 
 import Asterius.Internals.Binary
+import Asterius.Types.EntitySymbol
 import Control.Exception
 import Data.Binary
-import qualified Data.ByteString.Short as SBS
+import qualified Data.ByteString as BS
 import Data.Data
 import qualified Data.Map.Lazy as LM
-import Data.String
 import Foreign
 import GHC.Generics
 
 type BinaryenIndex = Word32
 
 data AsteriusCodeGenError
-  = UnsupportedCmmLit SBS.ShortByteString
-  | UnsupportedCmmInstr SBS.ShortByteString
-  | UnsupportedCmmBranch SBS.ShortByteString
-  | UnsupportedCmmType SBS.ShortByteString
-  | UnsupportedCmmWidth SBS.ShortByteString
-  | UnsupportedCmmGlobalReg SBS.ShortByteString
-  | UnsupportedCmmExpr SBS.ShortByteString
-  | UnsupportedCmmSectionType SBS.ShortByteString
+  = UnsupportedCmmLit BS.ByteString
+  | UnsupportedCmmInstr BS.ByteString
+  | UnsupportedCmmBranch BS.ByteString
+  | UnsupportedCmmType BS.ByteString
+  | UnsupportedCmmWidth BS.ByteString
+  | UnsupportedCmmGlobalReg BS.ByteString
+  | UnsupportedCmmExpr BS.ByteString
+  | UnsupportedCmmSectionType BS.ByteString
   | UnsupportedImplicitCasting Expression ValueType ValueType
   | AssignToImmutableGlobalReg UnresolvedGlobalReg
   deriving (Eq, Show, Generic, Data)
@@ -80,7 +80,7 @@ instance Exception AsteriusCodeGenError
 data AsteriusStatic
   = SymbolStatic EntitySymbol Int
   | Uninitialized Int
-  | Serialized SBS.ShortByteString
+  | Serialized BS.ByteString
   deriving (Eq, Ord, Show, Generic, Data)
 
 instance Binary AsteriusStatic
@@ -142,22 +142,12 @@ instance Monoid AsteriusModule where
 
 data AsteriusModuleSymbol
   = AsteriusModuleSymbol
-      { unitId :: SBS.ShortByteString,
-        moduleName :: [SBS.ShortByteString]
+      { unitId :: BS.ByteString,
+        moduleName :: [BS.ByteString]
       }
   deriving (Eq, Ord, Show, Generic, Data)
 
 instance Binary AsteriusModuleSymbol
-
-newtype EntitySymbol
-  = EntitySymbol
-      { entityName :: SBS.ShortByteString
-      }
-  deriving (Eq, Ord, IsString, Binary, Semigroup)
-
-deriving newtype instance Show EntitySymbol
-
-deriving instance Data EntitySymbol
 
 data UnresolvedLocalReg
   = UniqueLocalReg Int ValueType
@@ -349,7 +339,7 @@ instance Binary HostOp
 
 data Expression
   = Block
-      { name :: SBS.ShortByteString,
+      { name :: BS.ByteString,
         bodys :: [Expression],
         blockReturnTypes :: [ValueType]
       }
@@ -358,16 +348,16 @@ data Expression
         ifFalse :: Maybe Expression
       }
   | Loop
-      { name :: SBS.ShortByteString,
+      { name :: BS.ByteString,
         body :: Expression
       }
   | Break
-      { name :: SBS.ShortByteString,
+      { name :: BS.ByteString,
         breakCondition :: Maybe Expression
       }
   | Switch
-      { names :: [SBS.ShortByteString],
-        defaultName :: SBS.ShortByteString,
+      { names :: [BS.ByteString],
+        defaultName :: BS.ByteString,
         condition :: Expression
       }
   | Call
@@ -376,7 +366,7 @@ data Expression
         callReturnTypes :: [ValueType]
       }
   | CallImport
-      { target' :: SBS.ShortByteString,
+      { target' :: BS.ByteString,
         operands :: [Expression],
         callImportReturnTypes :: [ValueType]
       }
@@ -451,7 +441,7 @@ data Expression
         value :: Expression
       }
   | Barf
-      { barfMessage :: SBS.ShortByteString,
+      { barfMessage :: BS.ByteString,
         barfReturnTypes :: [ValueType]
       }
   deriving (Eq, Show, Generic, Data)
@@ -470,7 +460,7 @@ instance Binary Function
 
 data FunctionImport
   = FunctionImport
-      { internalName, externalModuleName, externalBaseName :: SBS.ShortByteString,
+      { internalName, externalModuleName, externalBaseName :: BS.ByteString,
         functionType :: FunctionType
       }
   deriving (Eq, Show, Data, Generic)
@@ -479,7 +469,7 @@ instance Binary FunctionImport
 
 data TableImport
   = TableImport
-      { externalModuleName, externalBaseName :: SBS.ShortByteString
+      { externalModuleName, externalBaseName :: BS.ByteString
       }
   deriving (Eq, Show, Data, Generic)
 
@@ -487,7 +477,7 @@ instance Binary TableImport
 
 data MemoryImport
   = MemoryImport
-      { externalModuleName, externalBaseName :: SBS.ShortByteString
+      { externalModuleName, externalBaseName :: BS.ByteString
       }
   deriving (Eq, Show, Data, Generic)
 
@@ -495,7 +485,7 @@ instance Binary MemoryImport
 
 data FunctionExport
   = FunctionExport
-      { internalName, externalName :: SBS.ShortByteString
+      { internalName, externalName :: BS.ByteString
       }
   deriving (Eq, Show, Data, Generic)
 
@@ -503,7 +493,7 @@ instance Binary FunctionExport
 
 newtype TableExport
   = TableExport
-      { externalName :: SBS.ShortByteString
+      { externalName :: BS.ByteString
       }
   deriving (Eq, Show, Data, Generic)
 
@@ -511,7 +501,7 @@ instance Binary TableExport
 
 newtype MemoryExport
   = MemoryExport
-      { externalName :: SBS.ShortByteString
+      { externalName :: BS.ByteString
       }
   deriving (Eq, Show, Data, Generic)
 
@@ -519,7 +509,7 @@ instance Binary MemoryExport
 
 data FunctionTable
   = FunctionTable
-      { tableFunctionNames :: [SBS.ShortByteString],
+      { tableFunctionNames :: [BS.ByteString],
         tableOffset :: BinaryenIndex
       }
   deriving (Eq, Show, Data, Generic)
@@ -528,7 +518,7 @@ instance Binary FunctionTable
 
 data DataSegment
   = DataSegment
-      { content :: SBS.ShortByteString,
+      { content :: BS.ByteString,
         offset :: Int32
       }
   deriving (Eq, Show, Data, Generic)
@@ -537,7 +527,7 @@ instance Binary DataSegment
 
 data Module
   = Module
-      { functionMap' :: LM.Map SBS.ShortByteString Function,
+      { functionMap' :: LM.Map BS.ByteString Function,
         functionImports :: [FunctionImport],
         functionExports :: [FunctionExport],
         functionTable :: FunctionTable,
@@ -566,11 +556,11 @@ instance Binary RelooperAddBlock
 
 data RelooperAddBranch
   = AddBranch
-      { to :: SBS.ShortByteString,
+      { to :: BS.ByteString,
         addBranchCondition :: Maybe Expression
       }
   | AddBranchForSwitch
-      { to :: SBS.ShortByteString,
+      { to :: BS.ByteString,
         indexes :: [BinaryenIndex]
       }
   deriving (Eq, Show, Generic, Data)
@@ -588,8 +578,8 @@ instance Binary RelooperBlock
 
 data RelooperRun
   = RelooperRun
-      { entry :: SBS.ShortByteString,
-        blockMap :: LM.Map SBS.ShortByteString RelooperBlock,
+      { entry :: BS.ByteString,
+        blockMap :: LM.Map BS.ByteString RelooperBlock,
         labelHelper :: BinaryenIndex
       }
   deriving (Eq, Show, Generic, Data)
@@ -612,7 +602,7 @@ instance Binary FFIValueTypeRep
 data FFIValueType
   = FFIValueType
       { ffiValueTypeRep :: FFIValueTypeRep,
-        hsTyCon :: SBS.ShortByteString
+        hsTyCon :: BS.ByteString
       }
   deriving (Eq, Show, Generic, Data)
 
@@ -639,7 +629,7 @@ data FFIImportDecl
   = FFIImportDecl
       { ffiFunctionType :: FFIFunctionType,
         ffiSafety :: FFISafety,
-        ffiSourceText :: SBS.ShortByteString
+        ffiSourceText :: BS.ByteString
       }
   deriving (Eq, Show, Generic, Data)
 

--- a/asterius/src/Asterius/Types/EntitySymbol.hs
+++ b/asterius/src/Asterius/Types/EntitySymbol.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Asterius.Types.EntitySymbol
+  ( EntitySymbol,
+    entityName,
+    mkEntitySymbol
+  )
+where
+
+import Data.Binary
+import qualified Data.ByteString as BS
+import Data.Data
+import Data.String
+
+newtype EntitySymbol = EntitySymbol BS.ByteString
+  deriving newtype (Eq, Ord, Show, IsString, Semigroup, Monoid)
+  deriving stock (Data)
+
+{-# INLINE entityName #-}
+entityName :: EntitySymbol -> BS.ByteString
+entityName (EntitySymbol k) = k
+
+{-# INLINE mkEntitySymbol #-}
+mkEntitySymbol :: BS.ByteString -> EntitySymbol
+mkEntitySymbol = EntitySymbol
+
+instance Binary EntitySymbol where
+  {-# INLINE put #-}
+  put = put . entityName
+  {-# INLINE get #-}
+  get = mkEntitySymbol <$> get

--- a/asterius/src/Asterius/Types/EntitySymbol.hs
+++ b/asterius/src/Asterius/Types/EntitySymbol.hs
@@ -15,21 +15,17 @@ import Data.Data
 import Data.String
 import qualified GhcPlugins as GHC
 
-newtype EntitySymbol = EntitySymbol BS.ByteString
+newtype EntitySymbol = EntitySymbol GHC.FastString
   deriving newtype (Eq, Ord, Show, IsString, Semigroup, Monoid)
   deriving stock (Data)
 
 {-# INLINE entityName #-}
 entityName :: EntitySymbol -> BS.ByteString
-entityName (EntitySymbol k) = k
+entityName (EntitySymbol k) = GHC.fastStringToByteString k
 
 {-# INLINE mkEntitySymbol #-}
 mkEntitySymbol :: BS.ByteString -> EntitySymbol
-mkEntitySymbol bs
-  | BS.null bs =
-    EntitySymbol BS.empty
-  | otherwise =
-    EntitySymbol $ GHC.fastStringToByteString $ GHC.mkFastStringByteString bs
+mkEntitySymbol = EntitySymbol . GHC.mkFastStringByteString
 
 instance Binary EntitySymbol where
   {-# INLINE put #-}

--- a/asterius/src/Asterius/Types/EntitySymbol.hs
+++ b/asterius/src/Asterius/Types/EntitySymbol.hs
@@ -5,7 +5,7 @@
 module Asterius.Types.EntitySymbol
   ( EntitySymbol,
     entityName,
-    mkEntitySymbol
+    mkEntitySymbol,
   )
 where
 
@@ -13,18 +13,19 @@ import Data.Binary
 import qualified Data.ByteString as BS
 import Data.Data
 import Data.String
+import qualified GhcPlugins as GHC
 
-newtype EntitySymbol = EntitySymbol BS.ByteString
+newtype EntitySymbol = EntitySymbol GHC.FastString
   deriving newtype (Eq, Ord, Show, IsString, Semigroup, Monoid)
   deriving stock (Data)
 
 {-# INLINE entityName #-}
 entityName :: EntitySymbol -> BS.ByteString
-entityName (EntitySymbol k) = k
+entityName (EntitySymbol sym) = GHC.fastStringToByteString sym
 
 {-# INLINE mkEntitySymbol #-}
 mkEntitySymbol :: BS.ByteString -> EntitySymbol
-mkEntitySymbol = EntitySymbol
+mkEntitySymbol = EntitySymbol . GHC.mkFastStringByteString
 
 instance Binary EntitySymbol where
   {-# INLINE put #-}

--- a/asterius/src/Asterius/Types/EntitySymbol.hs
+++ b/asterius/src/Asterius/Types/EntitySymbol.hs
@@ -5,7 +5,7 @@
 module Asterius.Types.EntitySymbol
   ( EntitySymbol,
     entityName,
-    mkEntitySymbol,
+    mkEntitySymbol
   )
 where
 
@@ -13,19 +13,18 @@ import Data.Binary
 import qualified Data.ByteString as BS
 import Data.Data
 import Data.String
-import qualified GhcPlugins as GHC
 
-newtype EntitySymbol = EntitySymbol GHC.FastString
+newtype EntitySymbol = EntitySymbol BS.ByteString
   deriving newtype (Eq, Ord, Show, IsString, Semigroup, Monoid)
   deriving stock (Data)
 
 {-# INLINE entityName #-}
 entityName :: EntitySymbol -> BS.ByteString
-entityName (EntitySymbol sym) = GHC.fastStringToByteString sym
+entityName (EntitySymbol k) = k
 
 {-# INLINE mkEntitySymbol #-}
 mkEntitySymbol :: BS.ByteString -> EntitySymbol
-mkEntitySymbol = EntitySymbol . GHC.mkFastStringByteString
+mkEntitySymbol = EntitySymbol
 
 instance Binary EntitySymbol where
   {-# INLINE put #-}

--- a/asterius/src/Asterius/Types/EntitySymbol.hs
+++ b/asterius/src/Asterius/Types/EntitySymbol.hs
@@ -5,7 +5,7 @@
 module Asterius.Types.EntitySymbol
   ( EntitySymbol,
     entityName,
-    mkEntitySymbol
+    mkEntitySymbol,
   )
 where
 
@@ -13,6 +13,7 @@ import Data.Binary
 import qualified Data.ByteString as BS
 import Data.Data
 import Data.String
+import qualified GhcPlugins as GHC
 
 newtype EntitySymbol = EntitySymbol BS.ByteString
   deriving newtype (Eq, Ord, Show, IsString, Semigroup, Monoid)
@@ -24,7 +25,11 @@ entityName (EntitySymbol k) = k
 
 {-# INLINE mkEntitySymbol #-}
 mkEntitySymbol :: BS.ByteString -> EntitySymbol
-mkEntitySymbol = EntitySymbol
+mkEntitySymbol bs
+  | BS.null bs =
+    EntitySymbol BS.empty
+  | otherwise =
+    EntitySymbol $ GHC.fastStringToByteString $ GHC.mkFastStringByteString bs
 
 instance Binary EntitySymbol where
   {-# INLINE put #-}

--- a/asterius/src/Asterius/TypesConv.hs
+++ b/asterius/src/Asterius/TypesConv.hs
@@ -13,8 +13,6 @@ where
 
 import Asterius.Types
 import qualified Data.ByteString.Char8 as CBS
-import qualified Data.ByteString.Short as SBS
-import Data.List
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified GhcPlugins as GHC
@@ -27,9 +25,9 @@ import System.IO
 {-# INLINE marshalToModuleSymbol #-}
 marshalToModuleSymbol :: GHC.Module -> AsteriusModuleSymbol
 marshalToModuleSymbol (GHC.Module u m) = AsteriusModuleSymbol
-  { unitId = SBS.toShort $ GHC.fs_bs $ GHC.unitIdFS u,
+  { unitId = GHC.fs_bs $ GHC.unitIdFS u,
     moduleName =
-      map SBS.toShort $ CBS.splitWith (== '.') $ GHC.fs_bs $ GHC.moduleNameFS m
+      CBS.splitWith (== '.') $ GHC.fs_bs $ GHC.moduleNameFS m
   }
 
 {-# INLINE zEncodeModuleSymbol #-}
@@ -38,9 +36,9 @@ zEncodeModuleSymbol AsteriusModuleSymbol {..} =
   GHC.zString
     $ GHC.zEncodeFS
     $ GHC.mkFastStringByteString
-    $ SBS.fromShort unitId
+    $ unitId
       <> "_"
-      <> CBS.intercalate "." [SBS.fromShort mod_chunk | mod_chunk <- moduleName]
+      <> CBS.intercalate "." moduleName
 
 {-# INLINE generateWasmFunctionTypeSet #-}
 generateWasmFunctionTypeSet :: Module -> Set.Set FunctionType

--- a/asterius/test/node-compile.hs
+++ b/asterius/test/node-compile.hs
@@ -11,7 +11,7 @@ import Control.Monad.Except
 import Data.Binary (encode)
 import Data.Binary.Put
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.ByteString.Short as SBS
+import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
 import Foreign
 import GHC.Exts
@@ -98,7 +98,7 @@ shrinkModule' m@Module {..} = _shrink_funcs {-_shrink_memory <> _shrink_exports 
     _shrink_memory, _shrink_exports, _shrink_funcs :: FList.FList Module
     _shrink_memory = case memory of
       Memory {..}
-        | not (SBS.null memoryExportName) || not (null dataSegments) ->
+        | not (BS.null memoryExportName) || not (null dataSegments) ->
           pure
             m
               { memory = memory {memoryExportName = mempty, dataSegments = mempty}


### PR DESCRIPTION
Previously, we use `ShortByteString`s for symbols. We now use `FastString`s in GHC API to represent the symbols, and as a side-effect, replace the usages of `ShortByteString`s with `ByteString`s.

This belongs to a series of PRs to reduce compile-time/link-time memory usage and speed things up. Starting from using `FastString`s, we can use `Binary` in GHC API for serialization, to dedupe the symbol strings in object files, and get run-time string consing.