### PR TITLE
Remove obsolete EventLogManager dependency on symbolTable

### DIFF
--- a/asterius/rts/rts.eventlog.mjs
+++ b/asterius/rts/rts.eventlog.mjs
@@ -8,8 +8,7 @@ class Event {
 }
 
 export class EventLogManager {
-  constructor(syms) {
-    this.symbolTable = syms;
+  constructor() {
     this.events = [];
     this.enabled = true;
     this.onEvent = () => {};

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -29,7 +29,7 @@ export async function newAsteriusInstance(req) {
       : {},
     __asterius_reentrancy_guard = new ReentrancyGuard(["Scheduler", "GC"]),
     __asterius_fs = new FS(__asterius_components),
-    __asterius_logger = new EventLogManager(req.symbolTable),
+    __asterius_logger = new EventLogManager(),
     __asterius_tracer = new Tracer(__asterius_logger, req.symbolTable),
     __asterius_wasm_instance = null,
     __asterius_wasm_table = new WebAssembly.Table({


### PR DESCRIPTION
AFAICT there is no real need for EventLogManager to depend on the symbol table, and I didn't find any usage of it currently. I believe we should be able to drop this dependency.