### PR TITLE
ahc-cabal improvement

### DIFF
--- a/asterius/cabal/config
+++ b/asterius/cabal/config
@@ -26,7 +26,9 @@ executable-stripping: False
 library-stripping: False
 tests: False
 coverage: False
-library-coverage: False
 benchmarks: False
 relocatable: False
+write-ghc-environment-files: never
 documentation: False
+minimize-conflict-set: True
+allow-boot-library-installs: True

--- a/asterius/cabal/config
+++ b/asterius/cabal/config
@@ -31,3 +31,4 @@ relocatable: False
 write-ghc-environment-files: never
 documentation: False
 minimize-conflict-set: True
+jobs: $ncpus

--- a/asterius/cabal/config
+++ b/asterius/cabal/config
@@ -1,0 +1,32 @@
+repository hackage.fpcomplete.com
+  url: https://s3.amazonaws.com/hackage.fpcomplete.com/
+  secure: True
+  root-keys:
+    0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d
+    1ea9ba32c526d1cc91ab5e5bd364ec5e9e8cb67179a471872f6e26f0ae773d42
+    280b10153a522681163658cb49f632cde3f38d768b736ddbc901d99a1a772833
+    2a96b1889dc221c17296fcc2bb34b908ca9734376f0f361660200935916ef201
+    2c6c3627bd6c982990239487f1abd02e08a02e6cf16edb105a8012d444d870c3
+    51f0161b906011b52c6613376b1ae937670da69322113a246a09f807c62f6921
+    772e9f4c7db33d251d5c6e357199c819e569d130857dc225549b40845ff0890d
+    aa315286e6ad281ad61182235533c41e806e5a787e0b6d1e7eef3f09d137d2e9
+    fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0
+  key-threshold: 3
+
+library-vanilla: True
+shared: False
+executable-dynamic: False
+profiling: False
+optimization: True
+debug-info: False
+library-for-ghci: False
+split-sections: False
+split-objs: False
+executable-stripping: False
+library-stripping: False
+tests: False
+coverage: False
+library-coverage: False
+benchmarks: False
+relocatable: False
+documentation: False

--- a/asterius/cabal/config
+++ b/asterius/cabal/config
@@ -31,4 +31,3 @@ relocatable: False
 write-ghc-environment-files: never
 documentation: False
 minimize-conflict-set: True
-allow-boot-library-installs: True

--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -39,6 +39,7 @@ extra-source-files:
   - test/argv/**/*.hs
 
 data-files:
+  - cabal/**
   - rts/**/*.mjs
   - boot-init.sh
   - boot.sh

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -76,7 +76,7 @@ RUN \
   rm -rf -v \
     /root/.asterius \
     /root/.asterius-compiler-bin/../share \
-    /root/.cabal \
+    /root/.ahc-cabal \
     /root/.config \
     /root/.local/bin/stack \
     /root/.npm \

--- a/stackage.Dockerfile
+++ b/stackage.Dockerfile
@@ -18,6 +18,6 @@ RUN \
 RUN \
   rm -rf \
     $ASTERIUS_LIB_DIR/bin \
-    /root/.cabal \
+    /root/.ahc-cabal \
     /tmp/* \
     /var/tmp/*


### PR DESCRIPTION
* We now use `~/.ahc-cabal` as a standalone `cabal` root directory. This avoids clashes with `~/.cabal`, and clears the main obstacle of #638
* The extra `cabal` config entries are included in the `cabal/config` file in tree, instead of hard-coding in `ahc-cabal.hs`. At run-time, we add the `program-locations` section and write it to `~/.ahc-cabal/config`. One downside: users can't customize `ahc-cabal` via `~/.ahc-cabal/config` since it always gets rewritten, but it's doubtful if there's really such a use case lol
* `ahc-cabal` now uses FP Complete's Hackage mirror by default and enables `hackage-security` verification.