### PR TITLE
Build base/dev images on GitHub Actions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -314,13 +314,13 @@ jobs:
 
       - name: build
         run: |
-          docker build \
+          podman build \
             --file $ASTERIUS_IMAGE.Dockerfile \
             --label "gitrev=$(git rev-parse HEAD)" \
             --squash \
             --tag terrorjack/asterius:$ASTERIUS_IMAGE \
             .
-          docker save terrorjack/asterius:$ASTERIUS_IMAGE -o image-$ASTERIUS_IMAGE.tar
+          podman save terrorjack/asterius:$ASTERIUS_IMAGE -o image-$ASTERIUS_IMAGE.tar
 
       - name: upload-artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -296,6 +296,38 @@ jobs:
           name: gen-pkgs
           path: gen-pkgs
 
+  image:
+    name: image-${{ matrix.image }}
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - base
+          - dev
+    env:
+      ASTERIUS_IMAGE: ${{ matrix.image }}
+    steps:
+
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: build
+        run: |
+          docker build \
+            --file $ASTERIUS_IMAGE.Dockerfile \
+            --label "gitrev=$(git rev-parse HEAD)" \
+            --squash \
+            --tag terrorjack/asterius:$ASTERIUS_IMAGE \
+            .
+          docker save terrorjack/asterius:$ASTERIUS_IMAGE -o image-$ASTERIUS_IMAGE.tar
+
+      - name: upload-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: image-${{ matrix.image }}
+          path: image-${{ matrix.image }}.tar
+
   docs:
     name: docs
     runs-on: ubuntu-18.04


### PR DESCRIPTION
This PR adds builds of the `base`/`dev` images to GitHub Actions, since their build times are short enough to be contained in a regular CI build. The benefits are:

* We can catch regressions in the image build scripts when we make architectural changes
* People can use the artifacts directly as prebuilt binaries. Better tracking of revisions compared to docker hub.

The `stackage` image needs to be built on BuildKite for now.