### PR TITLE
Un-escape .rsp contents to reverse the effects of Cabal's escapeResponseFileArg

### DIFF
--- a/asterius/app/ahc-ar.hs
+++ b/asterius/app/ahc-ar.hs
@@ -34,9 +34,23 @@ main = do
 getAhcArArgs :: IO [String]
 getAhcArArgs = getArgs >>= fmap concat . mapM expand
   where
+    expand :: String -> IO [String]
     expand opt = case opt of
-      ('@' : path) -> catchIOError (lines <$> readFile path) (const $ pure [opt])
+      ('@' : path) ->
+        catchIOError
+          (map undoEscapeResponseFileArg . lines <$> readFile path)
+          (const $ pure [opt])
       _ -> return [opt]
+
+-- | Un-escape a single the contents of @.rsp@ file, essentially reversing the
+-- effects of Cabal's @escapeResponseFileArg@
+-- (https://github.com/haskell/cabal/blob/dde6255a4e6b531c0567bc499840d11ead9d885b/Cabal/Distribution/Simple/Program/ResponseFile.hs#L48).
+undoEscapeResponseFileArg :: String -> String
+undoEscapeResponseFileArg arg = case arg of
+  "" -> ""
+  '\\' : c : cs -> c : undoEscapeResponseFileArg cs
+  '\\' : [] -> error "undoEscapeResponseFileArg: dangling backslash"
+  c : cs -> c : undoEscapeResponseFileArg cs
 
 -- | Create a library archive from a bunch of object files, using @Ar@ from the
 -- GHC API. Though the name of each object file is preserved, we set the


### PR DESCRIPTION
When implementing `ahc-ar` (PR https://github.com/tweag/asterius/pull/663), we didn't expect that  filenames with quotes, spaces, etc. would appear in `.rsp` files, but after all they do (https://github.com/tweag/asterius/issues/670). This PR reverses the effects of [escapeResponseFileArg](https://github.com/haskell/cabal/blob/dde6255a4e6b531c0567bc499840d11ead9d885b/Cabal/Distribution/Simple/Program/ResponseFile.hs#L48) and closes https://github.com/tweag/asterius/issues/670.