### PR TITLE
Remove asterius-profile from regular CI jobs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,28 +50,3 @@ steps:
         terrorjack/asterius:dev-200517 \
         .buildkite/ghc-testsuite.sh
       buildkite-agent artifact upload test-report.csv
-
-  - key: "asterius-profile"
-    label: "asterius-profile"
-    command: |
-      docker pull debian:sid
-      docker build \
-        --build-arg UID=$(id --user) \
-        --build-arg GID=$(id --group) \
-        --build-arg jobs=8 \
-        --compress \
-        --file profile.Dockerfile \
-        --network host \
-        --no-cache \
-        --tag asterius:profile \
-        .
-      docker run \
-        --env UID=$(id --user) \
-        --env GID=$(id --group) \
-        --rm \
-        --volume $(pwd):/asterius \
-        --workdir /asterius \
-        asterius:profile \
-        .buildkite/profile.sh
-      docker rmi asterius:profile
-      buildkite-agent artifact upload ".buildkite/reports/*"


### PR DESCRIPTION
This PR removes `asterius-profile` from regular CI jobs. The profile job will be migrated to a standalone branch to be run on buildkite or github actions.