### PR TITLE
Speed up the `asterius-profile` job

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -58,6 +58,7 @@ steps:
       docker build \
         --build-arg UID=$(id --user) \
         --build-arg GID=$(id --group) \
+        --build-arg jobs=8 \
         --compress \
         --file profile.Dockerfile \
         --network host \

--- a/lts-profile.sh
+++ b/lts-profile.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
-ahc-cabal v1-install -j$jobs --prefix=$ASTERIUS_LIB_DIR --package-db=clear --package-db=global --keep-going \
+ahc-cabal v1-install -j$jobs --prefix=$ASTERIUS_LIB_DIR --package-db=clear --package-db=global --ghc-option=-j$jobs \
   Cabal


### PR DESCRIPTION
This PR speeds up the `asterius-profile` job by passing the `-j` flag to `ghc` when building `Cabal`.