### PR TITLE
Add missing libstdc++-9-dev in the prebuilt images

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -26,6 +26,7 @@ RUN \
     libgmp-dev \
     libncurses-dev \
     libnuma-dev \
+    libstdc++-9-dev \
     make \
     sudo \
     xz-utils \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -15,20 +15,18 @@ RUN \
   apt install -y \
     automake \
     binaryen \
+    build-essential \
     curl \
     direnv \
     gawk \
-    gcc \
     git \
     libffi-dev \
     libgmp-dev \
     libncurses-dev \
     libnuma-dev \
-    make \
     openssh-client \
     python3-pip \
     sudo \
-    xz-utils \
     zlib1g-dev && \
   apt autoremove --purge -y && \
   apt clean && \


### PR DESCRIPTION
#571 introduced a hidden regression in the prebuilt images; since we no longer needed to compile C++, we removed `g++`, but `libstdc++-9-dev` has been accidentally removed as well, breaking the `binaryen` package configuration. This PR fixes the problem.