### PR TITLE
Implement Asterius.Builtins.Math

### DIFF
--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -24,6 +24,7 @@ import Asterius.Builtins.Exports
 import Asterius.Builtins.Hashable
 import Asterius.Builtins.MD5
 import Asterius.Builtins.Malloc
+import Asterius.Builtins.Math
 import Asterius.Builtins.Posix
 import Asterius.Builtins.Primitive
 import Asterius.Builtins.Scheduler
@@ -194,6 +195,7 @@ rtsAsteriusModule opts =
     <> stgPrimFloatCBits
     <> timeCBits
     <> primitiveCBits
+    <> mathCBits
 
 -- Generate the module consisting of functions which need to be wrapped
 -- for communication with the external runtime.

--- a/asterius/src/Asterius/Builtins/Math.hs
+++ b/asterius/src/Asterius/Builtins/Math.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Asterius.Builtins.Math

--- a/asterius/src/Asterius/Builtins/Math.hs
+++ b/asterius/src/Asterius/Builtins/Math.hs
@@ -14,80 +14,22 @@ import Asterius.Types
 
 mathCBits :: AsteriusModule
 mathCBits =
-  mathSin
-    <> mathCos
-    <> mathTan
-    <> mathSinh
-    <> mathCosh
-    <> mathTanh
-    <> mathAsin
-    <> mathAcos
-    <> mathAtan
-    <> mathLog
-    <> mathExp
-
-mathSin :: AsteriusModule
-mathSin = runEDSL "sin" $ do
-  setReturnTypes [F64]
-  x <- param F64
-  callImport' "__asterius_sin_F64" [x] F64 >>= emit
-
-mathCos :: AsteriusModule
-mathCos = runEDSL "cos" $ do
-  setReturnTypes [F64]
-  x <- param F64
-  callImport' "__asterius_cos_F64" [x] F64 >>= emit
-
-mathTan :: AsteriusModule
-mathTan = runEDSL "tan" $ do
-  setReturnTypes [F64]
-  x <- param F64
-  callImport' "__asterius_tan_F64" [x] F64 >>= emit
-
-mathSinh :: AsteriusModule
-mathSinh = runEDSL "sinh" $ do
-  setReturnTypes [F64]
-  x <- param F64
-  callImport' "__asterius_sinh_F64" [x] F64 >>= emit
-
-mathCosh :: AsteriusModule
-mathCosh = runEDSL "cosh" $ do
-  setReturnTypes [F64]
-  x <- param F64
-  callImport' "__asterius_cosh_F64" [x] F64 >>= emit
-
-mathTanh :: AsteriusModule
-mathTanh = runEDSL "tanh" $ do
-  setReturnTypes [F64]
-  x <- param F64
-  callImport' "__asterius_tanh_F64" [x] F64 >>= emit
-
-mathAsin :: AsteriusModule
-mathAsin = runEDSL "asin" $ do
-  setReturnTypes [F64]
-  x <- param F64
-  callImport' "__asterius_asin_F64" [x] F64 >>= emit
-
-mathAcos :: AsteriusModule
-mathAcos = runEDSL "acos" $ do
-  setReturnTypes [F64]
-  x <- param F64
-  callImport' "__asterius_acos_F64" [x] F64 >>= emit
-
-mathAtan :: AsteriusModule
-mathAtan = runEDSL "atan" $ do
-  setReturnTypes [F64]
-  x <- param F64
-  callImport' "__asterius_atan_F64" [x] F64 >>= emit
-
-mathLog :: AsteriusModule
-mathLog = runEDSL "log" $ do
-  setReturnTypes [F64]
-  x <- param F64
-  callImport' "__asterius_log_F64" [x] F64 >>= emit
-
-mathExp :: AsteriusModule
-mathExp = runEDSL "exp" $ do
-  setReturnTypes [F64]
-  x <- param F64
-  callImport' "__asterius_exp_F64" [x] F64 >>= emit
+  mconcat
+    [ runEDSL (mkEntitySymbol op) $ do
+        setReturnTypes [F64]
+        x <- param F64
+        callImport' ("__asterius_" <> op <> "_F64") [x] F64 >>= emit
+      | op <-
+          [ "sin",
+            "cos",
+            "tan",
+            "sinh",
+            "cosh",
+            "tanh",
+            "asin",
+            "acos",
+            "atan",
+            "log",
+            "exp"
+          ]
+    ]

--- a/asterius/src/Asterius/Builtins/Math.hs
+++ b/asterius/src/Asterius/Builtins/Math.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Asterius.Builtins.Math
+  ( mathCBits,
+  )
+where
+
+-- All the relevant Math imports can be found in Asterius.Builtins.rtsFunctionImports.
+
+import Asterius.EDSL
+import Asterius.Types
+
+mathCBits :: AsteriusModule
+mathCBits =
+  mathSin
+    <> mathCos
+    <> mathTan
+    <> mathSinh
+    <> mathCosh
+    <> mathTanh
+    <> mathAsin
+    <> mathAcos
+    <> mathAtan
+    <> mathLog
+    <> mathExp
+
+mathSin :: AsteriusModule
+mathSin = runEDSL "sin" $ do
+  x <- param F64
+  callImport' "__asterius_sin_F64" [x] F64 >>= emit
+
+mathCos :: AsteriusModule
+mathCos = runEDSL "cos" $ do
+  x <- param F64
+  callImport' "__asterius_cos_F64" [x] F64 >>= emit
+
+mathTan :: AsteriusModule
+mathTan = runEDSL "tan" $ do
+  x <- param F64
+  callImport' "__asterius_tan_F64" [x] F64 >>= emit
+
+mathSinh :: AsteriusModule
+mathSinh = runEDSL "sinh" $ do
+  x <- param F64
+  callImport' "__asterius_sinh_F64" [x] F64 >>= emit
+
+mathCosh :: AsteriusModule
+mathCosh = runEDSL "cosh" $ do
+  x <- param F64
+  callImport' "__asterius_cosh_F64" [x] F64 >>= emit
+
+mathTanh :: AsteriusModule
+mathTanh = runEDSL "tanh" $ do
+  x <- param F64
+  callImport' "__asterius_tanh_F64" [x] F64 >>= emit
+
+mathAsin :: AsteriusModule
+mathAsin = runEDSL "asin" $ do
+  x <- param F64
+  callImport' "__asterius_asin_F64" [x] F64 >>= emit
+
+mathAcos :: AsteriusModule
+mathAcos = runEDSL "acos" $ do
+  x <- param F64
+  callImport' "__asterius_acos_F64" [x] F64 >>= emit
+
+mathAtan :: AsteriusModule
+mathAtan = runEDSL "atan" $ do
+  x <- param F64
+  callImport' "__asterius_atan_F64" [x] F64 >>= emit
+
+mathLog :: AsteriusModule
+mathLog = runEDSL "log" $ do
+  x <- param F64
+  callImport' "__asterius_log_F64" [x] F64 >>= emit
+
+mathExp :: AsteriusModule
+mathExp = runEDSL "exp" $ do
+  x <- param F64
+  callImport' "__asterius_exp_F64" [x] F64 >>= emit

--- a/asterius/src/Asterius/Builtins/Math.hs
+++ b/asterius/src/Asterius/Builtins/Math.hs
@@ -6,7 +6,8 @@ module Asterius.Builtins.Math
   )
 where
 
--- All the relevant Math imports can be found in Asterius.Builtins.rtsFunctionImports.
+-- All the relevant @__asterius_<fn>_F64@ imports can be found in
+-- @Asterius.Builtins.rtsFunctionImports@.
 
 import Asterius.EDSL
 import Asterius.Types
@@ -27,55 +28,66 @@ mathCBits =
 
 mathSin :: AsteriusModule
 mathSin = runEDSL "sin" $ do
+  setReturnTypes [F64]
   x <- param F64
   callImport' "__asterius_sin_F64" [x] F64 >>= emit
 
 mathCos :: AsteriusModule
 mathCos = runEDSL "cos" $ do
+  setReturnTypes [F64]
   x <- param F64
   callImport' "__asterius_cos_F64" [x] F64 >>= emit
 
 mathTan :: AsteriusModule
 mathTan = runEDSL "tan" $ do
+  setReturnTypes [F64]
   x <- param F64
   callImport' "__asterius_tan_F64" [x] F64 >>= emit
 
 mathSinh :: AsteriusModule
 mathSinh = runEDSL "sinh" $ do
+  setReturnTypes [F64]
   x <- param F64
   callImport' "__asterius_sinh_F64" [x] F64 >>= emit
 
 mathCosh :: AsteriusModule
 mathCosh = runEDSL "cosh" $ do
+  setReturnTypes [F64]
   x <- param F64
   callImport' "__asterius_cosh_F64" [x] F64 >>= emit
 
 mathTanh :: AsteriusModule
 mathTanh = runEDSL "tanh" $ do
+  setReturnTypes [F64]
   x <- param F64
   callImport' "__asterius_tanh_F64" [x] F64 >>= emit
 
 mathAsin :: AsteriusModule
 mathAsin = runEDSL "asin" $ do
+  setReturnTypes [F64]
   x <- param F64
   callImport' "__asterius_asin_F64" [x] F64 >>= emit
 
 mathAcos :: AsteriusModule
 mathAcos = runEDSL "acos" $ do
+  setReturnTypes [F64]
   x <- param F64
   callImport' "__asterius_acos_F64" [x] F64 >>= emit
 
 mathAtan :: AsteriusModule
 mathAtan = runEDSL "atan" $ do
+  setReturnTypes [F64]
   x <- param F64
   callImport' "__asterius_atan_F64" [x] F64 >>= emit
 
 mathLog :: AsteriusModule
 mathLog = runEDSL "log" $ do
+  setReturnTypes [F64]
   x <- param F64
   callImport' "__asterius_log_F64" [x] F64 >>= emit
 
 mathExp :: AsteriusModule
 mathExp = runEDSL "exp" $ do
+  setReturnTypes [F64]
   x <- param F64
   callImport' "__asterius_exp_F64" [x] F64 >>= emit


### PR DESCRIPTION
This PR adds C standard library bindings to the following triangular functions: `cos`, `tan`, `sinh`, `cosh`, `tanh`, `asin`, `acos`, `atan`, `log`, and `exp`.

Closes https://github.com/tweag/asterius/issues/673.