### PR TITLE
Use nvm for managing node installation

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -9,7 +9,7 @@ ENV \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \
   LC_CTYPE=C.UTF-8 \
-  PATH=/home/asterius/.asterius-local-install-root/bin:/home/asterius/.asterius-snapshot-install-root/bin:/home/asterius/.asterius-compiler-bin:/home/asterius/.local/bin:${PATH}
+  PATH=/home/asterius/.asterius-local-install-root/bin:/home/asterius/.asterius-snapshot-install-root/bin:/home/asterius/.asterius-compiler-bin:/home/asterius/.local/bin:/home/asterius/.nvm/bin:${PATH}
 
 RUN \
   echo 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20200406T084528Z sid main contrib non-free' > /etc/apt/sources.list && \
@@ -23,7 +23,6 @@ RUN \
     gawk \
     gcc \
     git \
-    gnupg \
     libffi-dev \
     libgmp-dev \
     libncurses-dev \
@@ -33,10 +32,6 @@ RUN \
     sudo \
     xz-utils \
     zlib1g-dev && \
-  curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_13.x sid main" > /etc/apt/sources.list.d/nodesource.list && \
-  apt update && \
-  apt install -y nodejs && \
   useradd --create-home --shell /bin/bash asterius && \
   echo "asterius ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
@@ -45,10 +40,11 @@ USER asterius
 WORKDIR /home/asterius
 
 RUN \
+  (curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash) && \
+  bash -c ". ~/.nvm/nvm.sh && nvm install 13.12.0 && ln -s \$NVM_BIN ~/.nvm/bin" && \
   mkdir -p ~/.local/bin && \
   curl -L https://github.com/commercialhaskell/stack/releases/download/v2.3.0.1/stack-2.3.0.1-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack' && \
   curl -L https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz | tar xJ -C ~/.local/bin 'cabal' && \
-  npm config set prefix ~/.local && \
   mkdir ~/.asterius
 
 COPY --chown=asterius:asterius asterius /home/asterius/.asterius/asterius
@@ -81,7 +77,6 @@ RUN \
     curl \
     g++ \
     git \
-    gnupg \
     make \
     mawk \
     python3 \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -6,7 +6,7 @@ ENV \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \
   LC_CTYPE=C.UTF-8 \
-  PATH=/home/asterius/.local/bin:${PATH}
+  PATH=/home/asterius/.local/bin:/home/asterius/.nvm/bin:${PATH}
 
 RUN \
   echo 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20200406T084528Z sid main contrib non-free' > /etc/apt/sources.list && \
@@ -21,7 +21,6 @@ RUN \
     gawk \
     gcc \
     git \
-    gnupg \
     libffi-dev \
     libgmp-dev \
     libncurses-dev \
@@ -32,10 +31,6 @@ RUN \
     sudo \
     xz-utils \
     zlib1g-dev && \
-  curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_13.x sid main" > /etc/apt/sources.list.d/nodesource.list && \
-  apt update && \
-  apt install -y nodejs && \
   apt autoremove --purge -y && \
   apt clean && \
   rm -rf -v /var/lib/apt/lists/* && \
@@ -47,6 +42,8 @@ USER asterius
 WORKDIR /home/asterius
 
 RUN \
+  (curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash) && \
+  bash -c ". ~/.nvm/nvm.sh && nvm install 13.12.0 && ln -s \$NVM_BIN ~/.nvm/bin" && \
   echo "eval \"\$(direnv hook bash)\"" >> ~/.bashrc && \
   mkdir -p ~/.local/bin && \
   curl -L https://github.com/commercialhaskell/stack/releases/download/v2.3.0.1/stack-2.3.0.1-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack' && \
@@ -54,7 +51,6 @@ RUN \
   pip3 install \
     recommonmark \
     sphinx && \
-  npm config set prefix ~/.local && \
   mkdir /tmp/asterius
 
 COPY --chown=asterius:asterius asterius /tmp/asterius/asterius


### PR DESCRIPTION
Previously we install `nodejs` from the apt repositories maintained by `nodesource`. This PR moves to use `nvm` to manage `node`. This is convenient when we'd like to quickly switch between multiple `node` versions and see whether our generated code (plus the TH runner) still functions properly. Additionally, the `node` version is pinned in the build scripts for improved reproducibility.

The docker images have added `~/.nvm/bin` as a `PATH` entry, so `node`/`npm` is available when the images are run without an interactive `bash` session. `~/.nvm/bin` is a symlink that points to the `bin` directory of the installed `node` version when the image is built. When using the image interactively later, it's possible to simply use `nvm` commands to switch `node` versions.