### PR TITLE
Fix podman on CI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -365,6 +365,7 @@ jobs:
 
       - name: build
         run: |
+          echo "cgroup_manager=\"cgroupfs\"" > ~/.config/containers/libpod.conf
           podman build \
             --file $ASTERIUS_IMAGE.Dockerfile \
             --label "gitrev=$(git rev-parse HEAD)" \

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -365,6 +365,7 @@ jobs:
 
       - name: build
         run: |
+          mkdir -p ~/.config/containers
           echo "cgroup_manager=\"cgroupfs\"" > ~/.config/containers/libpod.conf
           podman build \
             --file $ASTERIUS_IMAGE.Dockerfile \


### PR DESCRIPTION
The image build jobs on CI has been failing with:

```
systemd cgroup flag passed, but systemd support for managing cgroups is not available
```

For now, we need to manually specify `cgroup_manager="cgroupfs"` in the user-level `libpod.conf` to fix this.