### PR TITLE
Remove warning

### DIFF
--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -59,7 +59,6 @@ import Asterius.Types.SymbolMap (SymbolMap)
 import qualified Asterius.Types.SymbolMap as SM
 import Asterius.Types.SymbolSet (SymbolSet)
 import qualified Asterius.Types.SymbolSet as SS
-import Control.DeepSeq
 import Control.Exception
 import qualified Data.ByteString as BS
 import Data.Data


### PR DESCRIPTION
Was:
```
/Users/ggreif/asterius/asterius/src/Asterius/Types.hs:62:1: warning: [-Wunused-imports]
    The import of ‘Control.DeepSeq’ is redundant
      except perhaps to import instances from ‘Control.DeepSeq’
    To import instances alone, use: import Control.DeepSeq()
   |        
62 | import Control.DeepSeq
   | ^^^^^^^^^^^^^^^^^^^^^^
```