### PR TITLE
Allow linking executables with -threaded

### DIFF
--- a/asterius/app/ahc-ld.hs
+++ b/asterius/app/ahc-ld.hs
@@ -27,13 +27,11 @@ parseLinkTask args = do
         outputIR =
           find ("--output-ir=" `isPrefixOf`) args
             >>= stripPrefix "--output-ir=",
-        rootSymbols =
-          map fromString $
-            str_args "--extra-root-symbol=",
+        rootSymbols = map fromString $ str_args "--extra-root-symbol=",
         exportFunctions =
-          ("main" :)
-            $ map fromString
-            $ str_args "--export-function="
+          ("main" :) $ map fromString $
+            str_args
+              "--export-function="
       }
   where
     prog_name
@@ -47,8 +45,11 @@ parseLinkTask args = do
     link_output = args !! succ output_i
     Just output_i = elemIndex "-o" args
     link_objs = filter ((== "o.") . take 2 . reverse) args
+    fix_libhsrts "libHSrts_thr.a" = "libHSrts.a"
+    fix_libhsrts lib = lib
     link_libnames =
-      map ((<> ".a") . ("lib" <>) . drop 2) $ filter ((== "-l") . take 2) args
+      map (fix_libhsrts . (<> ".a") . ("lib" <>) . drop 2) $
+        filter ((== "-l") . take 2) args
     link_libdirs = map (drop 2) $ filter ((== "-L") . take 2) args
     str_args arg_prefix = mapMaybe (stripPrefix arg_prefix) args
 


### PR DESCRIPTION
Closes #623.

This PR allows `-threaded` to be added to `ghc-options` of executable targets. Since we don't have a threaded flavor of the runtime, the flag is a no-op at link-time.