### PR TITLE
Delete law-violating obsolete Semigroup/Monoid instances for LinkReport

### DIFF
--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -112,7 +112,7 @@ linkStart ::
 linkStart debug gc_sections verbose_err store root_syms export_funcs =
   ( merged_m,
     result_m,
-    mempty
+    LinkReport
       { staticsSymbolMap = ss_sym_map,
         functionSymbolMap = func_sym_map,
         infoTableSet = makeInfoTableSet merged_m ss_sym_map,

--- a/asterius/src/Asterius/Types/LinkReport.hs
+++ b/asterius/src/Asterius/Types/LinkReport.hs
@@ -23,29 +23,3 @@ data LinkReport
   deriving (Show)
 
 $(genBinary ''LinkReport)
-
-instance Semigroup LinkReport where
-  r0 <> r1 =
-    LinkReport
-      { staticsSymbolMap = staticsSymbolMap r0 <> staticsSymbolMap r1,
-        functionSymbolMap = functionSymbolMap r0 <> functionSymbolMap r1,
-        infoTableSet = infoTableSet r0 <> infoTableSet r1,
-        tableSlots = 0,
-        staticMBlocks = 0,
-        sptEntries = sptEntries r0 <> sptEntries r1,
-        bundledFFIMarshalState =
-          bundledFFIMarshalState r0
-            <> bundledFFIMarshalState r1
-      }
-
-instance Monoid LinkReport where
-  mempty =
-    LinkReport
-      { staticsSymbolMap = mempty,
-        functionSymbolMap = mempty,
-        infoTableSet = mempty,
-        tableSlots = 0,
-        staticMBlocks = 0,
-        sptEntries = mempty,
-        bundledFFIMarshalState = mempty
-      }


### PR DESCRIPTION
~~Though lawful, these~~ These instances (the `Semigroup` one in particular) assume that `tableSlots` and `staticMBlocks` will be set correctly externally, which is weird and could easily get them out-of-sync. Fortunately, they don't seem to be used anywhere (the only place that seems to use them in `linkStart` sets all the fields explicitly anyway).