### PR TITLE
Omit V8 bounds checks & stack checks when running TH splices

### DIFF
--- a/asterius/src/Asterius/GHCi/Internals.hs
+++ b/asterius/src/Asterius/GHCi/Internals.hs
@@ -127,6 +127,8 @@ newGHCiJSSession = do
       defJSSessionOpts
         { nodeExtraArgs =
             [ "--experimental-wasm-return-call",
+              "--no-wasm-bounds-checks",
+              "--no-wasm-stack-checks",
               "--wasm-lazy-compilation",
               "--wasm-lazy-validation",
               "--wasm-max-mem-pages=65536"


### PR DESCRIPTION
Following #633, another V8 runtime option tuning for TH splices that result in minor overall speedups.