### PR TITLE
Fallback blackholing logic when updateThunk() throws

### DIFF
--- a/asterius/rts/rts.exception.mjs
+++ b/asterius/rts/rts.exception.mjs
@@ -60,12 +60,21 @@ export class ExceptionHelper {
           const p1 = Number(
             this.memory.i64Load(p + rtsConstants.offset_StgUpdateFrame_updatee)
           );
-          this.exports.updateThunk(
-            this.symbolTable.MainCapability,
-            tso,
-            p1,
-            raise_closure
-          );
+          try {
+            this.exports.updateThunk(
+              this.symbolTable.MainCapability,
+              tso,
+              p1,
+              raise_closure
+            );
+          } catch (err) {
+            console.error(`updateThunk failed with ${err}`);
+            this.memory.i64Store(p1, this.symbolTable.stg_BLACKHOLE_info);
+            this.memory.i64Store(
+              p1 + rtsConstants.offset_StgInd_indirectee,
+              raise_closure
+            );
+          }
           const size = Number(raw_layout & BigInt(0x3f));
           p += (1 + size) << 3;
           break;


### PR DESCRIPTION
Closes #580. When `updateThunk()` throws, `raiseExceptionHelper()` catches it and implements fallback blackholing logic, to allow the rest of the stack unwinding logic to move on. Compared to proper `updateThunk`, the fallback blackholing logic doesn't take the thread blocking queue of that thunk into account. This should fix the problem of "exported Haskell function's exception doesn't propagate to the `Promise` rejection".

Note that this is a mitigation of #579, not a complete fix; why `updateThunk` assertion fails in the first place will need more investigation.