### PR TITLE
[WIP] NFData Instance for AsteriusModule

### DIFF
--- a/asterius/src/Asterius/NFData/TH.hs
+++ b/asterius/src/Asterius/NFData/TH.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Asterius.NFData.TH
+  ( genNFData,
+  )
+where
+
+import Control.DeepSeq
+import Data.List (foldl1')
+import Language.Haskell.TH
+
+genNFData :: Name -> Q [Dec]
+genNFData ty = do
+  TyConI dec <- reify ty
+  case dec of
+    DataD [] ((== ty) -> True) [] Nothing cons _
+      | length cons <= 0xFF ->
+        pure
+          [ InstanceD
+              Nothing
+              []
+              (AppT (ConT ''NFData) (ConT ty))
+              [ FunD
+                  'rnf
+                  [ Clause
+                      [ ConP
+                          (dataConName con)
+                          (map VarP vars)
+                      ]
+                      ( NormalB $
+                          if null vars
+                            then VarE '()
+                            else
+                              foldl1'
+                                (\acc x -> AppE (AppE (VarE 'seq) acc) x)
+                                (map (AppE (VarE 'rnf) . VarE) vars)
+                      )
+                      []
+                    | con <- cons,
+                      let vars = [mkName $ "a" <> show j | j <- [1 .. dataConFields con]]
+                  ]
+              ]
+          ]
+    _ -> fail $ "Asterius.NFData.TH.genNFData: " <> show dec
+
+dataConName :: Con -> Name
+dataConName (NormalC n _) = n
+dataConName (RecC n _) = n
+dataConName c = error $ "Asterius.NFData.TH.dataConName: " <> show c
+
+dataConFields :: Con -> Int
+dataConFields (NormalC _ fs) = length fs
+dataConFields (RecC _ fs) = length fs
+dataConFields c = error $ "Asterius.NFData.TH.dataConFields: " <> show c

--- a/asterius/src/Asterius/NFData/TH.hs
+++ b/asterius/src/Asterius/NFData/TH.hs
@@ -30,7 +30,7 @@ genNFData ty = do
                       ]
                       ( NormalB $
                           if null vars
-                            then VarE '()
+                            then ConE '()
                             else
                               foldl1'
                                 (\acc x -> AppE (AppE (VarE 'seq) acc) x)

--- a/asterius/src/Asterius/NFData/TH.hs
+++ b/asterius/src/Asterius/NFData/TH.hs
@@ -14,34 +14,33 @@ genNFData :: Name -> Q [Dec]
 genNFData ty = do
   TyConI dec <- reify ty
   case dec of
-    DataD [] ((== ty) -> True) [] Nothing cons _
-      | length cons <= 0xFF ->
-        pure
-          [ InstanceD
-              Nothing
-              []
-              (AppT (ConT ''NFData) (ConT ty))
-              [ FunD
-                  'rnf
-                  [ Clause
-                      [ ConP
-                          (dataConName con)
-                          (map VarP vars)
-                      ]
-                      ( NormalB $
-                          if null vars
-                            then ConE '()
-                            else
-                              foldl1'
-                                (\acc x -> AppE (AppE (VarE 'seq) acc) x)
-                                (map (AppE (VarE 'rnf) . VarE) vars)
-                      )
-                      []
-                    | con <- cons,
-                      let vars = [mkName $ "a" <> show j | j <- [1 .. dataConFields con]]
-                  ]
-              ]
-          ]
+    DataD [] ((== ty) -> True) [] Nothing cons _ ->
+      pure
+        [ InstanceD
+            Nothing
+            []
+            (AppT (ConT ''NFData) (ConT ty))
+            [ FunD
+                'rnf
+                [ Clause
+                    [ ConP
+                        (dataConName con)
+                        (map VarP vars)
+                    ]
+                    ( NormalB $
+                        if null vars
+                          then ConE '()
+                          else
+                            foldl1'
+                              (\acc x -> AppE (AppE (VarE 'seq) acc) x)
+                              (map (AppE (VarE 'rnf) . VarE) vars)
+                    )
+                    []
+                  | con <- cons,
+                    let vars = [mkName $ "a" <> show j | j <- [1 .. dataConFields con]]
+                ]
+            ]
+        ]
     _ -> fail $ "Asterius.NFData.TH.genNFData: " <> show dec
 
 dataConName :: Con -> Name

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -110,25 +110,24 @@ linkStart ::
   [EntitySymbol] ->
   (AsteriusModule, Module, LinkReport)
 linkStart debug gc_sections verbose_err store root_syms export_funcs =
-  rnf merged_m
-    `seq` ( merged_m,
-            result_m,
-            mempty
-              { staticsSymbolMap = ss_sym_map,
-                functionSymbolMap = func_sym_map,
-                infoTableSet = makeInfoTableSet merged_m ss_sym_map,
-                Asterius.Types.LinkReport.tableSlots = tbl_slots,
-                staticMBlocks = static_mbs,
-                sptEntries = sptMap merged_m,
-                bundledFFIMarshalState = bundled_ffi_state
-              }
-          )
+  ( merged_m,
+    result_m,
+    mempty
+      { staticsSymbolMap = ss_sym_map,
+        functionSymbolMap = func_sym_map,
+        infoTableSet = makeInfoTableSet merged_m ss_sym_map,
+        Asterius.Types.LinkReport.tableSlots = tbl_slots,
+        staticMBlocks = static_mbs,
+        sptEntries = sptMap merged_m,
+        bundledFFIMarshalState = bundled_ffi_state
+      }
+  )
   where
     merged_m0
       | gc_sections = gcSections verbose_err store root_syms export_funcs
       | otherwise = fromCachedModule store
     merged_m1
-      | debug = addMemoryTrap merged_m0
+      | merged_m0 `deepseq` debug = addMemoryTrap merged_m0
       | otherwise = merged_m0
     !merged_m
       | verbose_err = merged_m1

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -126,9 +126,10 @@ linkStart debug gc_sections verbose_err store root_syms export_funcs =
     merged_m0
       | gc_sections = gcSections verbose_err store root_syms export_funcs
       | otherwise = fromCachedModule store
+    !merged_m0_evaluated = force merged_m0
     merged_m1
-      | merged_m0 `deepseq` debug = addMemoryTrap merged_m0
-      | otherwise = merged_m0
+      | debug = addMemoryTrap merged_m0_evaluated
+      | otherwise = merged_m0_evaluated
     !merged_m
       | verbose_err = merged_m1
       | otherwise =

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StrictData #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Asterius.Resolve
   ( unresolvedGlobalRegType,
@@ -22,6 +23,7 @@ import Asterius.Types
 import qualified Asterius.Types.SymbolMap as SM
 import qualified Asterius.Types.SymbolSet as SS
 import Asterius.Types.LinkReport
+import Control.DeepSeq
 import qualified Data.ByteString as BS
 import qualified Data.Map.Lazy as LM
 import Foreign
@@ -108,18 +110,19 @@ linkStart ::
   [EntitySymbol] ->
   (AsteriusModule, Module, LinkReport)
 linkStart debug gc_sections verbose_err store root_syms export_funcs =
-  ( merged_m,
-    result_m,
-    mempty
-      { staticsSymbolMap = ss_sym_map,
-        functionSymbolMap = func_sym_map,
-        infoTableSet = makeInfoTableSet merged_m ss_sym_map,
-        Asterius.Types.LinkReport.tableSlots = tbl_slots,
-        staticMBlocks = static_mbs,
-        sptEntries = sptMap merged_m,
-        bundledFFIMarshalState = bundled_ffi_state
-      }
-  )
+  rnf merged_m
+    `seq` ( merged_m,
+            result_m,
+            mempty
+              { staticsSymbolMap = ss_sym_map,
+                functionSymbolMap = func_sym_map,
+                infoTableSet = makeInfoTableSet merged_m ss_sym_map,
+                Asterius.Types.LinkReport.tableSlots = tbl_slots,
+                staticMBlocks = static_mbs,
+                sptEntries = sptMap merged_m,
+                bundledFFIMarshalState = bundled_ffi_state
+              }
+          )
   where
     merged_m0
       | gc_sections = gcSections verbose_err store root_syms export_funcs

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -53,11 +53,13 @@ where
 
 import Asterius.Binary.Orphans ()
 import Asterius.Binary.TH
+import Asterius.NFData.TH
 import Asterius.Types.EntitySymbol
 import Asterius.Types.SymbolMap (SymbolMap)
 import qualified Asterius.Types.SymbolMap as SM
 import Asterius.Types.SymbolSet (SymbolSet)
 import qualified Asterius.Types.SymbolSet as SS
+import Control.DeepSeq
 import Control.Exception
 import qualified Data.ByteString as BS
 import Data.Data
@@ -608,6 +610,74 @@ instance Semigroup FFIMarshalState where
 
 instance Monoid FFIMarshalState where
   mempty = FFIMarshalState {ffiImportDecls = mempty, ffiExportDecls = mempty}
+
+-- NFData instances
+
+$(genNFData ''AsteriusCodeGenError)
+
+$(genNFData ''AsteriusStatic)
+
+$(genNFData ''AsteriusStaticsType)
+
+$(genNFData ''AsteriusStatics)
+
+$(genNFData ''AsteriusModule)
+
+$(genNFData ''AsteriusCachedModule)
+
+$(genNFData ''UnresolvedLocalReg)
+
+$(genNFData ''UnresolvedGlobalReg)
+
+$(genNFData ''ValueType)
+
+$(genNFData ''FunctionType)
+
+$(genNFData ''UnaryOp)
+
+$(genNFData ''BinaryOp)
+
+$(genNFData ''Expression)
+
+$(genNFData ''Function)
+
+$(genNFData ''FunctionImport)
+
+$(genNFData ''TableImport)
+
+$(genNFData ''MemoryImport)
+
+$(genNFData ''FunctionExport)
+
+$(genNFData ''FunctionTable)
+
+$(genNFData ''DataSegment)
+
+$(genNFData ''Module)
+
+$(genNFData ''RelooperAddBlock)
+
+$(genNFData ''RelooperAddBranch)
+
+$(genNFData ''RelooperBlock)
+
+$(genNFData ''RelooperRun)
+
+$(genNFData ''FFIValueTypeRep)
+
+$(genNFData ''FFIValueType)
+
+$(genNFData ''FFIFunctionType)
+
+$(genNFData ''FFISafety)
+
+$(genNFData ''FFIImportDecl)
+
+$(genNFData ''FFIExportDecl)
+
+$(genNFData ''FFIMarshalState)
+
+-- Binary instances
 
 $(genBinary ''AsteriusCodeGenError)
 

--- a/asterius/src/Asterius/Types/EntitySymbol.hs
+++ b/asterius/src/Asterius/Types/EntitySymbol.hs
@@ -11,6 +11,7 @@ module Asterius.Types.EntitySymbol
 where
 
 import qualified Binary as GHC
+import Control.DeepSeq
 import qualified Data.ByteString as BS
 import Data.Data
 import Data.String
@@ -20,6 +21,11 @@ import qualified Unique as GHC
 newtype EntitySymbol = EntitySymbol GHC.FastString
   deriving newtype (Eq, Ord, Show, IsString, Semigroup, Monoid, GHC.Binary, GHC.Uniquable)
   deriving stock (Data)
+
+instance NFData EntitySymbol where
+  rnf = rwhnf -- TODO: Not entirely sure about this. In any case, we cannot
+              -- GNDerive the instance because FastString is neither an
+              -- instance of Generic nor an instance of NFData.
 
 -- | Convert an 'EntitySymbol' to a 'BS.ByteString'.
 {-# INLINE entityName #-}

--- a/asterius/src/Asterius/Types/EntitySymbol.hs
+++ b/asterius/src/Asterius/Types/EntitySymbol.hs
@@ -23,9 +23,7 @@ newtype EntitySymbol = EntitySymbol GHC.FastString
   deriving stock (Data)
 
 instance NFData EntitySymbol where
-  rnf = rwhnf -- TODO: Not entirely sure about this. In any case, we cannot
-              -- GNDerive the instance because FastString is neither an
-              -- instance of Generic nor an instance of NFData.
+  rnf = rwhnf -- TODO: Not entirely sure about this.
 
 -- | Convert an 'EntitySymbol' to a 'BS.ByteString'.
 {-# INLINE entityName #-}

--- a/asterius/src/Asterius/Types/EntitySymbol.hs
+++ b/asterius/src/Asterius/Types/EntitySymbol.hs
@@ -23,7 +23,7 @@ newtype EntitySymbol = EntitySymbol GHC.FastString
   deriving stock (Data)
 
 instance NFData EntitySymbol where
-  rnf = rwhnf -- TODO: Not entirely sure about this.
+  rnf = rwhnf
 
 -- | Convert an 'EntitySymbol' to a 'BS.ByteString'.
 {-# INLINE entityName #-}

--- a/asterius/src/Asterius/Types/SymbolMap.hs
+++ b/asterius/src/Asterius/Types/SymbolMap.hs
@@ -73,11 +73,8 @@ import Prelude hiding (filter, lookup)
 
 -- | A map from 'EntitySymbol's to values @a@.
 newtype SymbolMap a = SymbolMap (IM.IntMap (EntitySymbol, a))
-  deriving newtype (Eq, Semigroup, Monoid)
+  deriving newtype (Eq, Semigroup, Monoid, NFData)
   deriving stock (Data)
-
-instance NFData a => NFData (SymbolMap a) where
-  rnf (SymbolMap m) = rnf m
 
 instance Show a => Show (SymbolMap a) where
   showsPrec d m =

--- a/asterius/src/Asterius/Types/SymbolMap.hs
+++ b/asterius/src/Asterius/Types/SymbolMap.hs
@@ -77,7 +77,7 @@ newtype SymbolMap a = SymbolMap (IM.IntMap (EntitySymbol, a))
   deriving stock (Data)
 
 instance NFData a => NFData (SymbolMap a) where
-  rnf = rwhnf -- TODO: IntMap is an instance of NFData, but not of Generic.
+  rnf = rwhnf
 
 instance Show a => Show (SymbolMap a) where
   showsPrec d m =

--- a/asterius/src/Asterius/Types/SymbolMap.hs
+++ b/asterius/src/Asterius/Types/SymbolMap.hs
@@ -62,6 +62,7 @@ where
 import Asterius.Types.EntitySymbol
 import qualified Asterius.Types.SymbolSet as SS
 import Binary
+import Control.DeepSeq
 import Control.Monad
 import Data.Data
 import qualified Data.IntMap.Lazy as IM
@@ -74,6 +75,9 @@ import Prelude hiding (filter, lookup)
 newtype SymbolMap a = SymbolMap (IM.IntMap (EntitySymbol, a))
   deriving newtype (Eq, Semigroup, Monoid)
   deriving stock (Data)
+
+instance NFData a => NFData (SymbolMap a) where
+  rnf = rwhnf -- TODO: IntMap is an instance of NFData, but not of Generic.
 
 instance Show a => Show (SymbolMap a) where
   showsPrec d m =

--- a/asterius/src/Asterius/Types/SymbolMap.hs
+++ b/asterius/src/Asterius/Types/SymbolMap.hs
@@ -77,7 +77,7 @@ newtype SymbolMap a = SymbolMap (IM.IntMap (EntitySymbol, a))
   deriving stock (Data)
 
 instance NFData a => NFData (SymbolMap a) where
-  rnf = rwhnf
+  rnf (SymbolMap m) = rnf m
 
 instance Show a => Show (SymbolMap a) where
   showsPrec d m =

--- a/asterius/src/Asterius/Types/SymbolSet.hs
+++ b/asterius/src/Asterius/Types/SymbolSet.hs
@@ -69,7 +69,7 @@ instance Show SymbolSet where
       showString "fromList " . shows (toList s)
 
 instance NFData SymbolSet where
-  rnf = rwhnf
+  rnf (SymbolSet s) = rnf s
 
 instance Binary SymbolSet where
   put_ bh s =

--- a/asterius/src/Asterius/Types/SymbolSet.hs
+++ b/asterius/src/Asterius/Types/SymbolSet.hs
@@ -48,6 +48,7 @@ where
 
 import Asterius.Types.EntitySymbol
 import Binary
+import Control.DeepSeq
 import Control.Monad
 import Data.Coerce
 import Data.Data
@@ -66,6 +67,9 @@ instance Show SymbolSet where
   showsPrec p (SymbolSet s) =
     showParen (p > 10) $
       showString "fromList " . shows (toList s)
+
+instance NFData SymbolSet where
+  rnf = rwhnf -- TODO: IntMap is an instance of NFData, but not of Generic.
 
 instance Binary SymbolSet where
   put_ bh s =

--- a/asterius/src/Asterius/Types/SymbolSet.hs
+++ b/asterius/src/Asterius/Types/SymbolSet.hs
@@ -69,7 +69,7 @@ instance Show SymbolSet where
       showString "fromList " . shows (toList s)
 
 instance NFData SymbolSet where
-  rnf = rwhnf -- TODO: IntMap is an instance of NFData, but not of Generic.
+  rnf = rwhnf
 
 instance Binary SymbolSet where
   put_ bh s =

--- a/asterius/src/Asterius/Types/SymbolSet.hs
+++ b/asterius/src/Asterius/Types/SymbolSet.hs
@@ -60,16 +60,13 @@ import Prelude hiding (null)
 
 -- | A set of 'EntitySymbol's.
 newtype SymbolSet = SymbolSet (IM.IntMap EntitySymbol)
-  deriving newtype (Eq, Semigroup, Monoid)
+  deriving newtype (Eq, Semigroup, Monoid, NFData)
   deriving stock (Data)
 
 instance Show SymbolSet where
   showsPrec p (SymbolSet s) =
     showParen (p > 10) $
       showString "fromList " . shows (toList s)
-
-instance NFData SymbolSet where
-  rnf (SymbolSet s) = rnf s
 
 instance Binary SymbolSet where
   put_ bh s =


### PR DESCRIPTION
* Add `NFData` instances for most datatypes in `Asterius.Types`, and
* Utilize the new `NFData` instances to fully evaluate the shrinked `AsteriusModule` produced by `Asterius.Resolve.linkStart`.

After this PR is merged, we should be able to do a little better, by parallelizing `AsteriusModule`s evaluation (see https://github.com/tweag/asterius/issues/621).