### PR TITLE
Switch to new generation `inline-js-core`

### DIFF
--- a/asterius/src/Asterius/GHCi/Internals.hs
+++ b/asterius/src/Asterius/GHCi/Internals.hs
@@ -136,7 +136,8 @@ newGHCiSession = do
           nodeExtraEnv =
             [ ("ASTERIUS_NODE_READ_FD", show node_read_fd),
               ("ASTERIUS_NODE_WRITE_FD", show node_write_fd)
-            ]
+            ],
+          nodeExitOnEvalError = True
         }
   _ <- c_close node_read_fd
   _ <- c_close node_write_fd

--- a/asterius/src/Asterius/GHCi/Internals.hs
+++ b/asterius/src/Asterius/GHCi/Internals.hs
@@ -32,6 +32,7 @@ import qualified CLabel as GHC
 import qualified CmmInfo as GHC
 import Control.Concurrent
 import Control.Exception
+import Control.Monad
 import qualified CoreLint as GHC
 import qualified CorePrep as GHC
 import qualified CoreSyn as GHC
@@ -50,6 +51,7 @@ import Data.Data
 import Data.IORef
 import qualified Data.IntMap.Strict as IM
 import qualified Data.Map.Strict as M
+import Data.Maybe
 import Data.String
 import qualified ErrUtils as GHC
 import qualified FastString as GHC
@@ -75,6 +77,8 @@ import qualified SimplCore as GHC
 import qualified SimplStg as GHC
 import qualified SrcLoc as GHC
 import System.Directory
+import System.Environment.Blank
+import System.Exit
 import System.FilePath
 import System.IO
 import System.IO.Unsafe
@@ -162,6 +166,8 @@ tryCloseGHCiSession s = do
 -- only started upon 'GHC.RunTH' messages.
 asteriusStartIServ :: GHC.HscEnv -> IO GHC.IServ
 asteriusStartIServ hsc_env = do
+  ignore <- isJust <$> getEnv "ASTERIUS_TH_IGNORE"
+  when ignore exitFailure
   GHC.debugTraceMsg (GHC.hsc_dflags hsc_env) 3 $ GHC.text "asteriusStartIServ"
   cache_ref <- newIORef GHC.emptyUFM
   pure

--- a/asterius/src/Asterius/GHCi/Internals.hs
+++ b/asterius/src/Asterius/GHCi/Internals.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -352,7 +351,7 @@ asteriusRunTH hsc_env _ _ q ty loc s ahc_dist_input =
     req_val <- evalJSVal s Expression $ jsval req_mod_val <> ".default"
     buf_val <- evalJSVal s Expression $ buffer mod_buf
     mod_val <- evalJSVal s Expression $ "WebAssembly.compile(" <> jsval buf_val <> ")"
-    !i <-
+    i <-
       evalJSVal s Expression $
         jsval rts_val
           <> ".newAsteriusInstance(Object.assign("
@@ -360,7 +359,7 @@ asteriusRunTH hsc_env _ _ q ty loc s ahc_dist_input =
           <> ",{module:"
           <> jsval mod_val
           <> "}))"
-    !arr_buf <- evalJSVal s Expression $ buffer (encode loc)
+    arr_buf <- evalJSVal s Expression $ buffer (encode loc)
     let runner_closure =
           jsval i <> ".symbolTable."
             <> fromString
@@ -402,7 +401,7 @@ asteriusRunTH hsc_env _ _ q ty loc s ahc_dist_input =
         tid =
           jsval i <> ".exports.rts_evalLazyIO(" <> applied_closure <> ")"
     evalNone s Expression tid
-    pure i
+    evaluate i
   where
     runner_sym = closureSymbol hsc_env "ghci" "Asterius.GHCi" $ case ty of
       GHC.THExp -> "asteriusRunQExp"

--- a/asterius/src/Asterius/GHCi/Internals.hs
+++ b/asterius/src/Asterius/GHCi/Internals.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -87,16 +88,15 @@ import qualified UniqSupply as GHC
 import Unsafe.Coerce
 import qualified VarEnv as GHC
 
-data GHCiState
-  = GHCiState
-      { ghciUniqSupply :: GHC.UniqSupply,
-        ghciNameCacheUpdater :: GHC.NameCacheUpdater,
-        ghciLibs :: AsteriusCachedModule,
-        ghciObjs :: M.Map FilePath AsteriusCachedModule,
-        ghciCompiledCoreExprs :: IM.IntMap (EntitySymbol, AsteriusCachedModule),
-        ghciLastCompiledCoreExpr :: Int,
-        ghciSession :: ~(Session, Pipe, JSVal)
-      }
+data GHCiState = GHCiState
+  { ghciUniqSupply :: GHC.UniqSupply,
+    ghciNameCacheUpdater :: GHC.NameCacheUpdater,
+    ghciLibs :: AsteriusCachedModule,
+    ghciObjs :: M.Map FilePath AsteriusCachedModule,
+    ghciCompiledCoreExprs :: IM.IntMap (EntitySymbol, AsteriusCachedModule),
+    ghciLastCompiledCoreExpr :: Int,
+    ghciSession :: ~(Session, Pipe, JSVal)
+  }
 
 {-# NOINLINE globalGHCiState #-}
 globalGHCiState :: MVar GHCiState
@@ -351,7 +351,7 @@ asteriusRunTH hsc_env _ _ q ty loc s ahc_dist_input =
     req_val <- evalJSVal s Expression $ jsval req_mod_val <> ".default"
     buf_val <- evalJSVal s Expression $ buffer mod_buf
     mod_val <- evalJSVal s Expression $ "WebAssembly.compile(" <> jsval buf_val <> ")"
-    i <-
+    !i <-
       evalJSVal s Expression $
         jsval rts_val
           <> ".newAsteriusInstance(Object.assign("
@@ -359,7 +359,7 @@ asteriusRunTH hsc_env _ _ q ty loc s ahc_dist_input =
           <> ",{module:"
           <> jsval mod_val
           <> "}))"
-    arr_buf <- evalJSVal s Expression $ buffer (encode loc)
+    !arr_buf <- evalJSVal s Expression $ buffer (encode loc)
     let runner_closure =
           jsval i <> ".symbolTable."
             <> fromString

--- a/asterius/src/Asterius/JSRun/Main.hs
+++ b/asterius/src/Asterius/JSRun/Main.hs
@@ -9,39 +9,37 @@ module Asterius.JSRun.Main
 where
 
 import Asterius.BuildInfo
-import Data.ByteString.Builder
 import qualified Data.ByteString.Lazy as LBS
-import Data.Coerce
 import Language.JavaScript.Inline.Core
 import System.FilePath
 
-newAsteriusInstance :: JSSession -> FilePath -> LBS.ByteString -> IO JSVal
+newAsteriusInstance :: Session -> FilePath -> LBS.ByteString -> IO JSVal
 newAsteriusInstance s req_path mod_buf = do
   rts_val <- importMJS s $ dataDir </> "rts" </> "rts.mjs"
   req_mod_val <- importMJS s req_path
-  req_val <- eval s $ takeJSVal req_mod_val <> ".default"
-  buf_val <- alloc s mod_buf
-  mod_val <- eval s $ "WebAssembly.compile(" <> takeJSVal buf_val <> ")"
-  eval s $
-    takeJSVal rts_val
+  req_val <- evalJSVal s Expression $ jsval req_mod_val <> ".default"
+  buf_val <- evalJSVal s Expression $ buffer mod_buf
+  mod_val <- evalJSVal s Expression $ "WebAssembly.compile(" <> jsval buf_val <> ")"
+  evalJSVal s Expression $
+    jsval rts_val
       <> ".newAsteriusInstance(Object.assign("
-      <> takeJSVal req_val
+      <> jsval req_val
       <> ",{module:"
-      <> takeJSVal mod_val
+      <> jsval mod_val
       <> "}))"
 
-hsMain :: String -> JSSession -> JSVal -> IO ()
+hsMain :: String -> Session -> JSVal -> IO ()
 hsMain prog_name s i =
-  eval s $
-    deRefJSVal i
+  evalNone s Expression $
+    jsval i
       <> ".exports.main().catch(err => { if (!(err.startsWith('ExitSuccess') || err.startsWith('ExitFailure '))) { "
-      <> deRefJSVal i
+      <> jsval i
       <> ".fs.writeSync(2, `"
-      <> coerce (string7 prog_name)
+      <> code prog_name
       <> ": ${err}\n`);}})"
 
-hsStdOut :: JSSession -> JSVal -> IO LBS.ByteString
-hsStdOut s i = eval s $ deRefJSVal i <> ".stdio.stdout()"
+hsStdOut :: Session -> JSVal -> IO LBS.ByteString
+hsStdOut s i = evalBuffer s Expression $ jsval i <> ".stdio.stdout()"
 
-hsStdErr :: JSSession -> JSVal -> IO LBS.ByteString
-hsStdErr s i = eval s $ deRefJSVal i <> ".stdio.stderr()"
+hsStdErr :: Session -> JSVal -> IO LBS.ByteString
+hsStdErr s i = evalBuffer s Expression $ jsval i <> ".stdio.stderr()"

--- a/asterius/src/Asterius/JSRun/NonMain.hs
+++ b/asterius/src/Asterius/JSRun/NonMain.hs
@@ -64,7 +64,7 @@ distNonMain p extra_syms =
       }
 
 newAsteriusInstanceNonMain ::
-  JSSession ->
+  Session ->
   FilePath ->
   [EntitySymbol] ->
   AsteriusCachedModule ->
@@ -76,16 +76,16 @@ newAsteriusInstanceNonMain s p extra_syms m = do
       wasm_path = p -<.> "wasm"
   rts_val <- importMJS s rts_path
   req_mod_val <- importMJS s req_path
-  req_val <- eval s $ takeJSVal req_mod_val <> ".default"
+  req_val <- evalJSVal s Expression $ jsval req_mod_val <> ".default"
   mod_val <-
-    eval s $
+    evalJSVal s Expression $
       "import('fs').then(fs => fs.promises.readFile("
         <> fromString (show wasm_path)
         <> ")).then(buf => WebAssembly.compile(buf))"
-  eval s $
-    takeJSVal rts_val
+  evalJSVal s Expression $
+    jsval rts_val
       <> ".newAsteriusInstance(Object.assign("
-      <> takeJSVal req_val
+      <> jsval req_val
       <> ",{module:"
-      <> takeJSVal mod_val
+      <> jsval mod_val
       <> "}))"

--- a/asterius/test/ghc-testsuite.hs
+++ b/asterius/test/ghc-testsuite.hs
@@ -135,12 +135,12 @@ runTestCase l_opts tlref TestCase {..} = catch m h
               }
             ""
         mod_buf <- LBS.readFile $ tmp_case_path -<.> "wasm"
-        withJSSession
-          defJSSessionOpts
+        bracket
+          (newSession defaultConfig
             { nodeExtraArgs =
                 ["--experimental-wasm-bigint" | "--debug" `elem` l_opts]
                   <> [ "--experimental-wasm-return-call" ]
-            }
+            }) closeSession
           $ \s -> do
             i <- newAsteriusInstance s (tmp_case_path -<.> "req.mjs") mod_buf
             hsMain (takeBaseName tmp_case_path) s i

--- a/asterius/test/ghc-testsuite.hs
+++ b/asterius/test/ghc-testsuite.hs
@@ -27,11 +27,10 @@ import System.Process
 import Test.Tasty
 import Test.Tasty.HUnit
 
-data TestCase
-  = TestCase
-      { casePath :: FilePath,
-        caseStdIn, caseStdOut, caseStdErr :: LBS.ByteString
-      }
+data TestCase = TestCase
+  { casePath :: FilePath,
+    caseStdIn, caseStdOut, caseStdErr :: LBS.ByteString
+  }
   deriving (Show)
 
 -- Convert a Char to a Word8
@@ -84,14 +83,13 @@ data TestOutcome
 instance ToField TestOutcome where
   toField = toField . show
 
-data TestRecord
-  = TestRecord
-      { trOutcome :: TestOutcome,
-        -- | Path of the test case
-        trPath :: FilePath,
-        -- | If the test failed, then the error message associated to the failure.
-        trErrorMessage :: String
-      }
+data TestRecord = TestRecord
+  { trOutcome :: TestOutcome,
+    -- | Path of the test case
+    trPath :: FilePath,
+    -- | If the test failed, then the error message associated to the failure.
+    trErrorMessage :: String
+  }
   deriving (Generic)
 
 instance ToRecord TestRecord
@@ -136,11 +134,15 @@ runTestCase l_opts tlref TestCase {..} = catch m h
             ""
         mod_buf <- LBS.readFile $ tmp_case_path -<.> "wasm"
         bracket
-          (newSession defaultConfig
-            { nodeExtraArgs =
-                ["--experimental-wasm-bigint" | "--debug" `elem` l_opts]
-                  <> [ "--experimental-wasm-return-call" ]
-            }) closeSession
+          ( newSession
+              defaultConfig
+                { nodeExtraArgs =
+                    ["--experimental-wasm-bigint" | "--debug" `elem` l_opts]
+                      <> ["--experimental-wasm-return-call"],
+                  nodeExitOnEvalError = True
+                }
+          )
+          closeSession
           $ \s -> do
             i <- newAsteriusInstance s (tmp_case_path -<.> "req.mjs") mod_buf
             hsMain (takeBaseName tmp_case_path) s i

--- a/asterius/test/nomain.hs
+++ b/asterius/test/nomain.hs
@@ -24,9 +24,13 @@ main = do
   ncu <- newNameCacheUpdater
   m <- getFile ncu "test/nomain/NoMain.unlinked.bin"
   bracket
-    (newSession defaultConfig
-      { nodeExtraArgs = ["--experimental-wasm-return-call"]
-      }) closeSession
+    ( newSession
+        defaultConfig
+          { nodeExtraArgs = ["--experimental-wasm-return-call"],
+            nodeExitOnEvalError = True
+          }
+    )
+    closeSession
     $ \s -> do
       i <-
         newAsteriusInstanceNonMain

--- a/lts.sh
+++ b/lts.sh
@@ -5,11 +5,10 @@ set -eu
 ahc-cabal v1-install --ghc-option=-j$jobs --prefix=$ASTERIUS_LIB_DIR --package-db=clear --package-db=global \
   Cabal
 
-cp $(which node) /tmp
-cp $(which false) $(which node)
+export ASTERIUS_TH_IGNORE=1
 ahc-cabal v1-install -j$jobs --prefix=$ASTERIUS_LIB_DIR --package-db=clear --package-db=global --keep-going \
   $(cat pkgs.txt) || true
 
-mv /tmp/node $(which node)
+unset ASTERIUS_TH_IGNORE
 ahc-cabal v1-install -j$jobs_th --prefix=$ASTERIUS_LIB_DIR --package-db=clear --package-db=global --keep-going \
   $(cat pkgs.txt) || true

--- a/stack-profile.yaml
+++ b/stack-profile.yaml
@@ -9,7 +9,7 @@ build:
 resolver: lts-16.2
 extra-deps:
   - binaryen-0.0.1.1
-  - url: https://github.com/tweag/inline-js/archive/009f9d08238f95ad6a0722877484224fb972bd05.tar.gz
+  - url: https://github.com/tweag/inline-js/archive/e584aed5348363b39eab64de2af48acbe7234db3.tar.gz
     subdirs:
       - inline-js-core
 packages:

--- a/stack-profile.yaml
+++ b/stack-profile.yaml
@@ -9,7 +9,7 @@ build:
 resolver: lts-16.2
 extra-deps:
   - binaryen-0.0.1.1
-  - url: https://github.com/tweag/inline-js/archive/1588a83d81a591ec4c7a482aea2ebf31e4303de3.tar.gz
+  - url: https://github.com/tweag/inline-js/archive/b7e5b1e3941d896874af6bd3e2e1a5b3feaa59c3.tar.gz
     subdirs:
       - inline-js-core
 packages:

--- a/stack-profile.yaml
+++ b/stack-profile.yaml
@@ -9,7 +9,7 @@ build:
 resolver: lts-16.2
 extra-deps:
   - binaryen-0.0.1.1
-  - url: https://github.com/tweag/inline-js/archive/b7e5b1e3941d896874af6bd3e2e1a5b3feaa59c3.tar.gz
+  - url: https://github.com/tweag/inline-js/archive/6e43916afbd2c5f7bdb4f08e81670244e810eeeb.tar.gz
     subdirs:
       - inline-js-core
 packages:

--- a/stack-profile.yaml
+++ b/stack-profile.yaml
@@ -9,7 +9,7 @@ build:
 resolver: lts-16.2
 extra-deps:
   - binaryen-0.0.1.1
-  - url: https://github.com/tweag/inline-js/archive/e584aed5348363b39eab64de2af48acbe7234db3.tar.gz
+  - url: https://github.com/tweag/inline-js/archive/1588a83d81a591ec4c7a482aea2ebf31e4303de3.tar.gz
     subdirs:
       - inline-js-core
 packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 resolver: lts-16.2
 extra-deps:
   - binaryen-0.0.1.1
-  - url: https://github.com/tweag/inline-js/archive/e584aed5348363b39eab64de2af48acbe7234db3.tar.gz
+  - url: https://github.com/tweag/inline-js/archive/1588a83d81a591ec4c7a482aea2ebf31e4303de3.tar.gz
     subdirs:
       - inline-js-core
 packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 resolver: lts-16.2
 extra-deps:
   - binaryen-0.0.1.1
-  - url: https://github.com/tweag/inline-js/archive/009f9d08238f95ad6a0722877484224fb972bd05.tar.gz
+  - url: https://github.com/tweag/inline-js/archive/e584aed5348363b39eab64de2af48acbe7234db3.tar.gz
     subdirs:
       - inline-js-core
 packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 resolver: lts-16.2
 extra-deps:
   - binaryen-0.0.1.1
-  - url: https://github.com/tweag/inline-js/archive/1588a83d81a591ec4c7a482aea2ebf31e4303de3.tar.gz
+  - url: https://github.com/tweag/inline-js/archive/b7e5b1e3941d896874af6bd3e2e1a5b3feaa59c3.tar.gz
     subdirs:
       - inline-js-core
 packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 resolver: lts-16.2
 extra-deps:
   - binaryen-0.0.1.1
-  - url: https://github.com/tweag/inline-js/archive/b7e5b1e3941d896874af6bd3e2e1a5b3feaa59c3.tar.gz
+  - url: https://github.com/tweag/inline-js/archive/6e43916afbd2c5f7bdb4f08e81670244e810eeeb.tar.gz
     subdirs:
       - inline-js-core
 packages:


### PR DESCRIPTION
This PR switches from `develop` branch of `inline-js-core` to the `v2` new generation branch, which will soon become the new `master`. The new generation `inline-js-core` offers many benefits over the previous implementations; details will follow in `inline-js` design doc shortly.