### PR TITLE
Only double the linear memory size when it's below 1024M

### DIFF
--- a/asterius/rts/rts.memory.mjs
+++ b/asterius/rts/rts.memory.mjs
@@ -234,7 +234,8 @@ export class Memory {
     // No luck, we need to grow the Wasm linear memory
     // (we actually - at least - double it, in order to reduce
     // amortized overhead of allocating individual MBlocks)
-    const d = Math.max(n, this.capacity);
+    let d = Math.max(n, this.capacity);
+    if (this.capacity + d >= 1024) d = n;
     this.grow(d * (rtsConstants.mblock_size / rtsConstants.pageSize));
 
     return this.getMBlocks(n);

--- a/asterius/src/Asterius/GHCi/Internals.hs
+++ b/asterius/src/Asterius/GHCi/Internals.hs
@@ -127,7 +127,8 @@ newGHCiJSSession = do
       defJSSessionOpts
         { nodeExtraArgs =
             [ "--experimental-wasm-return-call",
-              "--wasm-interpret-all"
+              "--wasm-interpret-all",
+              "--wasm-max-mem-pages=65536"
             ],
           nodeExtraEnv =
             [ ("ASTERIUS_NODE_READ_FD", show node_read_fd),


### PR DESCRIPTION
Following #607. This fixes the building of `singletons`.