### PR TITLE
Misc fixes

### DIFF
--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -22,6 +22,7 @@ module Asterius.Backends.Binaryen
   )
 where
 
+import Asterius.Builtins
 import Asterius.EDSL (addInt64, constI64, extendUInt32)
 import qualified Asterius.Internals.Arena as A
 import Asterius.Internals.Barf
@@ -449,8 +450,7 @@ marshalExpression e = case e of
                   ptr =
                     ConstI32
                       $ fromIntegral
-                      $ (ss_sym_map SM.! "__asterius_pc")
-                        .&. 0xFFFFFFFF,
+                      $ unTag (ss_sym_map SM.! "__asterius_pc"),
                   value = ConstI64 t,
                   valueType = I64
                 }
@@ -490,8 +490,7 @@ marshalExpression e = case e of
               ptr =
                 ConstI32
                   $ fromIntegral
-                  $ (ss_sym_map SM.! "__asterius_pc")
-                    .&. 0xFFFFFFFF,
+                  $ unTag (ss_sym_map SM.! "__asterius_pc"),
               value = returnCallIndirectTarget64,
               valueType = I64
             }
@@ -608,7 +607,7 @@ marshalMemorySegments mbs segs = do
     (seg_sizes, _) <- marshalV a $ map (fromIntegral . BS.length . content) segs
     Binaryen.setMemory
       m
-      (fromIntegral $ mbs * (mblock_size `quot` 65536))
+      (fromIntegral $ mbs * (mblock_size `quot` wasmPageSize))
       (-1)
       nullPtr
       seg_bufs

--- a/asterius/src/Asterius/Backends/WasmToolkit.hs
+++ b/asterius/src/Asterius/Backends/WasmToolkit.hs
@@ -23,6 +23,7 @@ module Asterius.Backends.WasmToolkit
   )
 where
 
+import Asterius.Builtins
 import Asterius.EDSL (addInt64, constI64, extendUInt32)
 import Asterius.Internals.Barf
 import Asterius.Internals.MagicNumber
@@ -35,7 +36,6 @@ import Bag
 import Control.Exception
 import Control.Monad.Except
 import Control.Monad.Reader
-import Data.Bits
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Short as SBS
 import Data.Coerce
@@ -157,7 +157,7 @@ makeImportSection Module {..} ModuleSymbolTable {..} = pure Wasm.ImportSection
                 { minLimit =
                     fromIntegral $
                       memoryMBlocks
-                        * (mblock_size `quot` 65536),
+                        * (mblock_size `quot` wasmPageSize),
                   maxLimit = Nothing
                 }
             }
@@ -726,8 +726,7 @@ makeInstructions expr =
                 ptr =
                   ConstI32
                     $ fromIntegral
-                    $ (ss_sym_map SM.! "__asterius_pc")
-                      .&. 0xFFFFFFFF,
+                    $ unTag (ss_sym_map SM.! "__asterius_pc"),
                 value = ConstI64 t,
                 valueType = I64
               }
@@ -761,8 +760,7 @@ makeInstructions expr =
               ptr =
                 ConstI32
                   $ fromIntegral
-                  $ (ss_sym_map SM.! "__asterius_pc")
-                    .&. 0xFFFFFFFF,
+                  $ unTag (ss_sym_map SM.! "__asterius_pc"),
               value = returnCallIndirectTarget64,
               valueType = I64
             }

--- a/asterius/src/Asterius/Internals/MagicNumber.hs
+++ b/asterius/src/Asterius/Internals/MagicNumber.hs
@@ -2,9 +2,11 @@ module Asterius.Internals.MagicNumber
   ( dataTag,
     functionTag,
     invalidAddress,
+    unTag,
   )
 where
 
+import Data.Bits
 import Data.Int
 
 dataTag :: Int64
@@ -15,3 +17,6 @@ functionTag = 0x00000000001fffed -- 2097133
 
 invalidAddress :: Int64
 invalidAddress = 0x001fffffffff0000
+
+unTag :: Int64 -> Int64
+unTag = (.&. 0xFFFFFFFF)

--- a/asterius/src/Asterius/Passes/DataSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/DataSymbolTable.hs
@@ -8,15 +8,13 @@ module Asterius.Passes.DataSymbolTable
   )
 where
 
+import Asterius.Builtins
 import Asterius.Internals
 import Asterius.Internals.MagicNumber
 import Asterius.Types
 import qualified Asterius.Types.SymbolMap as SM
-import Data.Bits
 import qualified Data.ByteString as BS
 import Data.Foldable
--- import Data.Map.Strict (Map)
--- import qualified Data.Map.Strict as Map
 import Data.Monoid
 import Data.Tuple
 import GHC.Int
@@ -33,9 +31,6 @@ sizeofStatics =
           Serialized buf -> BS.length buf
       )
     . asteriusStatics
-
-unTag :: Int64 -> Int64
-unTag = (.&. 0xFFFFFFFF)
 
 {-# INLINEABLE makeDataSymbolTable #-}
 makeDataSymbolTable ::
@@ -57,7 +52,7 @@ makeMemory ::
 makeMemory AsteriusModule {..} sym_map last_addr =
   ( fromIntegral $
       (fromIntegral (unTag last_addr) `roundup` mblock_size)
-        `quot` 65536,
+        `quot` wasmPageSize,
     SM.foldrWithKey'
       ( \statics_sym ss@AsteriusStatics {..} statics_segs ->
           fst $

--- a/asterius/src/Asterius/Passes/FunctionSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/FunctionSymbolTable.hs
@@ -6,9 +6,9 @@ module Asterius.Passes.FunctionSymbolTable
   )
 where
 
+import Asterius.Internals.MagicNumber
 import Asterius.Types
 import qualified Asterius.Types.SymbolMap as SM
-import Data.Bits
 import Data.Int
 import Data.Tuple
 
@@ -22,5 +22,5 @@ makeFunctionSymbolTable AsteriusModule {..} func_start_addr =
 makeFunctionTable :: SM.SymbolMap Int64 -> Int64 -> FunctionTable
 makeFunctionTable func_sym_map func_start_addr = FunctionTable
   { tableFunctionNames = map entityName $ SM.keys func_sym_map,
-    tableOffset = fromIntegral $ func_start_addr .&. 0xFFFFFFFF
+    tableOffset = fromIntegral $ unTag func_start_addr
   }

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -59,7 +59,7 @@ resolveAsteriusModule debug bundled_ffi_state m_globals_resolved func_start_addr
   where
     (func_sym_map, last_func_addr) =
       makeFunctionSymbolTable m_globals_resolved func_start_addr
-    table_slots = fromIntegral $ last_func_addr .&. 0xFFFFFFFF
+    table_slots = fromIntegral $ unTag last_func_addr
     func_table = makeFunctionTable func_sym_map func_start_addr
     (ss_sym_map, last_data_addr) =
       makeDataSymbolTable m_globals_resolved data_start_addr


### PR DESCRIPTION
* Use existing `wasmPageSize` instead of hard-wiring its constant value.
* Use existing `unTag` instead of hard-wiring its constant value.
* Delete a couple of obsolete comments in `Asterius.Passes.DataSymbolTable`.