### PR TITLE
Change the default rtsopts for `asterius` executables

### DIFF
--- a/.buildkite/profile.sh
+++ b/.buildkite/profile.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 cd .buildkite
 
-GHCRTS="-pa -hy -l-au" ahc-link --input-hs Setup.hs
+GHCRTS="-P -hy -l-au" ahc-link --input-hs Setup.hs
 
 mkdir reports
 mv \

--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -45,7 +45,7 @@ data-files:
 ghc-options: -Wall
 
 _exe-ghc-options: &exe-ghc-options
-  - -threaded -rtsopts "-with-rtsopts=-H256m -I0 -qg"
+  - -threaded -rtsopts "-with-rtsopts=-H512m -I0 -qg"
 
 dependencies:
   - base

--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -45,7 +45,7 @@ data-files:
 ghc-options: -Wall
 
 _exe-ghc-options: &exe-ghc-options
-  - -threaded -rtsopts "-with-rtsopts=-A64m -n2m -I0 -qg"
+  - -threaded -rtsopts "-with-rtsopts=-H64m -I0 -qg"
 
 dependencies:
   - base

--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -45,7 +45,7 @@ data-files:
 ghc-options: -Wall
 
 _exe-ghc-options: &exe-ghc-options
-  - -threaded -rtsopts "-with-rtsopts=-H128m -I0 -qg"
+  - -threaded -rtsopts "-with-rtsopts=-H256m -I0 -qg"
 
 dependencies:
   - base

--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -45,7 +45,7 @@ data-files:
 ghc-options: -Wall
 
 _exe-ghc-options: &exe-ghc-options
-  - -threaded -rtsopts "-with-rtsopts=-H1024m -I0 -qg"
+  - -threaded -rtsopts "-with-rtsopts=-H512m -I0 -qg"
 
 dependencies:
   - base

--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -45,7 +45,7 @@ data-files:
 ghc-options: -Wall
 
 _exe-ghc-options: &exe-ghc-options
-  - -threaded -rtsopts "-with-rtsopts=-H64m -I0 -qg"
+  - -threaded -rtsopts "-with-rtsopts=-H64m -c -I0 -qg"
 
 dependencies:
   - base

--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -45,7 +45,7 @@ data-files:
 ghc-options: -Wall
 
 _exe-ghc-options: &exe-ghc-options
-  - -threaded -rtsopts "-with-rtsopts=-H512m -I0 -qg"
+  - -threaded -rtsopts "-with-rtsopts=-H1024m -I0 -qg"
 
 dependencies:
   - base

--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -45,7 +45,7 @@ data-files:
 ghc-options: -Wall
 
 _exe-ghc-options: &exe-ghc-options
-  - -threaded -rtsopts "-with-rtsopts=-H64m -c -I0 -qg"
+  - -threaded -rtsopts "-with-rtsopts=-H128m -I0 -qg"
 
 dependencies:
   - base


### PR DESCRIPTION
This PR changes the default rtsopts we build/profile the `asteirus` executables. This also solves the issue of built-in "GC" cost center occupying the majority of the time usage.