### PR TITLE
Remove (expected obsolete) staticsErrorMap

### DIFF
--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -1609,7 +1609,7 @@ marshalCmmDecl decl = case decl of
     sym <- marshalCLabel clbl
     r <- unCodeGen $ marshalCmmData sym sec d
     pure $ case r of
-      Left err -> mempty {staticsErrorMap = SM.fromList [(sym, err)]}
+      Left err -> error $ "marshalCmmDecl: " <> show err
       Right ass -> mempty {staticsMap = SM.fromList [(sym, ass)]}
   GHC.CmmProc _ clbl _ g -> do
     sym <- marshalCLabel clbl

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -1609,7 +1609,7 @@ marshalCmmDecl decl = case decl of
     sym <- marshalCLabel clbl
     r <- unCodeGen $ marshalCmmData sym sec d
     pure $ case r of
-      Left err -> mempty
+      Left err -> error $ "marshalCmmDecl: " <> show err
       Right ass -> mempty {staticsMap = SM.fromList [(sym, ass)]}
   GHC.CmmProc _ clbl _ g -> do
     sym <- marshalCLabel clbl

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -1609,7 +1609,7 @@ marshalCmmDecl decl = case decl of
     sym <- marshalCLabel clbl
     r <- unCodeGen $ marshalCmmData sym sec d
     pure $ case r of
-      Left err -> error $ "marshalCmmDecl: " <> show err
+      Left err -> mempty
       Right ass -> mempty {staticsMap = SM.fromList [(sym, ass)]}
   GHC.CmmProc _ clbl _ g -> do
     sym <- marshalCLabel clbl

--- a/asterius/src/Asterius/Passes/GCSections.hs
+++ b/asterius/src/Asterius/Passes/GCSections.hs
@@ -12,7 +12,6 @@ where
 import Asterius.Types
 import qualified Asterius.Types.SymbolMap as SM
 import qualified Asterius.Types.SymbolSet as SS
-import Data.String
 
 gcSections ::
   Bool ->
@@ -81,14 +80,7 @@ gcSections verbose_err c_store_mod root_syms export_funcs =
                                   { staticsType = ConstBytes,
                                     asteriusStatics =
                                       [ Serialized $
-                                          entityName i_staging_sym
-                                            <> ( case SM.lookup
-                                                   i_staging_sym
-                                                   (staticsErrorMap store_mod) of
-                                                   Just err -> fromString (": " <> show err)
-                                                   _ -> mempty
-                                               )
-                                            <> "\0"
+                                          entityName i_staging_sym <> "\0"
                                       ]
                                   }
                                 (staticsMap o_m_acc)

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -106,7 +106,6 @@ data AsteriusStatics
 data AsteriusModule
   = AsteriusModule
       { staticsMap :: SymbolMap AsteriusStatics,
-        staticsErrorMap :: SymbolMap AsteriusCodeGenError,
         functionMap :: SymbolMap Function,
         sptMap :: SymbolMap (Word64, Word64),
         ffiMarshalState :: FFIMarshalState
@@ -114,16 +113,15 @@ data AsteriusModule
   deriving (Show, Data)
 
 instance Semigroup AsteriusModule where
-  AsteriusModule sm0 se0 fm0 spt0 mod_ffi_state0 <> AsteriusModule sm1 se1 fm1 spt1 mod_ffi_state1 =
+  AsteriusModule sm0 fm0 spt0 mod_ffi_state0 <> AsteriusModule sm1 fm1 spt1 mod_ffi_state1 =
     AsteriusModule
       (sm0 <> sm1)
-      (se0 <> se1)
       (fm0 <> fm1)
       (spt0 <> spt1)
       (mod_ffi_state0 <> mod_ffi_state1)
 
 instance Monoid AsteriusModule where
-  mempty = AsteriusModule mempty mempty mempty mempty mempty
+  mempty = AsteriusModule mempty mempty mempty mempty
 
 -- | An 'AsteriusCachedModule' in an 'AsteriusModule' along with  with all of
 -- its 'EntitySymbol' dependencies, as they are appear in the modules data


### PR DESCRIPTION
This PR removes `staticsErrorMap` from `AsteriusModule`. Though small, this change eliminates data dependencies in `gcSections`, and thus simplifies the development of https://github.com/tweag/asterius/pull/666.