### PR TITLE
Fix demo links

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -416,7 +416,13 @@ jobs:
           cd docs
           sphinx-build . _build
 
-          pushd _build
+          mkdir _build/demo
+          pushd _build/demo
+
+          mkdir diagrams
+          pushd diagrams
+          curl -L https://asterius.s3-us-west-2.amazonaws.com/diagrams.tar | tar x
+          popd
 
           mkdir pandoc
           pushd pandoc

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -415,10 +415,26 @@ jobs:
         run: |
           cd docs
           sphinx-build . _build
+
           pushd _build
-          curl -L https://raw.githubusercontent.com/tweag/asterius/examples/ormolu.tar.xz | tar xJ
-          curl -L https://raw.githubusercontent.com/tweag/asterius/examples/pandoc.tar.xz | tar xJ
+
+          mkdir pandoc
+          pushd pandoc
+          curl -L https://asterius.s3-us-west-2.amazonaws.com/pandoc.tar | tar x
           popd
+
+          mkdir ormolu
+          pushd ormolu
+          curl -L https://asterius.s3-us-west-2.amazonaws.com/ormolu.tar | tar x
+          popd
+
+          mkdir todomvc
+          pushd todomvc
+          curl -L https://asterius.s3-us-west-2.amazonaws.com/todomvc.tar | tar x
+          popd
+
+          popd
+
           if [ $GITHUB_REPOSITORY = "tweag/asterius" ]
           then
             if [ $(git rev-parse --abbrev-ref HEAD) = "master" ]

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -393,7 +393,7 @@ jobs:
       - name: setup-python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8.3
+          python-version: 3.8.5
 
       - name: setup-node-14
         uses: actions/setup-node@v2.0.0

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ maintained by [Tweag I/O](https://tweag.io/).
 
 Demos of popular Haskell apps, running in your browser:
 
-- [`diagrams`](https://asterius.netlify.app/demo/diagrams/diagrams.html)
+- [`diagrams`](https://asterius.netlify.app/demo/diagrams/hilbert.html)
 - [`ormolu`](https://asterius.netlify.app/demo/ormolu/WebOrmolu.html)
 - [`pandoc`](https://asterius.netlify.app/demo/pandoc/pandoc.html)
 - [`todomvc`](https://asterius.netlify.app/demo/todomvc/index.html)

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ maintained by [Tweag I/O](https://tweag.io/).
 
 Demos of popular Haskell apps, running in your browser:
 
-- [`ormolu`](https://asterius.netlify.app/ormolu/WebOrmolu.html)
-- [`pandoc`](https://asterius.netlify.app/pandoc/pandoc.html)
-- [`todomvc`](https://asterius.netlify.app/todomvc/index.html)
+- [`diagrams`](https://asterius.netlify.app/demo/diagrams/diagrams.html)
+- [`ormolu`](https://asterius.netlify.app/demo/ormolu/WebOrmolu.html)
+- [`pandoc`](https://asterius.netlify.app/demo/pandoc/pandoc.html)
+- [`todomvc`](https://asterius.netlify.app/demo/todomvc/index.html)
 
 ## Quickstart using the prebuilt container image
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Demos of popular Haskell apps, running in your browser:
 
 - [`ormolu`](https://asterius.netlify.app/ormolu/WebOrmolu.html)
 - [`pandoc`](https://asterius.netlify.app/pandoc/pandoc.html)
+- [`todomvc`](https://asterius.netlify.app/todomvc/index.html)
 
 ## Quickstart using the prebuilt container image
 

--- a/asterius/test/todomvc/index.html
+++ b/asterius/test/todomvc/index.html
@@ -5,8 +5,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>asterius • TodoMVC</title>
-    <link rel="stylesheet" href="node_modules/todomvc-common/base.css">
-    <link rel="stylesheet" href="node_modules/todomvc-app-css/index.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/todomvc-common@1.0.5/base.css" integrity="sha256-XGfdx3G1WLwHtYaVycS39mPSuoE+20gQNBeZxHuggi0=" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/todomvc-app-css@2.3.0/index.css" integrity="sha256-Xty1xPcve0drW/6UL6tCwJQTKVfkyCKSocXp0LLxRFw=" crossorigin="anonymous">
 </head>
 
 <body>
@@ -68,7 +68,7 @@
         <p>Created by <a href="http://todomvc.com">you</a></p>
         <p>Part of <a href="http://todomvc.com">TodoMVC</a></p>
     </footer>
-    <script src="node_modules/todomvc-common/base.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/todomvc-common@1.0.5/base.js" integrity="sha256-hAkHiQIfX4IGgAUD4Yrbw4tf3b+wqEv+NuhuaD2mDCA=" crossorigin="anonymous"></script>
     <script src="todomvc.js"></script>
 </body>
 

--- a/asterius/test/todomvc/package.json
+++ b/asterius/test/todomvc/package.json
@@ -3,5 +3,8 @@
   "dependencies": {
     "todomvc-app-css": "^2.0.0",
     "todomvc-common": "^1.0.0"
-  }
+  },
+  "browserslist": [
+    "last 1 Chrome version"
+  ]
 }


### PR DESCRIPTION
Demos are now built by BuildKite using the latest docker image on the `buildkite-examples` branch. The artifacts are uploaded to our S3 bucket, and the regular CI `docs` job fetch them and deploy them to netlify. The links in `README` is corrected.

Also includes a minor fix for `todomvc`.