### PR TITLE
Fix the profile job

### DIFF
--- a/profile.Dockerfile
+++ b/profile.Dockerfile
@@ -25,6 +25,7 @@ RUN \
     automake \
     binaryen \
     curl \
+    g++ \
     gawk \
     gcc \
     git \
@@ -34,6 +35,7 @@ RUN \
     libnuma-dev \
     libstdc++-9-dev \
     make \
+    python3-minimal \
     sudo \
     xz-utils \
     zlib1g-dev && \


### PR DESCRIPTION
Following #619. Recent toolchain update additionally requires `g++` and `python3` (as build-time transitive dependencies of `npm-utils`).