### PR TITLE
Enable relocatable packages for `ahc-cabal`

### DIFF
--- a/asterius/cabal/config
+++ b/asterius/cabal/config
@@ -27,7 +27,7 @@ library-stripping: False
 tests: False
 coverage: False
 benchmarks: False
-relocatable: False
+relocatable: True
 write-ghc-environment-files: never
 documentation: False
 minimize-conflict-set: True

--- a/asterius/src/Asterius/Boot.hs
+++ b/asterius/src/Asterius/Boot.hs
@@ -64,6 +64,7 @@ defaultBootArgs = BootArgs
        "--disable-split-objs",
        "--disable-split-sections",
        "--disable-library-stripping",
+       "--enable-relocatable",
        "-O2",
        "--ghc-option=-v1",
        "--ghc-option=-dsuppress-ticks"

--- a/asterius/src/Asterius/Boot.hs
+++ b/asterius/src/Asterius/Boot.hs
@@ -15,6 +15,7 @@ import Asterius.Binary.File
 import Asterius.BuildInfo
 import Asterius.Builtins
 import Asterius.CodeGen
+import Asterius.Internals
 import Asterius.Internals.Directory
 import Asterius.Internals.PrettyShow
 import Asterius.Types
@@ -83,16 +84,17 @@ bootCreateProcess args@BootArgs {..} = do
       { cwd = Just dataDir,
         env =
           Just $
-            ("ASTERIUS_BOOT_LIBS_DIR", bootLibsPath)
-              : ("ASTERIUS_SANDBOX_GHC_LIBDIR", sandboxGhcLibDir)
-              : ("ASTERIUS_LIB_DIR", bootDir </> "asterius_lib")
-              : ("ASTERIUS_TMP_DIR", bootTmpDir args)
-              : ("ASTERIUS_AHC", ahc)
-              : ("ASTERIUS_AHCPKG", ahcPkg)
-              : ("ASTERIUS_AR", ahcAr)
-              : ("ASTERIUS_SETUP_GHC_PRIM", setupGhcPrim)
-              : ("ASTERIUS_CONFIGURE_OPTIONS", configureOptions)
-              : [(k, v) | (k, v) <- e, k /= "GHC_PACKAGE_PATH"],
+            kvDedup $
+              ("ASTERIUS_BOOT_LIBS_DIR", bootLibsPath) :
+              ("ASTERIUS_SANDBOX_GHC_LIBDIR", sandboxGhcLibDir) :
+              ("ASTERIUS_LIB_DIR", bootDir </> "asterius_lib") :
+              ("ASTERIUS_TMP_DIR", bootTmpDir args) :
+              ("ASTERIUS_AHC", ahc) :
+              ("ASTERIUS_AHCPKG", ahcPkg) :
+              ("ASTERIUS_AR", ahcAr) :
+              ("ASTERIUS_SETUP_GHC_PRIM", setupGhcPrim) :
+              ("ASTERIUS_CONFIGURE_OPTIONS", configureOptions) :
+                [(k, v) | (k, v) <- e, k /= "GHC_PACKAGE_PATH"],
         delegate_ctlc = True
       }
 

--- a/asterius/src/Asterius/Internals.hs
+++ b/asterius/src/Asterius/Internals.hs
@@ -8,11 +8,13 @@ module Asterius.Internals
     reinterpretCast,
     showBS,
     c8BS,
+    kvDedup,
   )
 where
 
 import qualified Data.ByteString.Internal as BS
 import qualified Data.ByteString.Char8 as CBS
+import qualified Data.Map.Strict as M
 import Foreign
 import GHC.Exts
 import qualified GHC.Types
@@ -48,3 +50,8 @@ showBS = fromString . show
 {-# INLINE c8BS #-}
 c8BS :: BS.ByteString -> String
 c8BS = CBS.unpack
+
+-- | Deduplicate an association list in a left-biased manner; if the same key
+-- appears more than once, the left-most key/value pair is preserved.
+kvDedup :: Ord k => [(k, a)] -> [(k, a)]
+kvDedup = M.toList . M.fromListWith (\_ a -> a)


### PR DESCRIPTION
This PR enables relocatable packages for `ahc-cabal`. Benefits:

* The boot package database will become relocatable. It'll be easy to implement support for switching between multiple boot package databases at runtime, and we can provide the prebuilt stackage packages as a tarball in addition to a full-fledged image. This will shorten the dev feedback cycle considerably.
* For V1-style builds, the result of `getDataDir` will no longer return a hard-coded absolute path; it'll compute the path prefix based on the `getExecutablePath` return value. This makes it possible to support packages which use `data-dirs` in the browser, provided we can transitively collect the data files and serve them via a virtual FS. (V2-style builds don't support this yet)