### PR TITLE
Simplify treatment of archive files

### DIFF
--- a/asterius/src/Asterius/Ar.hs
+++ b/asterius/src/Asterius/Ar.hs
@@ -29,46 +29,24 @@ where
 import Asterius.Binary.ByteString
 import Asterius.Types
 import Control.Monad
-import Data.Binary.Get
 import Data.Binary.Put
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as CBS
 import qualified Data.ByteString.Lazy as LBS
+import Data.Char
 import Data.Foldable
 import Data.Traversable
 import GHC.IO.Unsafe
 import qualified IfaceEnv as GHC
-import System.FilePath
+import System.Exit (die)
+import System.IO
 
 -------------------------------------------------------------------------------
 
-data ArchiveEntry
-  = ArchiveEntry
-      { -- | File name.
-        filename :: String,
-        -- | File modification time.
-        filetime :: Int,
-        -- | File owner.
-        fileown :: Int,
-        -- | File group.
-        filegrp :: Int,
-        -- | File mode.
-        filemode :: Int,
-        -- | File size.
-        filesize :: Int,
-        -- | File bytes.
-        filedata :: BS.ByteString
-      }
-  deriving (Eq, Show)
-
-newtype Archive = Archive [ArchiveEntry]
+newtype Archive = Archive [BS.ByteString]
   deriving (Eq, Show, Semigroup, Monoid)
 
 -------------------------------------------------------------------------------
-
--- | Archives have numeric values padded with '\x20' to the right.
-getPaddedInt :: BS.ByteString -> Int
-getPaddedInt = read . CBS.unpack . CBS.takeWhile (/= '\x20')
 
 putPaddedInt :: Int -> Int -> Put
 putPaddedInt padding i = putPaddedString '\x20' padding (show i)
@@ -80,74 +58,40 @@ putPaddedString pad padding s =
 putArchMagic :: Put
 putArchMagic = putByteString $ CBS.pack "!<arch>\n"
 
-getArchMagic :: Get ()
-getArchMagic = do
-  magic <- liftM CBS.unpack $ getByteString 8
-  when (magic /= "!<arch>\n")
-    $ fail
-    $ "Invalid magic number " ++ show magic
-
 -- | Put an archive entry. Note that this assumes that the entry has been
 -- preprocessed to account for the extended file name table section. That is,
 -- the name is assumed to fit in 16 characters; if it's longer, it gets
 -- truncated.
-putArchEntry :: ArchiveEntry -> PutM ()
-putArchEntry (ArchiveEntry name time own grp mode st_size file) = do
-  putPaddedString ' ' 16 name
-  putPaddedInt 12 time
-  putPaddedInt 6 own
-  putPaddedInt 6 grp
-  putPaddedInt 8 mode
-  putPaddedInt 10 (st_size + pad)
-  putByteString "\x60\x0a"
-  putByteString file
-  when (pad == 1) $
+putArchEntry :: BS.ByteString -> PutM ()
+putArchEntry file_contents = do
+  -- total: 60 bytes
+  putByteString "                " -- name, 16 bytes
+  putByteString "0           " -- mtime, 12 bytes
+  putByteString "0     " -- UID, 6 bytes
+  putByteString "0     " -- GID, 6 bytes
+  putByteString "0644    " -- mode, 8 bytes
+  putPaddedInt 10 st_size -- file length, 10 bytes
+  putByteString "\x60\x0a" -- header magic, 2 bytes
+  putByteString file_contents
+  when (st_size `mod` 2 == 1) $
     putWord8 0x0a
   where
-    pad = st_size `mod` 2
+    st_size = BS.length file_contents
 
-putGNUArch :: Archive -> PutM ()
-putGNUArch (Archive as) = do
-  putArchMagic
-  mapM_ putArchEntry (processEntries as)
-  where
-    processEntry :: ArchiveEntry -> ArchiveEntry -> (ArchiveEntry, ArchiveEntry)
-    processEntry extInfo archive@(ArchiveEntry name _ _ _ _ _ _)
-      | length name > 15 =
-        ( extInfo
-            { filesize = filesize extInfo + length name + 2,
-              filedata = filedata extInfo <> CBS.pack name <> "/\n"
-            },
-          archive {filename = "/" <> show (filesize extInfo)}
-        )
-      | otherwise = (extInfo, archive {filename = name <> "/"})
-    processEntries :: [ArchiveEntry] -> [ArchiveEntry]
-    processEntries =
-      uncurry (:) . mapAccumL processEntry (ArchiveEntry "//" 0 0 0 0 0 mempty)
+putArchive :: Archive -> PutM ()
+putArchive (Archive as) = putArchMagic >> mapM_ putArchEntry as
 
 -- | Create a library archive from a bunch of object files. Though the name of
 -- each object file is preserved, we set the timestamp, owner ID, group ID, and
 -- file mode to default values (0, 0, 0, and 0644, respectively). When we
--- deserialize (see 'loadArchive'), the metadata is ignored anyway.
+-- deserialize (see 'loadArchiveRep'), the metadata is ignored anyway.
 createArchive :: FilePath -> [FilePath] -> IO ()
 createArchive arFile objFiles = do
   blobs <- for objFiles (unsafeDupableInterleaveIO . BS.readFile)
-  writeGNUAr arFile $
-    Archive
-      [ ArchiveEntry
-          { filename = takeFileName obj_path,
-            filetime = 0,
-            fileown = 0,
-            filegrp = 0,
-            filemode = 0o644,
-            filesize = BS.length blob,
-            filedata = blob
-          }
-        | (obj_path, blob) <- zip objFiles blobs
-      ]
+  writeArchiveToFile arFile $ Archive blobs
 
-writeGNUAr :: FilePath -> Archive -> IO ()
-writeGNUAr fp = LBS.writeFile fp . runPut . putGNUArch
+writeArchiveToFile :: FilePath -> Archive -> IO ()
+writeArchiveToFile fp = LBS.writeFile fp . runPut . putArchive
 
 -------------------------------------------------------------------------------
 
@@ -157,85 +101,48 @@ writeGNUAr fp = LBS.writeFile fp . runPut . putGNUArch
 -- values anyway).
 loadArchive :: GHC.NameCacheUpdater -> FilePath -> IO AsteriusCachedModule
 loadArchive ncu p = do
-  Archive entries <- parseAr <$> BS.readFile p
+  entries <- walkArchiveFile p
   foldlM
-    ( \acc ArchiveEntry {..} -> tryGetBS ncu filedata >>= \case
+    ( \acc entry -> tryGetBS ncu entry >>= \case
         Left _ -> pure acc
         Right m -> pure $ m <> acc
     )
     mempty
     entries
 
-getAllArEntryFields :: Get (CBS.ByteString, Int, Int, Int, Int, Int, CBS.ByteString)
-getAllArEntryFields = do
-  name <- getByteString 16
-  time <- getPaddedInt <$> getByteString 12
-  own <- getPaddedInt <$> getByteString 6
-  grp <- getPaddedInt <$> getByteString 6
-  mode <- getPaddedInt <$> getByteString 8
-  st_size <- getPaddedInt <$> getByteString 10
-  end <- getByteString 2
-  when (end /= "\x60\x0a") $
-    fail
-      ( "[GNU Archive] Invalid archive header end marker for name: "
-          ++ CBS.unpack name
-      )
-  file <- getByteString st_size
-  -- data sections are two byte aligned (see Trac #15396)
-  when (odd st_size) $
-    void (getByteString 1)
-  return (name, time, own, grp, mode, st_size, file)
+-------------------------------------------------------------------------------
 
-getExtendedFileNamesTable :: Get BS.ByteString
-getExtendedFileNamesTable = do
-  (name, _time, _own, _grp, _mode, _st_size, file) <- getAllArEntryFields
-  if CBS.takeWhile (/= ' ') name == "//"
-    then pure file
-    else fail "[GNU Archive] First entry must be the filename table."
-
-getMany :: Get a -> Get [a]
-getMany fn = do
-  is_empty <- isEmpty
-  if is_empty
-    then return []
-    else (:) <$> fn <*> getMany fn
-
--- | GNU Archives feature a special '//' entry that contains the
--- extended names. Those are referred to as /<num>, where num is the
--- offset into the '//' entry.
--- In addition, filenames are terminated with '/' in the archive.
--- @putGNUArch@ always places the filename table first.
-getGNUArchEntries :: Get [ArchiveEntry]
-getGNUArchEntries = do
-  filenamesTable <- getExtendedFileNamesTable
-  getMany (getGNUArchEntry filenamesTable)
-
--- | Get a GNU-style archive entry (NOT the filename table entry).
-getGNUArchEntry :: CBS.ByteString -> Get ArchiveEntry
-getGNUArchEntry filenamesTable = do
-  (name, time, own, grp, mode, st_size, file) <- getAllArEntryFields
-  let real_name = getRealFileName filenamesTable name
-  pure $ ArchiveEntry real_name time own grp mode st_size file
-
-getRealFileName :: CBS.ByteString -> CBS.ByteString -> String
-getRealFileName filenamesTable name =
-  CBS.unpack $
-    if CBS.unpack (CBS.take 1 name) == "/"
-      then
-        getExtName filenamesTable
-          $ read
-          $ CBS.unpack
-          $ CBS.drop 1
-          $ CBS.takeWhile (/= ' ') name
-      else CBS.takeWhile (/= '/') name
+walkArchiveFile :: FilePath -> IO [CBS.ByteString]
+walkArchiveFile path = withBinaryFile path ReadMode $ \h ->
+  hFileSize h >>= walkArchive h
   where
-    getExtName :: BS.ByteString -> Int -> BS.ByteString
-    getExtName info offset = CBS.takeWhile (/= '/') $ CBS.drop offset info
-
-getArch :: Get Archive
-getArch = Archive <$> do
-  getArchMagic
-  getGNUArchEntries
-
-parseAr :: BS.ByteString -> Archive
-parseAr = runGet getArch . LBS.fromChunks . pure
+    walkError msg = die $ "Asterius.Ar.walkArchiveFile: " ++ msg
+    archLF = "!<arch>\x0a" -- global magic, 8 bytes
+    walkArchive :: Handle -> Integer -> IO [CBS.ByteString]
+    walkArchive h archiveSize = do
+      global <- BS.hGet h (BS.length archLF)
+      unless (global == archLF) $ walkError "Bad global header"
+      go $ toInteger $ BS.length archLF
+      where
+        go :: Integer -> IO [CBS.ByteString]
+        go offset = case compare offset archiveSize of
+          EQ -> pure []
+          GT -> walkError $ "Archive truncated at offset " ++ show offset
+          LT -> do
+            -- Get the size of the file (ignore the rest of the header).
+            hSeek h AbsoluteSeek (offset + 48)
+            objSize <- do
+              size <- BS.hGet h 10
+              case reads (CBS.unpack size) of
+                [(n, s)] | all isSpace s -> pure n
+                _ -> walkError $ "Bad file size in header at offset " ++ show offset
+            -- Get the contents of the object file.
+            hSeek h AbsoluteSeek (offset + 60) -- skip the whole header
+            object <- BS.hGet h (fromIntegral objSize)
+            -- Get the rest of the contents.
+            let nextHeader =
+                  offset + 60 + if odd objSize then objSize + 1 else objSize
+            hSeek h AbsoluteSeek nextHeader
+            objects <- go nextHeader
+            -- Combine em.
+            pure (object : objects)


### PR DESCRIPTION
Following PR https://github.com/tweag/asterius/pull/678, we can simplify archive files and their treatment even more:

* There is no need for keeping track of the names of the object files the archive file contains; we never use them, and they are not even accurate (`takeFileName` drops most of the path).
* If there is no need for names, there is definitely no need for creating and parsing the initial entry containing all long filenames.
* In fact, all other metadata is also set to defaults; there is no point in reading these either.

So, this PR strips treatment of archive files down to the bare minimum:
* Drops the filename table entry
* Drops fine deserialization of metadata
* Represents archive files as just the list of the content of the binary files they contain.

It would have been nice to drop the metadata altogether, but `ahc-cabal` internally uses `cabal`, which calls `Distribution.Simple.Program.Ar.wipeMetadata`. `wipeMetadata` traverses the archive file and sets the metadata to defaults, so this is the maximum deviation from GNU archive files we can afford at the moment.