### PR TITLE
Use YOLO mode for TH runner

### DIFF
--- a/asterius/src/Asterius/JSRun/NonMain.hs
+++ b/asterius/src/Asterius/JSRun/NonMain.hs
@@ -56,6 +56,7 @@ distNonMain p extra_syms =
         outputDirectory = takeDirectory p,
         outputBaseName = takeBaseName p,
         tailCalls = True,
+        yolo = True,
         Asterius.Main.Task.hasMain = False,
         Asterius.Main.Task.verboseErr = True,
         extraRootSymbols = extra_syms

--- a/lts.sh
+++ b/lts.sh
@@ -240,6 +240,7 @@ ahc-cabal v1-install -j$jobs --prefix=$ASTERIUS_LIB_DIR --package-db=clear --pac
   auto \
   auto-update \
   autoexporter \
+  avers \
   avro \
   aws-cloudfront-signed-cookies \
   base-compat \
@@ -586,6 +587,7 @@ ahc-cabal v1-install -j$jobs --prefix=$ASTERIUS_LIB_DIR --package-db=clear --pac
   either-unwrap \
   elerea \
   elf \
+  eliminators \
   elm-bridge \
   elm-core-sources \
   elm2nix \
@@ -820,6 +822,7 @@ ahc-cabal v1-install -j$jobs --prefix=$ASTERIUS_LIB_DIR --package-db=clear --pac
   hostname-validate \
   hourglass \
   hourglass-orphans \
+  hpack \
   hpc-codecov \
   hreader \
   hreader-lens \
@@ -987,6 +990,7 @@ ahc-cabal v1-install -j$jobs --prefix=$ASTERIUS_LIB_DIR --package-db=clear --pac
   json-rpc-generic \
   jsonpath \
   junit-xml \
+  justified-containers \
   jwt \
   kan-extensions \
   kanji \
@@ -1447,6 +1451,7 @@ ahc-cabal v1-install -j$jobs --prefix=$ASTERIUS_LIB_DIR --package-db=clear --pac
   regex-posix \
   regex-tdfa \
   regex-with-pcre \
+  registry \
   reinterpret-cast \
   relapse \
   relational-query \
@@ -1473,6 +1478,7 @@ ahc-cabal v1-install -j$jobs --prefix=$ASTERIUS_LIB_DIR --package-db=clear --pac
   rio-orphans \
   rio-prettyprint \
   roc-id \
+  roles \
   rope-utf16-splay \
   rosezipper \
   rot13 \
@@ -1581,6 +1587,8 @@ ahc-cabal v1-install -j$jobs --prefix=$ASTERIUS_LIB_DIR --package-db=clear --pac
   simplistic-generics \
   since \
   singleton-bool \
+  singleton-nats \
+  singletons \
   siphash \
   sitemap-gen \
   size-based \


### PR DESCRIPTION
This PR flips on the YOLO mode flag for the TH runner. Combined with #600, this enables the `singletons` package to build (and potentially others as well).