### PR TITLE
Re-add Asterius.Binary.Orphans import

### DIFF
--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -47,6 +47,7 @@ module Asterius.Types
   )
 where
 
+import Asterius.Binary.Orphans ()
 import Asterius.Binary.TH
 import Asterius.Types.EntitySymbol
 import Asterius.Types.SymbolMap


### PR DESCRIPTION
To fix the build failure that https://github.com/tweag/asterius/pull/595 introduced.