### PR TITLE
tweag/binaryen has moved

### DIFF
--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -13,7 +13,7 @@
 -- License     :  All rights reserved (see LICENCE file in the distribution).
 --
 -- Elaboration of Asterius types into the Binaryen AST (as defined in the
--- [binaryen package](https://github.com/tweag/binaryen)).
+-- [binaryen package](https://github.com/tweag/haskell-binaryen)).
 module Asterius.Backends.Binaryen
   ( MarshalError (..),
     marshalModule,

--- a/stack-profile.yaml
+++ b/stack-profile.yaml
@@ -8,7 +8,7 @@ build:
 
 resolver: lts-15.7
 extra-deps:
-  - https://github.com/tweag/binaryen/archive/e2eed3661781de680617425b1081a396bc50c504.tar.gz
+  - https://github.com/tweag/haskell-binaryen/archive/e2eed3661781de680617425b1081a396bc50c504.tar.gz
   - url: https://github.com/tweag/inline-js/archive/f192891283e21f8af9bb4dc07d3b36d59c658e2f.tar.gz
     subdirs:
       - inline-js-core

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 resolver: lts-15.7
 extra-deps:
-  - https://github.com/tweag/binaryen/archive/e2eed3661781de680617425b1081a396bc50c504.tar.gz
+  - https://github.com/tweag/haskell-binaryen/archive/e2eed3661781de680617425b1081a396bc50c504.tar.gz
   - url: https://github.com/tweag/inline-js/archive/f192891283e21f8af9bb4dc07d3b36d59c658e2f.tar.gz
     subdirs:
       - inline-js-core


### PR DESCRIPTION
It's new location is tweag/haskell-binaryen.