### PR TITLE
Fix clock support

### DIFF
--- a/asterius/src/Asterius/CodeGen/Droppable.hs
+++ b/asterius/src/Asterius/CodeGen/Droppable.hs
@@ -8,5 +8,6 @@ where
 import Asterius.Types
 
 ccallResultDroppable :: EntitySymbol -> [ValueType]
-ccallResultDroppable sym | sym == "memset" || sym == "memcpy" = [I64]
+ccallResultDroppable sym
+  | sym `elem` ["memset", "memcpy", "clock_gettime", "clock_getres"] = [I64]
 ccallResultDroppable _ = []


### PR DESCRIPTION
Fixes support for the `clock` package, closes #730. See #452 for more explanation.