### PR TITLE
Use TH for generating trivial Semigroup and Monoid instances

### DIFF
--- a/asterius/src/Asterius/Monoid/TH.hs
+++ b/asterius/src/Asterius/Monoid/TH.hs
@@ -9,6 +9,13 @@ where
 import Data.List (foldl')
 import Language.Haskell.TH
 
+-- | Generate a 'Monoid' instance of the form
+--
+-- > instance Monoid TyCon where
+-- >   mempty = DataCon mempty ... mempty
+--
+-- Note that this approach works only for monomorphic datatypes with a single
+-- data constructor, whose fields are themselves all instances of 'Monoid'.
 genMonoid :: Name -> Q [Dec]
 genMonoid ty = do
   TyConI dec <- reify ty

--- a/asterius/src/Asterius/Monoid/TH.hs
+++ b/asterius/src/Asterius/Monoid/TH.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Asterius.Monoid.TH
+  ( genMonoid,
+  )
+where
+
+import Data.List (foldl')
+import Language.Haskell.TH
+
+genMonoid :: Name -> Q [Dec]
+genMonoid ty = do
+  TyConI dec <- reify ty
+  case dec of
+    DataD [] ((== ty) -> True) [] Nothing [con] _ ->
+      pure
+        [ InstanceD
+            Nothing
+            []
+            (AppT (ConT ''Monoid) (ConT ty))
+            [ FunD
+                'mempty
+                [ Clause
+                    []
+                    ( NormalB $
+                        foldl'
+                          AppE
+                          (ConE $ dataConName con)
+                          [VarE 'mempty | _ <- [1 .. dataConFields con]]
+                    )
+                    []
+                ]
+            ]
+        ]
+    _ -> fail $ "Asterius.Monoid.TH.genMonoid: " <> show dec
+
+dataConName :: Con -> Name
+dataConName (NormalC n _) = n
+dataConName (RecC n _) = n
+dataConName c = error $ "Asterius.Monoid.TH.dataConName: " <> show c
+
+dataConFields :: Con -> Int
+dataConFields (NormalC _ fs) = length fs
+dataConFields (RecC _ fs) = length fs
+dataConFields c = error $ "Asterius.Monoid.TH.dataConFields: " <> show c

--- a/asterius/src/Asterius/Semigroup/TH.hs
+++ b/asterius/src/Asterius/Semigroup/TH.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Asterius.Semigroup.TH
+  ( genSemigroup,
+  )
+where
+
+import Data.List (foldl')
+import Language.Haskell.TH
+
+genSemigroup :: Name -> Q [Dec]
+genSemigroup ty = do
+  TyConI dec <- reify ty
+  case dec of
+    DataD [] ((== ty) -> True) [] Nothing [con] _ ->
+      pure
+        [ InstanceD
+            Nothing
+            []
+            (AppT (ConT ''Semigroup) (ConT ty))
+            [ FunD
+                '(<>)
+                [ let avars = [mkName $ "a" <> show j | j <- [1 .. dataConFields con]]
+                      bvars = [mkName $ "b" <> show j | j <- [1 .. dataConFields con]]
+                   in Clause
+                        [ ConP (dataConName con) (map VarP avars),
+                          ConP (dataConName con) (map VarP bvars)
+                        ]
+                        ( NormalB $
+                            foldl'
+                              (\acc (a, b) -> AppE acc (AppE (AppE (VarE '(<>)) (VarE a)) (VarE b)))
+                              (ConE $ dataConName con)
+                              (zip avars bvars)
+                        )
+                        []
+                ]
+            ]
+        ]
+    _ -> fail $ "Asterius.Semigroup.TH.genSemigroup: " <> show dec
+
+dataConName :: Con -> Name
+dataConName (NormalC n _) = n
+dataConName (RecC n _) = n
+dataConName c = error $ "Asterius.Semigroup.TH.dataConName: " <> show c
+
+dataConFields :: Con -> Int
+dataConFields (NormalC _ fs) = length fs
+dataConFields (RecC _ fs) = length fs
+dataConFields c = error $ "Asterius.Semigroup.TH.dataConFields: " <> show c

--- a/asterius/src/Asterius/Semigroup/TH.hs
+++ b/asterius/src/Asterius/Semigroup/TH.hs
@@ -9,6 +9,14 @@ where
 import Data.List (foldl')
 import Language.Haskell.TH
 
+-- | Generate a 'Semigroup' instance of the form
+--
+-- > instance Semigroup TyCon where
+-- >   DataCon a1 ... an <> DataCon b1 .... bn =
+-- >     DataCon (a1 <> b1) ... (an <> bn)
+--
+-- Note that this approach works only for monomorphic datatypes with a single
+-- data constructor, whose fields are themselves all instances of 'Semigroup'.
 genSemigroup :: Name -> Q [Dec]
 genSemigroup ty = do
   TyConI dec <- reify ty


### PR DESCRIPTION
By "trivial" we mean instances for types with a single data constructor, where `mappend` simply `mappend`s the fields element-wise.