### PR TITLE
Remove IO from types of ByteString/JSUint8Array conversion functions

### DIFF
--- a/asterius/test/nomain/NoMain.hs
+++ b/asterius/test/nomain/NoMain.hs
@@ -10,6 +10,6 @@ import System.IO.Unsafe
 x :: JSUint8Array
 x = unsafePerformIO $ do
   love
-  byteStringToJSUint8Array "Lorem ipsum"
+  pure $ byteStringToJSUint8Array "Lorem ipsum"
 
 foreign import javascript "console.error('From node, with love')" love :: IO ()

--- a/asterius/test/teletype/teletype.hs
+++ b/asterius/test/teletype/teletype.hs
@@ -48,8 +48,8 @@ main = do
   js_arr <- js_get_arr
   js_print $ coerce $ toJSArray $ fromJSArray js_arr
   js_buf <- js_get_buf
-  hs_buf <- byteStringFromJSUint8Array js_buf
-  byteStringToJSUint8Array hs_buf >>= js_print_buf
+  let hs_buf = byteStringFromJSUint8Array js_buf
+  js_print_buf $ byteStringToJSUint8Array hs_buf
   print hs_buf
   cb1 <- makeHaskellCallback1 js_print
   js_setTimeout cb1 4096 (coerce js_str)

--- a/asterius/test/todomvc/WebAPI.hs
+++ b/asterius/test/todomvc/WebAPI.hs
@@ -65,7 +65,7 @@ localStorageGetItem k = do
       then do
         vs <- js_localStorage_getItem ks
         buf <- js_decode vs
-        r <- Just <$> byteStringFromJSUint8Array buf
+        let r = Just $ byteStringFromJSUint8Array buf
         freeJSVal (coerce vs)
         freeJSVal (coerce buf)
         pure r

--- a/docs/jsffi.md
+++ b/docs/jsffi.md
@@ -74,8 +74,8 @@ fromJSArray :: JSArray -> [JSVal]
 toJSArray :: [JSVal] -> JSArray
 fromJSString :: JSString -> String
 toJSString :: String -> JSString
-byteStringFromJSUint8Array :: JSUint8Array -> IO ByteString
-byteStringToJSUint8Array :: ByteString -> IO JSUint8Array
+byteStringFromJSUint8Array :: JSUint8Array -> ByteString
+byteStringToJSUint8Array :: ByteString -> JSUint8Array
 textFromJSString :: JSString -> Text
 textToJSString :: Text -> JSString
 jsonToJSVal :: ToJSON a => a -> JSVal

--- a/ghc-toolkit/boot-libs/asterius-prelude/src/Asterius/ByteString.hs
+++ b/ghc-toolkit/boot-libs/asterius-prelude/src/Asterius/ByteString.hs
@@ -5,6 +5,7 @@ module Asterius.ByteString
   )
 where
 
+import Asterius.Magic
 import Asterius.Types
 import Control.Exception
 import Data.ByteString.Internal
@@ -14,17 +15,22 @@ import Data.ByteString.Internal
 import Data.ByteString.Unsafe (unsafeUseAsCStringLen)
 
 {-# INLINEABLE byteStringFromJSUint8Array #-}
-byteStringFromJSUint8Array :: JSUint8Array -> IO ByteString
-byteStringFromJSUint8Array buf = do
+byteStringFromJSUint8Array :: JSUint8Array -> ByteString
+byteStringFromJSUint8Array buf = accursedUnutterablePerformIO $ do
   fp <- fromJSUint8Array buf
   len <- lengthOfJSUint8Array buf
   evaluate $ fromForeignPtr fp 0 len
 
 {-# INLINEABLE byteStringToJSUint8Array #-}
-byteStringToJSUint8Array :: ByteString -> IO JSUint8Array
-byteStringToJSUint8Array bs = unsafeUseAsCStringLen bs $ uncurry toJSUint8Array
+byteStringToJSUint8Array :: ByteString -> JSUint8Array
+byteStringToJSUint8Array bs =
+  accursedUnutterablePerformIO $ unsafeUseAsCStringLen bs $
+    uncurry
+      toJSUint8Array
 
 {-# INLINEABLE unsafeByteStringToJSUint8Array #-}
-unsafeByteStringToJSUint8Array :: ByteString -> IO JSUint8Array
+unsafeByteStringToJSUint8Array :: ByteString -> JSUint8Array
 unsafeByteStringToJSUint8Array bs =
-  unsafeUseAsCStringLen bs $ uncurry unsafeToJSUint8Array
+  accursedUnutterablePerformIO $ unsafeUseAsCStringLen bs $
+    uncurry
+      unsafeToJSUint8Array


### PR DESCRIPTION
For the convenience of the TH runner.