### PR TITLE
Simplifications in Asterius.Passes.DataSymbolTable

### DIFF
--- a/asterius/src/Asterius/Passes/DataSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/DataSymbolTable.hs
@@ -8,7 +8,6 @@ module Asterius.Passes.DataSymbolTable
   )
 where
 
-import Asterius.Builtins
 import Asterius.Internals
 import Asterius.Internals.MagicNumber
 import Asterius.Types
@@ -61,17 +60,8 @@ makeSegment off static =
   )
 
 {-# INLINEABLE makeMemory #-}
-makeMemory ::
-  AsteriusModule ->
-  SM.SymbolMap Int64 ->
-  Int64 ->
-  (BinaryenIndex, [DataSegment])
-makeMemory AsteriusModule {..} sym_map last_addr = (initial_page_addr, segments)
-  where
-    initial_page_addr =
-      fromIntegral $
-        (fromIntegral (unTag last_addr) `roundup` mblock_size)
-          `quot` wasmPageSize
-    segments = concat $ SM.elems $ flip SM.mapWithKey staticsMap $ \statics_sym ss ->
-      let initial_offset = fromIntegral $ unTag $ sym_map SM.! statics_sym
-       in catMaybes $ snd $ mapAccumL makeSegment initial_offset $ asteriusStatics ss
+makeMemory :: AsteriusModule -> SM.SymbolMap Int64 -> [DataSegment]
+makeMemory AsteriusModule {..} sym_map =
+  concat $ SM.elems $ flip SM.mapWithKey staticsMap $ \statics_sym ss ->
+    let initial_offset = fromIntegral $ unTag $ sym_map SM.! statics_sym
+     in catMaybes $ snd $ mapAccumL makeSegment initial_offset $ asteriusStatics ss

--- a/asterius/src/Asterius/Passes/DataSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/DataSymbolTable.hs
@@ -56,7 +56,7 @@ makeMemory (staticsMap -> statics) sym_map last_addr = (initial_page_addr, segme
       fromIntegral $
         (fromIntegral (unTag last_addr) `roundup` mblock_size)
           `quot` wasmPageSize
-    fn statics_sym ss@AsteriusStatics {..} statics_segs =
+    fn statics_sym ss statics_segs =
       fst $
         foldr'
           ( \static (static_segs, static_tail_addr) ->
@@ -81,5 +81,5 @@ makeMemory (staticsMap -> statics) sym_map last_addr = (initial_page_addr, segme
           ( statics_segs,
             fromIntegral $ unTag $ sym_map SM.! statics_sym + sizeofStatics ss
           )
-          asteriusStatics
+          (asteriusStatics ss)
     segments = SM.foldrWithKey' fn [] statics

--- a/asterius/src/Asterius/Passes/DataSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/DataSymbolTable.hs
@@ -72,8 +72,6 @@ makeMemory AsteriusModule {..} sym_map last_addr = (initial_page_addr, segments)
       fromIntegral $
         (fromIntegral (unTag last_addr) `roundup` mblock_size)
           `quot` wasmPageSize
-    computeStaticAddrs statics_sym ss =
-      catMaybes $ snd $ mapAccumL makeSegment initial_offset (asteriusStatics ss)
-      where
-        initial_offset = fromIntegral $ unTag $ sym_map SM.! statics_sym
-    segments = concat $ SM.elems $ SM.mapWithKey computeStaticAddrs staticsMap
+    segments = concat $ SM.elems $ flip SM.mapWithKey staticsMap $ \statics_sym ss ->
+      let initial_offset = fromIntegral $ unTag $ sym_map SM.! statics_sym
+       in catMaybes $ snd $ mapAccumL makeSegment initial_offset $ asteriusStatics ss

--- a/asterius/src/Asterius/Passes/DataSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/DataSymbolTable.hs
@@ -49,12 +49,12 @@ makeDataSymbolTable AsteriusModule {..} l =
 
 {-# INLINEABLE makeSegment #-}
 makeSegment :: Int32 -> AsteriusStatic -> (Int32, Maybe DataSegment)
-makeSegment addr static =
-  ( addr + fromIntegral (sizeofStatic static),
+makeSegment off static =
+  ( off + fromIntegral (sizeofStatic static),
     case static of
-      SymbolStatic {} -> Just DataSegment {content = encodeStorable addr, offset = addr}
+      SymbolStatic {} -> Just DataSegment {content = encodeStorable off, offset = off}
       Uninitialized {} -> Nothing
-      Serialized buf -> Just DataSegment {content = buf, offset = addr}
+      Serialized buf -> Just DataSegment {content = buf, offset = off}
   )
 
 {-# INLINEABLE makeMemory #-}
@@ -70,7 +70,7 @@ makeMemory (staticsMap -> statics) sym_map last_addr = (initial_page_addr, segme
         (fromIntegral (unTag last_addr) `roundup` mblock_size)
           `quot` wasmPageSize
     computeStaticAddrs statics_sym ss =
-      catMaybes $ snd $ mapAccumL makeSegment initial_address (asteriusStatics ss)
+      catMaybes $ snd $ mapAccumL makeSegment initial_offset (asteriusStatics ss)
       where
-        initial_address = fromIntegral $ unTag $ sym_map SM.! statics_sym
+        initial_offset = fromIntegral $ unTag $ sym_map SM.! statics_sym
     segments = concat $ SM.elems $ SM.mapWithKey computeStaticAddrs statics

--- a/asterius/src/Asterius/Passes/DataSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/DataSymbolTable.hs
@@ -63,14 +63,7 @@ makeMemory (staticsMap -> statics) sym_map last_addr = (initial_page_addr, segme
               foldr'
                 ( \static (static_segs, static_tail_addr) ->
                     let flush_static_segs buf =
-                          ( case static_segs of
-                              DataSegment {..} : static_segs'
-                                | offset == static_tail_addr ->
-                                  DataSegment {content = buf <> content, offset = static_addr}
-                                    : static_segs'
-                              _ ->
-                                DataSegment {content = buf, offset = static_addr}
-                                  : static_segs,
+                          ( DataSegment {content = buf, offset = static_addr} : static_segs,
                             static_addr
                           )
                           where

--- a/asterius/src/Asterius/Passes/DataSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/DataSymbolTable.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Asterius.Passes.DataSymbolTable
   ( makeDataSymbolTable,
@@ -49,44 +50,46 @@ makeMemory ::
   SM.SymbolMap Int64 ->
   Int64 ->
   (BinaryenIndex, [DataSegment])
-makeMemory AsteriusModule {..} sym_map last_addr =
-  ( fromIntegral $
-      (fromIntegral (unTag last_addr) `roundup` mblock_size)
-        `quot` wasmPageSize,
-    SM.foldrWithKey'
-      ( \statics_sym ss@AsteriusStatics {..} statics_segs ->
-          fst $
-            foldr'
-              ( \static (static_segs, static_tail_addr) ->
-                  let flush_static_segs buf =
-                        ( case static_segs of
-                            DataSegment {..} : static_segs'
-                              | offset == static_tail_addr ->
-                                DataSegment {content = buf <> content, offset = static_addr}
-                                  : static_segs'
-                            _ ->
-                              DataSegment {content = buf, offset = static_addr}
-                                : static_segs,
-                          static_addr
-                        )
-                        where
-                          static_addr = static_tail_addr - fromIntegral (BS.length buf)
-                   in case static of
-                        SymbolStatic sym o ->
-                          flush_static_segs
-                            $ encodeStorable
-                            $ case SM.lookup sym sym_map of
-                              Just addr -> addr + fromIntegral o
-                              _ -> invalidAddress
-                        Uninitialized l ->
-                          (static_segs, static_tail_addr - fromIntegral l)
-                        Serialized buf -> flush_static_segs buf
-              )
-              ( statics_segs,
-                fromIntegral $ unTag $ sym_map SM.! statics_sym + sizeofStatics ss
-              )
-              asteriusStatics
-      )
-      []
-      staticsMap
-  )
+makeMemory (staticsMap -> statics) sym_map last_addr = (initial_page_addr, segments)
+  where
+    initial_page_addr =
+      fromIntegral $
+        (fromIntegral (unTag last_addr) `roundup` mblock_size)
+          `quot` wasmPageSize
+    segments =
+      SM.foldrWithKey'
+        ( \statics_sym ss@AsteriusStatics {..} statics_segs ->
+            fst $
+              foldr'
+                ( \static (static_segs, static_tail_addr) ->
+                    let flush_static_segs buf =
+                          ( case static_segs of
+                              DataSegment {..} : static_segs'
+                                | offset == static_tail_addr ->
+                                  DataSegment {content = buf <> content, offset = static_addr}
+                                    : static_segs'
+                              _ ->
+                                DataSegment {content = buf, offset = static_addr}
+                                  : static_segs,
+                            static_addr
+                          )
+                          where
+                            static_addr = static_tail_addr - fromIntegral (BS.length buf)
+                     in case static of
+                          SymbolStatic sym o ->
+                            flush_static_segs
+                              $ encodeStorable
+                              $ case SM.lookup sym sym_map of
+                                Just addr -> addr + fromIntegral o
+                                _ -> invalidAddress
+                          Uninitialized l ->
+                            (static_segs, static_tail_addr - fromIntegral l)
+                          Serialized buf -> flush_static_segs buf
+                )
+                ( statics_segs,
+                  fromIntegral $ unTag $ sym_map SM.! statics_sym + sizeofStatics ss
+                )
+                asteriusStatics
+        )
+        []
+        statics

--- a/asterius/src/Asterius/Passes/DataSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/DataSymbolTable.hs
@@ -72,7 +72,8 @@ makeMemory (staticsMap -> statics) sym_map last_addr = (initial_page_addr, segme
                         static_addr
                       )
                 Uninitialized l ->
-                  (static_segs, static_tail_addr - fromIntegral l)
+                  let static_addr = static_tail_addr - fromIntegral l
+                   in (static_segs, static_addr)
                 Serialized buf ->
                   let static_addr = static_tail_addr - fromIntegral (BS.length buf)
                    in ( DataSegment {content = buf, offset = static_addr} : static_segs,

--- a/asterius/src/Asterius/Passes/DataSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/DataSymbolTable.hs
@@ -21,16 +21,17 @@ import Data.Tuple
 import GHC.Int
 import Language.Haskell.GHC.Toolkit.Constants
 
+sizeofStatic :: AsteriusStatic -> Int
+sizeofStatic = \case
+  SymbolStatic {} -> 8
+  Uninitialized x -> x
+  Serialized buf -> BS.length buf
+
 sizeofStatics :: AsteriusStatics -> Int64
 sizeofStatics =
   fromIntegral
     . getSum
-    . foldMap
-      ( Sum . \case
-          SymbolStatic {} -> 8
-          Uninitialized x -> x
-          Serialized buf -> BS.length buf
-      )
+    . foldMap (Sum . sizeofStatic)
     . asteriusStatics
 
 {-# INLINEABLE makeDataSymbolTable #-}

--- a/asterius/src/Asterius/Passes/DataSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/DataSymbolTable.hs
@@ -46,6 +46,10 @@ makeDataSymbolTable AsteriusModule {..} l =
       l
       staticsMap
 
+-- | Given the offset of a static and the static itself, compute the
+-- corresponding data segment and the offset of the subsequent static. NOTE: we
+-- do not generate data segments for uninitialized statics; we do not have to
+-- specify each segment and the linear memory is zero-initialized anyway.
 {-# INLINEABLE makeSegment #-}
 makeSegment :: Int32 -> AsteriusStatic -> (Int32, Maybe DataSegment)
 makeSegment off static =

--- a/asterius/src/Asterius/Passes/DataSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/DataSymbolTable.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Asterius.Passes.DataSymbolTable
   ( makeDataSymbolTable,
@@ -63,7 +62,7 @@ makeMemory ::
   SM.SymbolMap Int64 ->
   Int64 ->
   (BinaryenIndex, [DataSegment])
-makeMemory (staticsMap -> statics) sym_map last_addr = (initial_page_addr, segments)
+makeMemory AsteriusModule {..} sym_map last_addr = (initial_page_addr, segments)
   where
     initial_page_addr =
       fromIntegral $
@@ -73,4 +72,4 @@ makeMemory (staticsMap -> statics) sym_map last_addr = (initial_page_addr, segme
       catMaybes $ snd $ mapAccumL makeSegment initial_offset (asteriusStatics ss)
       where
         initial_offset = fromIntegral $ unTag $ sym_map SM.! statics_sym
-    segments = concat $ SM.elems $ SM.mapWithKey computeStaticAddrs statics
+    segments = concat $ SM.elems $ SM.mapWithKey computeStaticAddrs staticsMap

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -68,10 +68,12 @@ resolveAsteriusModule debug bundled_ffi_state m_globals_resolved func_start_addr
       rtsFunctionImports debug <> generateFFIFunctionImports bundled_ffi_state
     new_function_map =
       LM.mapKeys entityName $ SM.toMap $ functionMap m_globals_resolved
-    (initial_pages, segs) =
-      makeMemory m_globals_resolved all_sym_map last_data_addr
+    segs = makeMemory m_globals_resolved all_sym_map
+    initial_pages =
+      (fromIntegral (unTag last_data_addr) `roundup` mblock_size)
+        `quot` wasmPageSize
     initial_mblocks =
-      fromIntegral initial_pages `quot` (mblock_size `quot` wasmPageSize)
+      initial_pages `quot` (mblock_size `quot` wasmPageSize)
     new_mod = Module
       { functionMap' = new_function_map,
         functionImports = func_imports,


### PR DESCRIPTION
This PR simplifies the implementation of `makeMemory`, which creates the `DataSegment`s from `AsteriusStatics` (and computes the offset of each segment). More specifically,

* We get rid of a small optimization that over-complicated the code (merging adjacent data segments into one, if possible). Now each `AsteriusStatic` gives rise to its own `DataSegment` (uninitialized statics do not give rise to data segments, still).
* We compute the data segment offsets left-to-right, as opposed to the previous approach that computed the offsets by subtracting the length of each segment from the offset at its end.
* `makeMemory` no longer computes `initial_pages`; this task is delegated to `resolveAsteriusModule`, where it belongs. This change also eliminates two unnecessary calls to `fromIntegral`.