### PR TITLE
Enforce eager blackholing in rts

### DIFF
--- a/asterius/rts/rts.exception.mjs
+++ b/asterius/rts/rts.exception.mjs
@@ -60,21 +60,12 @@ export class ExceptionHelper {
           const p1 = Number(
             this.memory.i64Load(p + rtsConstants.offset_StgUpdateFrame_updatee)
           );
-          try {
-            this.exports.updateThunk(
-              this.symbolTable.MainCapability,
-              tso,
-              p1,
-              raise_closure
-            );
-          } catch (err) {
-            console.error(`updateThunk failed with ${err}`);
-            this.memory.i64Store(p1, this.symbolTable.stg_BLACKHOLE_info);
-            this.memory.i64Store(
-              p1 + rtsConstants.offset_StgInd_indirectee,
-              raise_closure
-            );
-          }
+          this.exports.updateThunk(
+            this.symbolTable.MainCapability,
+            tso,
+            p1,
+            raise_closure
+          );
           const size = Number(raw_layout & BigInt(0x3f));
           p += (1 + size) << 3;
           break;

--- a/asterius/src/Asterius/Boot.hs
+++ b/asterius/src/Asterius/Boot.hs
@@ -114,6 +114,7 @@ bootRTSCmm BootArgs {..} =
           { ghcFlags =
               [ "-this-unit-id",
                 "rts",
+                "-feager-blackholing",
                 "-dcmm-lint",
                 "-O2",
                 "-DASTERIUS",

--- a/ghc-toolkit/boot-libs/rts/StgStdThunks.cmm
+++ b/ghc-toolkit/boot-libs/rts/StgStdThunks.cmm
@@ -73,7 +73,7 @@
       UPD_BH_UPDATABLE(node);                                           \
       LDV_ENTER(node);                                                  \
       selectee = StgThunk_payload(node,0);                              \
-      push (UPDATE_FRAME_FIELDS(,,stg_upd_frame_info,CCCS,0,node)) {    \
+      push (UPDATE_FRAME_FIELDS(,,stg_marked_upd_frame_info,CCCS,0,node)) {    \
         ENTER_CCS_THUNK(node);                                          \
         if (NEED_EVAL(selectee)) {                                      \
           SAVE_CCS;                                                     \
@@ -173,7 +173,7 @@ INFO_TABLE(stg_ap_1_upd,1,0,THUNK_1_0,"stg_ap_1_upd_info","stg_ap_1_upd_info")
     STK_CHK_NP(node);
     UPD_BH_UPDATABLE(node);
     LDV_ENTER(node);
-    push (UPDATE_FRAME_FIELDS(,,stg_upd_frame_info, CCCS, 0, node)) {
+    push (UPDATE_FRAME_FIELDS(,,stg_marked_upd_frame_info, CCCS, 0, node)) {
         ENTER_CCS_THUNK(node);
         jump stg_ap_0_fast
             (StgThunk_payload(node,0));
@@ -187,7 +187,7 @@ INFO_TABLE(stg_ap_2_upd,2,0,THUNK_2_0,"stg_ap_2_upd_info","stg_ap_2_upd_info")
     STK_CHK_NP(node);
     UPD_BH_UPDATABLE(node);
     LDV_ENTER(node);
-    push (UPDATE_FRAME_FIELDS(,,stg_upd_frame_info, CCCS, 0, node)) {
+    push (UPDATE_FRAME_FIELDS(,,stg_marked_upd_frame_info, CCCS, 0, node)) {
         ENTER_CCS_THUNK(node);
         jump stg_ap_p_fast
             (StgThunk_payload(node,0),
@@ -202,7 +202,7 @@ INFO_TABLE(stg_ap_3_upd,3,0,THUNK,"stg_ap_3_upd_info","stg_ap_3_upd_info")
     STK_CHK_NP(node);
     UPD_BH_UPDATABLE(node);
     LDV_ENTER(node);
-    push (UPDATE_FRAME_FIELDS(,,stg_upd_frame_info, CCCS, 0, node)) {
+    push (UPDATE_FRAME_FIELDS(,,stg_marked_upd_frame_info, CCCS, 0, node)) {
         ENTER_CCS_THUNK(node);
         jump stg_ap_pp_fast
             (StgThunk_payload(node,0),
@@ -218,7 +218,7 @@ INFO_TABLE(stg_ap_4_upd,4,0,THUNK,"stg_ap_4_upd_info","stg_ap_4_upd_info")
     STK_CHK_NP(node);
     UPD_BH_UPDATABLE(node);
     LDV_ENTER(node);
-    push (UPDATE_FRAME_FIELDS(,,stg_upd_frame_info, CCCS, 0, node)) {
+    push (UPDATE_FRAME_FIELDS(,,stg_marked_upd_frame_info, CCCS, 0, node)) {
         ENTER_CCS_THUNK(node);
         jump stg_ap_ppp_fast
             (StgThunk_payload(node,0),
@@ -235,7 +235,7 @@ INFO_TABLE(stg_ap_5_upd,5,0,THUNK,"stg_ap_5_upd_info","stg_ap_5_upd_info")
     STK_CHK_NP(node);
     UPD_BH_UPDATABLE(node);
     LDV_ENTER(node);
-    push (UPDATE_FRAME_FIELDS(,,stg_upd_frame_info, CCCS, 0, node)) {
+    push (UPDATE_FRAME_FIELDS(,,stg_marked_upd_frame_info, CCCS, 0, node)) {
         ENTER_CCS_THUNK(node);
         jump stg_ap_pppp_fast
             (StgThunk_payload(node,0),
@@ -253,7 +253,7 @@ INFO_TABLE(stg_ap_6_upd,6,0,THUNK,"stg_ap_6_upd_info","stg_ap_6_upd_info")
     STK_CHK_NP(node);
     UPD_BH_UPDATABLE(node);
     LDV_ENTER(node);
-    push (UPDATE_FRAME_FIELDS(,,stg_upd_frame_info, CCCS, 0, node)) {
+    push (UPDATE_FRAME_FIELDS(,,stg_marked_upd_frame_info, CCCS, 0, node)) {
         ENTER_CCS_THUNK(node);
         jump stg_ap_ppppp_fast
             (StgThunk_payload(node,0),
@@ -272,7 +272,7 @@ INFO_TABLE(stg_ap_7_upd,7,0,THUNK,"stg_ap_7_upd_info","stg_ap_7_upd_info")
     STK_CHK_NP(node);
     UPD_BH_UPDATABLE(node);
     LDV_ENTER(node);
-    push (UPDATE_FRAME_FIELDS(,,stg_upd_frame_info, CCCS, 0, node)) {
+    push (UPDATE_FRAME_FIELDS(,,stg_marked_upd_frame_info, CCCS, 0, node)) {
       ENTER_CCS_THUNK(node);
       jump stg_ap_pppppp_fast
           (StgThunk_payload(node,0),


### PR DESCRIPTION
Closes #627, #579. We also revert the workaround in #581 since it's no longer needed.