### PR TITLE
Make -DASTERIUS a wired-in CPP flag

### DIFF
--- a/asterius/boot.sh
+++ b/asterius/boot.sh
@@ -17,7 +17,7 @@ cd ..
 
 cd base
 autoreconf -i
-ahc-cabal act-as-setup --build-type=Configure -- configure --prefix=$ASTERIUS_LIB_DIR --package-db=clear --package-db=global --builddir=$ASTERIUS_TMP_DIR/dist/base --with-ghc=$ASTERIUS_AHC --with-ghc-pkg=$ASTERIUS_AHCPKG --with-ar=$ASTERIUS_AR -finteger-simple --ghc-option=-DASTERIUS $ASTERIUS_CONFIGURE_OPTIONS
+ahc-cabal act-as-setup --build-type=Configure -- configure --prefix=$ASTERIUS_LIB_DIR --package-db=clear --package-db=global --builddir=$ASTERIUS_TMP_DIR/dist/base --with-ghc=$ASTERIUS_AHC --with-ghc-pkg=$ASTERIUS_AHCPKG --with-ar=$ASTERIUS_AR -finteger-simple $ASTERIUS_CONFIGURE_OPTIONS
 ahc-cabal act-as-setup --build-type=Configure -- build -j --builddir=$ASTERIUS_TMP_DIR/dist/base
 ahc-cabal act-as-setup --build-type=Configure -- install --builddir=$ASTERIUS_TMP_DIR/dist/base
 cd ..
@@ -61,7 +61,7 @@ ahc-cabal act-as-setup --build-type=Simple -- install --builddir=$ASTERIUS_TMP_D
 cd ..
 
 cd text
-ahc-cabal act-as-setup --build-type=Simple -- configure --prefix=$ASTERIUS_LIB_DIR --package-db=clear --package-db=global --builddir=$ASTERIUS_TMP_DIR/dist/text --with-ghc=$ASTERIUS_AHC --with-ghc-pkg=$ASTERIUS_AHCPKG --with-ar=$ASTERIUS_AR --ghc-option=-DASTERIUS $ASTERIUS_CONFIGURE_OPTIONS
+ahc-cabal act-as-setup --build-type=Simple -- configure --prefix=$ASTERIUS_LIB_DIR --package-db=clear --package-db=global --builddir=$ASTERIUS_TMP_DIR/dist/text --with-ghc=$ASTERIUS_AHC --with-ghc-pkg=$ASTERIUS_AHCPKG --with-ar=$ASTERIUS_AR $ASTERIUS_CONFIGURE_OPTIONS
 ahc-cabal act-as-setup --build-type=Simple -- build -j --builddir=$ASTERIUS_TMP_DIR/dist/text
 ahc-cabal act-as-setup --build-type=Simple -- install --builddir=$ASTERIUS_TMP_DIR/dist/text
 cd ..

--- a/asterius/src/Asterius/Boot.hs
+++ b/asterius/src/Asterius/Boot.hs
@@ -120,6 +120,8 @@ bootRTSCmm BootArgs {..} =
                 "-feager-blackholing",
                 "-dcmm-lint",
                 "-O2",
+                "-DASTERIUS",
+                "-optc=-DASTERIUS",
                 "-I" <> obj_topdir </> "include"
               ]
           }

--- a/asterius/src/Asterius/Boot.hs
+++ b/asterius/src/Asterius/Boot.hs
@@ -120,8 +120,6 @@ bootRTSCmm BootArgs {..} =
                 "-feager-blackholing",
                 "-dcmm-lint",
                 "-O2",
-                "-DASTERIUS",
-                "-optc=-DASTERIUS",
                 "-I" <> obj_topdir </> "include"
               ]
           }

--- a/ghc-toolkit/ghc-libdir/settings
+++ b/ghc-toolkit/ghc-libdir/settings
@@ -4,7 +4,7 @@
  ("C compiler link flags", ""),
  ("C compiler supports -no-pie", "YES"),
  ("Haskell CPP command","gcc"),
- ("Haskell CPP flags","-E -undef -traditional"),
+ ("Haskell CPP flags","-E -undef -traditional -DASTERIUS"),
  ("ld command", "ld"),
  ("ld flags", ""),
  ("ld supports compact unwind", "YES"),
@@ -33,4 +33,3 @@
  ("LLVM opt command", "opt"),
  ("LLVM clang command", "clang")
  ]
-


### PR DESCRIPTION
This PR makes `-DASTERIUS` a wired-in CPP flag for `ahc`. Asterius users shall be able to use the `ASTERIUS` CPP macro to determine whether the current module is being compiled by asterius, without specifying additional flags to `ahc-cabal`, `ahc-link`, etc. Relevant: #722  