### PR TITLE
Allow exported Haskell functions to be called with redundant arguments

### DIFF
--- a/asterius/rts/rts.exports.mjs
+++ b/asterius/rts/rts.exports.mjs
@@ -84,13 +84,13 @@ export class Exports {
     }
     const cb = async (...args) => {
       try {
-        if (args.length !== arg_mk_funcs.length) {
+        if (args.length < arg_mk_funcs.length) {
           throw new WebAssembly.RuntimeError(
             `Expected ${arg_mk_funcs.length} arguments, got ${args.length}`
           );
         }
         let p = this.context.stablePtrManager.deRefStablePtr(sp);
-        for (let i = 0; i < args.length; ++i) {
+        for (let i = 0; i < arg_mk_funcs.length; ++i) {
           p = this.rts_apply(p, arg_mk_funcs[i](args[i]));
         }
         p = this.rts_apply(run_func, p);


### PR DESCRIPTION
When a Haskell function with arity `n` is exported to JavaScript, previously, it must also be called with exactly `n` arguments, otherwise a runtime error will be thrown. This PR lessens the check and allows more than `n` arguments to be passed. The first `n` arguments will be passed to Haskell, and the rest will be ignored.

The rationale for this change: fix an undiscovered break in the `todomvc` example. We used to export a `IO ()` continuation as an event handler, but in JavaScript, all event handlers are passed with an event object parameter. The correct behavior should be simply ignoring that parameter; but after #501 this has been silently broken.

Also includes another fix of `todomvc` due to `JSVal` use-after-free caused by laziness.