### PR TITLE
Binaryen update

### DIFF
--- a/.github/workflows/setup-deps.sh
+++ b/.github/workflows/setup-deps.sh
@@ -11,8 +11,8 @@ sudo apt install -y \
   happy \
   libnuma-dev
 
-curl -L https://github.com/WebAssembly/binaryen/archive/version_93.tar.gz | tar xz -C /tmp
-cd /tmp/binaryen-version_93
+curl -L https://github.com/WebAssembly/binaryen/archive/version_94.tar.gz | tar xz -C /tmp
+cd /tmp/binaryen-version_94
 mkdir build
 cd build
 cmake \

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -10,7 +10,7 @@ ENV \
   PATH=/root/.asterius-local-install-root/bin:/root/.asterius-snapshot-install-root/bin:/root/.asterius-compiler-bin:/root/.local/bin:/root/.nvm/versions/node/v14.5.0/bin:${PATH}
 
 RUN \
-  echo 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20200615T204439Z sid main contrib non-free' > /etc/apt/sources.list && \
+  echo 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20200708T084958Z sid main contrib non-free' > /etc/apt/sources.list && \
   apt update && \
   apt full-upgrade -y && \
   apt install -y \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -9,7 +9,7 @@ ENV \
   PATH=/root/.local/bin:/root/.nvm/versions/node/v14.5.0/bin:${PATH}
 
 RUN \
-  echo 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20200615T204439Z sid main contrib non-free' > /etc/apt/sources.list && \
+  echo 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20200708T084958Z sid main contrib non-free' > /etc/apt/sources.list && \
   apt update && \
   apt full-upgrade -y && \
   apt install -y \

--- a/docs/building.md
+++ b/docs/building.md
@@ -39,7 +39,7 @@ In addition to regular GHC dependencies, these dependencies are
 needed in the local environment:
 
 * `libnuma-dev` (required by GHC)
-* `binaryen` (at least `version_92`)
+* `binaryen` (at least `version_94`)
 * `automake`, `autoconf` (required by `ahc-boot`)
 * `cabal` (at least `v3.0.0.0`)
 * `node`, `npm` (at least `v12`)

--- a/stack-profile.yaml
+++ b/stack-profile.yaml
@@ -8,7 +8,7 @@ build:
 
 resolver: lts-16.4
 extra-deps:
-  - binaryen-0.0.1.1
+  - https://github.com/tweag/haskell-binaryen/archive/f25d5af56ac188b0bada9e7c7bfd0910da427993.tar.gz
   - url: https://github.com/tweag/inline-js/archive/9ef93df2026c11d0bbee0b96287eb41042bf437d.tar.gz
     subdirs:
       - inline-js-core

--- a/stack-profile.yaml
+++ b/stack-profile.yaml
@@ -8,7 +8,7 @@ build:
 
 resolver: lts-16.4
 extra-deps:
-  - https://github.com/tweag/haskell-binaryen/archive/f25d5af56ac188b0bada9e7c7bfd0910da427993.tar.gz
+  - binaryen-0.0.2.0
   - url: https://github.com/tweag/inline-js/archive/9ef93df2026c11d0bbee0b96287eb41042bf437d.tar.gz
     subdirs:
       - inline-js-core

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 resolver: lts-16.4
 extra-deps:
-  - https://github.com/tweag/haskell-binaryen/archive/f25d5af56ac188b0bada9e7c7bfd0910da427993.tar.gz
+  - binaryen-0.0.2.0
   - url: https://github.com/tweag/inline-js/archive/9ef93df2026c11d0bbee0b96287eb41042bf437d.tar.gz
     subdirs:
       - inline-js-core

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 resolver: lts-16.4
 extra-deps:
-  - binaryen-0.0.1.1
+  - https://github.com/tweag/haskell-binaryen/archive/f25d5af56ac188b0bada9e7c7bfd0910da427993.tar.gz
   - url: https://github.com/tweag/inline-js/archive/9ef93df2026c11d0bbee0b96287eb41042bf437d.tar.gz
     subdirs:
       - inline-js-core


### PR DESCRIPTION
Close #699. Use `binaryen-0.0.2.0` which works with `version_94`.