### PR TITLE
Fix ghc-testsuite major regression

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -161,7 +161,9 @@ jobs:
 
       - name: ghc-testsuite
         run: |
-          GHCRTS=-N2 stack test asterius:ghc-testsuite --test-arguments="-j2 --timeout=300s" || true
+          export GHCRTS=-N2
+          export ASTERIUS_GHC_TESTSUITE_TIMEOUT=300
+          stack test asterius:ghc-testsuite --test-arguments="-j2" || true
 
       - name: upload-artifact
         uses: actions/upload-artifact@v2

--- a/asterius/src/Asterius/Internals/Timeout.hs
+++ b/asterius/src/Asterius/Internals/Timeout.hs
@@ -1,0 +1,19 @@
+module Asterius.Internals.Timeout where
+
+import Control.Concurrent
+import Control.Exception
+import Control.Monad
+
+timeout :: Int -> IO a -> IO a
+timeout t m = do
+  box <- newEmptyMVar
+  tid0 <- forkIO $ do
+    r <- try m
+    putMVar box $ case r of
+      Left (SomeException err) -> throw err
+      Right x -> x
+  _ <- forkIO $ do
+    threadDelay (t * 1000000)
+    f <- tryPutMVar box (error "TIMEOUT")
+    when f $ killThread tid0
+  evaluate =<< readMVar box

--- a/asterius/src/Asterius/JSRun/Main.hs
+++ b/asterius/src/Asterius/JSRun/Main.hs
@@ -10,6 +10,7 @@ module Asterius.JSRun.Main
 where
 
 import Asterius.BuildInfo
+import Control.Exception
 import qualified Data.ByteString.Lazy as LBS
 import Data.String
 import Language.JavaScript.Inline.Core
@@ -31,13 +32,16 @@ newAsteriusInstance s req_path mod_buf = do
 
 hsMain :: String -> Session -> JSVal -> IO ()
 hsMain prog_name s i =
-  eval s $
-    toJS i
-      <> ".exports.main().catch(err => { if (!(err.startsWith('ExitSuccess') || err.startsWith('ExitFailure '))) { "
-      <> toJS i
-      <> ".fs.writeSync(2, `"
-      <> fromString prog_name
-      <> ": ${err}\n`);}})"
+  evaluate
+    =<< eval
+      s
+      ( toJS i
+          <> ".exports.main().catch(err => { if (!(err.startsWith('ExitSuccess') || err.startsWith('ExitFailure '))) { "
+          <> toJS i
+          <> ".fs.writeSync(2, `"
+          <> fromString prog_name
+          <> ": ${err}\n`);}})"
+      )
 
 hsStdOut :: Session -> JSVal -> IO LBS.ByteString
 hsStdOut s i = eval s $ toJS i <> ".stdio.stdout()"


### PR DESCRIPTION
`ghc-testsuite` has regressed (~600 failures); the regressed tests would produce an empty `stdout`/`stderr`, and the root cause is the `main` `IO` action in compiled modules haven't been fully executed and returned before we attempt to read `stdout`/`stderr`.