### PR TITLE
Misc mblock allocator improvements

### DIFF
--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -36,7 +36,7 @@ export async function newAsteriusInstance(req) {
       initial: req.tableSlots
     }),
     __asterius_wasm_memory = new WebAssembly.Memory({
-      initial: req.staticMBlocks * (rtsConstants.mblock_size / 65536)
+      initial: Math.max(req.staticMBlocks + 2, req.gcThreshold) * (rtsConstants.mblock_size / 65536)
     }),
     __asterius_memory = new Memory(),
     __asterius_memory_trap = new MemoryTrap(


### PR DESCRIPTION
* The initial memory size is no less than `gcThreshold` or `staticMBlocks + 2`. This avoids immediate linear memory growth when initializing the heap allocator.
* When the `getMBlocks` method needs to actually grow the memory, it grows the memory and then recalls itself. We used to immediately return, using the starting point of the extended memory as the allocated space, but this may cause fragmentation (e.g. 1 free mblock left, but 2 is being allocated)
* Fixed incorrect comment in `getMBlocks`.
* The `grow` method no longer returns the previous page count since it's not used. Also, it now updates `this.capacity` as well.
* The `buffer` accessor is removed since it's barely used.