### PR TITLE
Set npm `unsafe-perm` flag to true in image build scripts

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -37,6 +37,7 @@ WORKDIR /root
 RUN \
   (curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash) && \
   bash -c ". ~/.nvm/nvm.sh && nvm install 14.4.0" && \
+  npm config set unsafe-perm true && \
   npm install -g parcel-bundler@1.12.4 && \
   mkdir -p ~/.local/bin && \
   curl -L https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64-bin -o ~/.local/bin/stack && \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -49,6 +49,7 @@ RUN \
   curl -L https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64-bin -o ~/.local/bin/stack && \
   chmod +x ~/.local/bin/stack && \
   curl -L https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz | tar xJ -C ~/.local/bin 'cabal' && \
+  npm config set unsafe-perm true && \
   npm install -g \
     0x@4.9.1 \
     parcel-bundler@1.12.4 && \


### PR DESCRIPTION
Solves image build regressions in #688.