### PR TITLE
Remove legacy documentation about hs_init

### DIFF
--- a/docs/ahc-link.md
+++ b/docs/ahc-link.md
@@ -56,7 +56,6 @@ import req from "./xxx.req.mjs";
 module
   .then(m => rts.newAsteriusInstance(Object.assign(req, { module: m })))
   .then(i => {
-    i.exports.hs_init();
     i.exports.main();
   });
 ```

--- a/docs/jsffi.md
+++ b/docs/jsffi.md
@@ -169,7 +169,6 @@ In JavaScript, after `newAsteriusInstance()` returns the Asterius instance
 object, one can access the exported functions in the `exports` field:
 
 ```javascript
-i.exports.hs_init();
 const r = await i.exports.mult_hs(6, 7);
 ```
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -4,7 +4,7 @@ Asterius compiles Haskell code to [WebAssembly](https://webassembly.org/)
 (Wasm). Its frontend is based on [GHC](https://www.haskell.org/ghc/).
 
 The Asterius pipeline provides everything to create a Wasm instance which
-exports two functions (``hs_init`` and ``main``) that can be called from
+exports the foreign exported functions (e.g. `main`) that can be called from
 JavaScript to execute the main Haskell program.
 
 ## Asterius pipeline

--- a/docs/rts-api.md
+++ b/docs/rts-api.md
@@ -42,7 +42,6 @@ result. Assuming we're passing `--asterius-instance-callback=i=>{ ... }` to
 `ahc-link`, in the callback body, we can use RTS API like this:
 
 ```JavaScript
-i.exports.hs_init();
 const argument = i.exports.rts_mkInt(5);
 const thunk = i.exports.rts_apply(i.staticsSymbolMap.Main_fact_closure, argument);
 const tid = i.exports.rts_eval(thunk);
@@ -50,8 +49,6 @@ console.log(i.exports.rts_getInt(i.exports.getTSOret(tid)));
 ```
 
 A line-by-line explanation follows:
-
-* As usual, the first step is calling `hs_init` to initialize the runtime.
 
 * Assuming we'd like to calculate `fact 5`, we need to build an `Int` object
   which value is `5`. We can't directly pass the JavaScript `5`, instead we


### PR DESCRIPTION
Since #524 we simplified our RTS API by automatically calling `hs_init()` when the asterius instance object is initialized. Users should not call `hs_init()` in their own code; calling it twice results in undefined behavior. This PR corrects the relevant documentation.