### PR TITLE
Fix `getArgs` support for node

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -61,3 +61,5 @@ stack --no-terminal test asterius:nomain --test-arguments="--tail-calls"
 stack --no-terminal test asterius:th
 
 stack --no-terminal test asterius:primitive
+
+stack --no-terminal test asterius:argv

--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -36,6 +36,7 @@ extra-source-files:
   - test/nodeio/**/*.hs
   - test/time/**/*.hs
   - test/primitive/**/*.hs
+  - test/argv/**/*.hs
 
 data-files:
   - rts/**/*.mjs
@@ -318,6 +319,13 @@ tests:
   primitive:
     source-dirs: test
     main: primitive.hs
+    ghc-options: *exe-ghc-options
+    dependencies:
+      - asterius
+
+  argv:
+    source-dirs: test
+    main: argv.hs
     ghc-options: *exe-ghc-options
     dependencies:
       - asterius

--- a/asterius/rts/browser/default.mjs
+++ b/asterius/rts/browser/default.mjs
@@ -7,9 +7,8 @@ class Posix {
     this.memory = memory;
     Object.seal(this);
   }
-  getProgArgv(argc, argv) {
-    this.memory.i64Store(argc, 0);
-    this.memory.i64Store(argv, 0);
+  getProgArgv(argc, argv_buf) {
+    this.memory.i64Store(argc, 1);
   }
   get_errno() {
     throw WebAssembly.RuntimeError("Unsupported rts interface: get_errno");

--- a/asterius/rts/browser/default.mjs
+++ b/asterius/rts/browser/default.mjs
@@ -3,6 +3,14 @@
  */
 
 class Posix {
+  constructor(memory, rtsConstants) {
+    this.memory = memory;
+    Object.seal(this);
+  }
+  getProgArgv(argc, argv) {
+    this.memory.i64Store(argc, 0);
+    this.memory.i64Store(argv, 0);
+  }
   get_errno() {
     throw WebAssembly.RuntimeError("Unsupported rts interface: get_errno");
   }

--- a/asterius/rts/node/default.mjs
+++ b/asterius/rts/node/default.mjs
@@ -13,6 +13,10 @@ class Posix {
     this.errno = 0;
     Object.seal(this);
   }
+  getProgArgv(argc, argv) {
+    this.memory.i64Store(argc, 0);
+    this.memory.i64Store(argv, 0);
+  }
   get_errno() {
     return this.errno;
   }

--- a/asterius/rts/node/default.mjs
+++ b/asterius/rts/node/default.mjs
@@ -19,7 +19,11 @@ class Posix {
       argv_header_size = (1 + arg_bufs.length) * 8,
       argv_total_size =
         argv_header_size +
-        arg_bufs.reduce((acc, buf) => acc + buf.byteLength + 1, 0);
+        // All strings are \0-terminated, hence the +1
+        arg_bufs.reduce((acc, buf) => acc + buf.byteLength + 1, 0); 
+    // The total size (in bytes) of the runtime arguments cannot exceed the 1KB
+    // size of the data segment we have reserved. If you wish to change this
+    // number, you should also update envArgvBuf in Asterius.Builtins.Env.
     if (argv_total_size > 1024) {
       throw new WebAssembly.RuntimeError(
         `getProgArgv: exceeding buffer size for ${process.argv}`

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -19,6 +19,7 @@ where
 
 import Asterius.Builtins.Blackhole
 import Asterius.Builtins.CMath
+import Asterius.Builtins.Env
 import Asterius.Builtins.Exports
 import Asterius.Builtins.Hashable
 import Asterius.Builtins.MD5
@@ -101,12 +102,6 @@ rtsAsteriusModule opts =
                     ]
                 }
             ),
-            ( "prog_argv",
-              AsteriusStatics
-                { staticsType = ConstBytes,
-                  asteriusStatics = [SymbolStatic "prog_name" 0]
-                }
-            ),
             ( "__asterius_localeEncoding",
               AsteriusStatics
                 { staticsType = ConstBytes,
@@ -162,7 +157,6 @@ rtsAsteriusModule opts =
     <> tryWakeupThreadFunction opts
     <> raiseExceptionHelperFunction opts
     <> barfFunction opts
-    <> getProgArgvFunction opts
     <> suspendThreadFunction opts
     <> scheduleThreadFunction opts
     <> scheduleThreadOnFunction opts
@@ -190,6 +184,7 @@ rtsAsteriusModule opts =
     <> cmathCBits
     <> hashableCBits
     <> md5CBits
+    <> envCBits
     <> posixCBits
     <> sptCBits
     <> stgPrimFloatCBits
@@ -618,6 +613,7 @@ rtsFunctionImports debug =
       )
     <> schedulerImports
     <> exportsImports
+    <> envImports
     <> posixImports
     <> sptImports
     <> timeImports
@@ -1400,12 +1396,6 @@ unicodeCBits =
       ("u_iswcntrl", [I64], [I64]),
       ("u_iswprint", [I64], [I64])
     ]
-
-getProgArgvFunction :: BuiltinsOptions -> AsteriusModule
-getProgArgvFunction _ = runEDSL "getProgArgv" $ do
-  [argc, argv] <- params [I64, I64]
-  storeI64 argc 0 $ constI64 1
-  storeI64 argv 0 $ symbol "prog_argv"
 
 suspendThreadFunction :: BuiltinsOptions -> AsteriusModule
 suspendThreadFunction _ = runEDSL "suspendThread" $ do

--- a/asterius/src/Asterius/Builtins/Env.hs
+++ b/asterius/src/Asterius/Builtins/Env.hs
@@ -28,6 +28,11 @@ envImports =
 envCBits :: AsteriusModule
 envCBits = envArgvBuf <> envGetProgArgv
 
+-- | Data segment used to store runtime arguments. In normal native programs,
+-- the arguments passed to a program @argv@ exist in special memory pages and are
+-- managed by the OS kernel. Since we cannot do this here, we instead reserve a
+-- data segment of 1KB of memory to be used for this purpose (see @getProgArgv@ in
+-- @rts/node/default.mjs@).
 envArgvBuf :: AsteriusModule
 envArgvBuf =
   mempty

--- a/asterius/src/Asterius/Builtins/Env.hs
+++ b/asterius/src/Asterius/Builtins/Env.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Asterius.Builtins.Env
+  ( envImports,
+    envCBits,
+  )
+where
+
+import Asterius.EDSL
+import Asterius.Types
+
+envImports :: [FunctionImport]
+envImports =
+  [ FunctionImport
+      { internalName = "__asterius_getProgArgv",
+        externalModuleName = "posix",
+        externalBaseName = "getProgArgv",
+        functionType =
+          FunctionType
+            { paramTypes = [F64, F64],
+              returnTypes = []
+            }
+      }
+  ]
+
+envCBits :: AsteriusModule
+envCBits = envGetProgArgv
+
+envGetProgArgv :: AsteriusModule
+envGetProgArgv = runEDSL "getProgArgv" $ do
+  args <- params [I64, I64]
+  callImport "__asterius_getProgArgv" $ map convertUInt64ToFloat64 args

--- a/asterius/test/argv.hs
+++ b/asterius/test/argv.hs
@@ -1,0 +1,11 @@
+import System.Environment
+import System.Directory
+import System.Process
+
+main :: IO ()
+main = do
+  args <- getArgs
+  callProcess "ahc-link" $ ["--input-hs", "test/argv/argv.hs"] <> args
+  withCurrentDirectory "test/argv" $ do
+    callProcess "node" ["argv.mjs", "extra", "flags"]
+

--- a/asterius/test/argv/argv.hs
+++ b/asterius/test/argv/argv.hs
@@ -1,0 +1,11 @@
+import Asterius.Types
+import Data.Coerce
+import System.Environment
+
+foreign import javascript "console.log($1)" js_print :: JSVal -> IO ()
+
+js_print_string :: String -> IO ()
+js_print_string s = js_print (coerce (toJSString s))
+
+main :: IO ()
+main = getArgs >>= print  -- expected output: ["extra","flags"]

--- a/asterius/test/argv/argv.hs
+++ b/asterius/test/argv/argv.hs
@@ -1,11 +1,4 @@
-import Asterius.Types
-import Data.Coerce
 import System.Environment
-
-foreign import javascript "console.log($1)" js_print :: JSVal -> IO ()
-
-js_print_string :: String -> IO ()
-js_print_string s = js_print (coerce (toJSString s))
 
 main :: IO ()
 main = getArgs >>= print  -- expected output: ["extra","flags"]


### PR DESCRIPTION
Closes #634.

This PR fixes `getArgs` for `node`. Say we compile `test.hs` and run `node test.mjs extra flags`, `getArgs` will properly return `["extra", "flags"]`.

The current implementation is just enough to support #640. Limitations compared to native `getArgs`:

* No support for `setProgArgv`.
* Total size of arguments must not exceed 1024 bytes.
* No handling for `+RTS ...` flags. See https://gitlab.haskell.org/ghc/ghc/-/blob/ghc-8.8/rts/RtsFlags.c#L612 for complete logic to handle them, which IMO is an unnecessary complexity to add for now.
* No support for `getFullArgs`.