### PR TITLE
Wasm implementations of hs_bswap and ntohs functions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -136,7 +136,7 @@ jobs:
 
           stack test asterius:argv --test-arguments="--backend=$ASTERIUS_BACKEND"
 
-          stack test asterius:endianness
+          stack test asterius:endianness --test-arguments="--backend=$ASTERIUS_BACKEND"
 
   ghc-testsuite:
     name: ghc-testsuite

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -136,6 +136,8 @@ jobs:
 
           stack test asterius:argv --test-arguments="--backend=$ASTERIUS_BACKEND"
 
+          stack test asterius:endianness
+
   ghc-testsuite:
     name: ghc-testsuite
     needs: boot

--- a/asterius/package.yaml
+++ b/asterius/package.yaml
@@ -40,6 +40,7 @@ extra-source-files:
   - test/time/**/*.hs
   - test/primitive/**/*.hs
   - test/argv/**/*.hs
+  - test/endianness/**/*.hs
 
 data-files:
   - cabal/**
@@ -343,6 +344,13 @@ tests:
   argv:
     source-dirs: test
     main: argv.hs
+    ghc-options: *exe-ghc-options
+    dependencies:
+      - asterius
+
+  endianness:
+    source-dirs: test
+    main: endianness.hs
     ghc-options: *exe-ghc-options
     dependencies:
       - asterius

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -21,6 +21,7 @@ where
 
 import Asterius.Builtins.Blackhole
 import Asterius.Builtins.CMath
+import Asterius.Builtins.Endianness
 import Asterius.Builtins.Env
 import Asterius.Builtins.Exports
 import Asterius.Builtins.Hashable
@@ -198,6 +199,7 @@ rtsAsteriusModule opts =
     <> timeCBits
     <> primitiveCBits
     <> mathCBits
+    <> endiannessCBits
 
 -- Generate the module consisting of functions which need to be wrapped
 -- for communication with the external runtime.

--- a/asterius/src/Asterius/Builtins/Endianness.hs
+++ b/asterius/src/Asterius/Builtins/Endianness.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      :  Asterius.Builtins.Endianness
+-- Copyright   :  (c) 2018 EURL Tweag
+-- License     :  All rights reserved (see LICENCE file in the distribution).
+--
+-- Wasm implementations of conversions between host and network byte order
+-- (@htonl@, @htons@, @ntohl@, and @ntohs@). Network byte order is always Most
+-- Significant Byte first (big endian). On i386 the host byte order is Least
+-- Significant Byte first (little endian), which we assume always as the host
+-- byte order.
+module Asterius.Builtins.Endianness
+  ( endiannessCBits,
+  )
+where
+
+import Asterius.EDSL
+import Asterius.Types
+
+endiannessCBits :: AsteriusModule
+-- endiannessCBits = mempty -- htonl <> htons <> ntohl <> ntohs
+endiannessCBits = htonl <> htons <> ntohl <> ntohs
+
+-- | @uint32_t htonl(uint32_t hostlong);@
+htonl :: AsteriusModule
+htonl = runEDSL "htonl" $ do
+  setReturnTypes [I64]
+  hostlong <- param I64
+  emit $ byteSwap32 hostlong
+
+-- | @uint16_t htons(uint16_t hostshort);@
+htons :: AsteriusModule
+htons = runEDSL "htons" $ do
+  setReturnTypes [I64]
+  hostshort <- param I64
+  emit $ byteSwap16 hostshort
+
+-- | @uint32_t ntohl(uint32_t netlong);@
+ntohl :: AsteriusModule
+ntohl = runEDSL "ntohl" $ do
+  setReturnTypes [I64]
+  netlong <- param I64
+  emit $ byteSwap32 netlong
+
+-- | @uint16_t ntohs(uint16_t netshort);@
+ntohs :: AsteriusModule
+ntohs = runEDSL "ntohs" $ do
+  setReturnTypes [I64]
+  netshort <- param I64
+  emit $ byteSwap16 netshort
+
+byteSwap16 :: Expression -> Expression
+byteSwap16 n = msb `orInt64` lsb
+  where
+    msb = (n `andInt64` constI64 0xFF) `shlInt64` constI64 8
+    lsb = (n `shrUInt64` constI64 8) `andInt64` constI64 0xFF
+
+byteSwap32 :: Expression -> Expression
+byteSwap32 n = byte1 `orInt64` byte2 `orInt64` byte3 `orInt64` byte4
+  where
+    byte1 = (n `andInt64` constI64 0xFF) `shlInt64` constI64 24
+    byte2 = (n `andInt64` constI64 0xFF00) `shlInt64` constI64 8
+    byte3 = (n `andInt64` constI64 0xFF0000) `shrUInt64` constI64 8
+    byte4 = (n `andInt64` constI64 0xFF000000) `shrUInt64` constI64 24

--- a/asterius/src/Asterius/Builtins/Endianness.hs
+++ b/asterius/src/Asterius/Builtins/Endianness.hs
@@ -9,9 +9,6 @@
 -- (big-endian) byte order: @htonl@, @htons@, @ntohl@, and @ntohs@.
 module Asterius.Builtins.Endianness
   ( endiannessCBits,
-    byteSwap16,
-    byteSwap32,
-    byteSwap64,
   )
 where
 
@@ -19,7 +16,8 @@ import Asterius.EDSL
 import Asterius.Types
 
 endiannessCBits :: AsteriusModule
-endiannessCBits = hs_bswap16 <> hs_bswap32 <> hs_bswap64 <> htonl <> htons <> ntohl <> ntohs
+endiannessCBits =
+  hs_bswap16 <> hs_bswap32 <> hs_bswap64 <> htonl <> htons <> ntohl <> ntohs
 
 -- ----------------------------------------------------------------------------
 

--- a/asterius/src/Asterius/Builtins/Endianness.hs
+++ b/asterius/src/Asterius/Builtins/Endianness.hs
@@ -5,8 +5,9 @@
 -- Copyright   :  (c) 2018 EURL Tweag
 -- License     :  All rights reserved (see LICENCE file in the distribution).
 --
--- Wasm implementations of conversions between host (little-endian) and network
--- (big-endian) byte order: @htonl@, @htons@, @ntohl@, and @ntohs@.
+-- Wasm implementations of byte-swapping functions (@hs_bswap16@, @hs_bswap32@,
+-- and @hs_bswap64@), and conversions between host (little-endian) and network
+-- (big-endian) byte order (@htonl@, @htons@, @ntohl@, and @ntohs@).
 module Asterius.Builtins.Endianness
   ( endiannessCBits,
   )

--- a/asterius/src/Asterius/Builtins/Endianness.hs
+++ b/asterius/src/Asterius/Builtins/Endianness.hs
@@ -51,15 +51,13 @@ ntohs = runEDSL "ntohs" $ do
   emit $ byteSwap16 netshort
 
 byteSwap16 :: Expression -> Expression
-byteSwap16 n = msb `orInt64` lsb
-  where
-    msb = (n `andInt64` constI64 0xFF) `shlInt64` constI64 8
-    lsb = (n `shrUInt64` constI64 8) `andInt64` constI64 0xFF
+byteSwap16 n =
+  ((n `andInt64` constI64 0xFF) `shlInt64` constI64 8)
+    `orInt64` ((n `shrUInt64` constI64 8) `andInt64` constI64 0xFF)
 
 byteSwap32 :: Expression -> Expression
-byteSwap32 n = byte1 `orInt64` byte2 `orInt64` byte3 `orInt64` byte4
-  where
-    byte1 = (n `andInt64` constI64 0xFF) `shlInt64` constI64 24
-    byte2 = (n `andInt64` constI64 0xFF00) `shlInt64` constI64 8
-    byte3 = (n `andInt64` constI64 0xFF0000) `shrUInt64` constI64 8
-    byte4 = (n `andInt64` constI64 0xFF000000) `shrUInt64` constI64 24
+byteSwap32 n =
+  ((n `andInt64` constI64 0xFF) `shlInt64` constI64 24)
+    `orInt64` ((n `andInt64` constI64 0xFF00) `shlInt64` constI64 8)
+    `orInt64` ((n `andInt64` constI64 0xFF0000) `shrUInt64` constI64 8)
+    `orInt64` ((n `andInt64` constI64 0xFF000000) `shrUInt64` constI64 24)

--- a/asterius/src/Asterius/Builtins/Endianness.hs
+++ b/asterius/src/Asterius/Builtins/Endianness.hs
@@ -5,11 +5,8 @@
 -- Copyright   :  (c) 2018 EURL Tweag
 -- License     :  All rights reserved (see LICENCE file in the distribution).
 --
--- Wasm implementations of conversions between host and network byte order
--- (@htonl@, @htons@, @ntohl@, and @ntohs@). Network byte order is always Most
--- Significant Byte first (big endian). On i386 the host byte order is Least
--- Significant Byte first (little endian), which we assume always as the host
--- byte order.
+-- Wasm implementations of conversions between host (little-endian) and network
+-- (big-endian) byte order: @htonl@, @htons@, @ntohl@, and @ntohs@.
 module Asterius.Builtins.Endianness
   ( endiannessCBits,
   )

--- a/asterius/src/Asterius/Builtins/Endianness.hs
+++ b/asterius/src/Asterius/Builtins/Endianness.hs
@@ -16,8 +16,8 @@ import Asterius.EDSL
 import Asterius.Types
 
 endiannessCBits :: AsteriusModule
--- endiannessCBits = mempty -- htonl <> htons <> ntohl <> ntohs
-endiannessCBits = htonl <> htons <> ntohl <> ntohs
+endiannessCBits = mempty
+-- endiannessCBits = htonl <> htons <> ntohl <> ntohs
 
 -- | @uint32_t htonl(uint32_t hostlong);@
 htonl :: AsteriusModule

--- a/asterius/src/Asterius/Builtins/Endianness.hs
+++ b/asterius/src/Asterius/Builtins/Endianness.hs
@@ -16,8 +16,7 @@ import Asterius.EDSL
 import Asterius.Types
 
 endiannessCBits :: AsteriusModule
-endiannessCBits = mempty
--- endiannessCBits = htonl <> htons <> ntohl <> ntohs
+endiannessCBits = htonl <> htons <> ntohl <> ntohs
 
 -- | @uint32_t htonl(uint32_t hostlong);@
 htonl :: AsteriusModule

--- a/asterius/src/Asterius/Builtins/Endianness.hs
+++ b/asterius/src/Asterius/Builtins/Endianness.hs
@@ -19,35 +19,62 @@ import Asterius.EDSL
 import Asterius.Types
 
 endiannessCBits :: AsteriusModule
-endiannessCBits = htonl <> htons <> ntohl <> ntohs
+endiannessCBits = hs_bswap16 <> hs_bswap32 <> hs_bswap64 <> htonl <> htons <> ntohl <> ntohs
+
+-- ----------------------------------------------------------------------------
 
 -- | @uint32_t htonl(uint32_t hostlong);@
 htonl :: AsteriusModule
 htonl = runEDSL "htonl" $ do
   setReturnTypes [I64]
   hostlong <- param I64
-  emit $ byteSwap32 hostlong
+  call' "hs_bswap32" [hostlong] I64 >>= emit
 
 -- | @uint16_t htons(uint16_t hostshort);@
 htons :: AsteriusModule
 htons = runEDSL "htons" $ do
   setReturnTypes [I64]
   hostshort <- param I64
-  emit $ byteSwap16 hostshort
+  call' "hs_bswap16" [hostshort] I64 >>= emit
 
 -- | @uint32_t ntohl(uint32_t netlong);@
 ntohl :: AsteriusModule
 ntohl = runEDSL "ntohl" $ do
   setReturnTypes [I64]
   netlong <- param I64
-  emit $ byteSwap32 netlong
+  call' "hs_bswap32" [netlong] I64 >>= emit
 
 -- | @uint16_t ntohs(uint16_t netshort);@
 ntohs :: AsteriusModule
 ntohs = runEDSL "ntohs" $ do
   setReturnTypes [I64]
   netshort <- param I64
-  emit $ byteSwap16 netshort
+  call' "hs_bswap16" [netshort] I64 >>= emit
+
+-- ----------------------------------------------------------------------------
+
+-- | @extern StgWord16 hs_bswap16(StgWord16 x);@
+hs_bswap16 :: AsteriusModule
+hs_bswap16 = runEDSL "hs_bswap16" $ do
+  setReturnTypes [I64]
+  x <- param I64
+  emit $ byteSwap16 x
+
+-- | @extern StgWord32 hs_bswap32(StgWord32 x);@
+hs_bswap32 :: AsteriusModule
+hs_bswap32 = runEDSL "hs_bswap32" $ do
+  setReturnTypes [I64]
+  x <- param I64
+  emit $ byteSwap32 x
+
+-- | @extern StgWord64 hs_bswap64(StgWord64 x);@
+hs_bswap64 :: AsteriusModule
+hs_bswap64 = runEDSL "hs_bswap64" $ do
+  setReturnTypes [I64]
+  x <- param I64
+  emit $ byteSwap64 x
+
+-- ----------------------------------------------------------------------------
 
 byteSwap16 :: Expression -> Expression
 byteSwap16 n = msb `orInt64` lsb

--- a/asterius/src/Asterius/Builtins/Endianness.hs
+++ b/asterius/src/Asterius/Builtins/Endianness.hs
@@ -9,6 +9,9 @@
 -- (big-endian) byte order: @htonl@, @htons@, @ntohl@, and @ntohs@.
 module Asterius.Builtins.Endianness
   ( endiannessCBits,
+    byteSwap16,
+    byteSwap32,
+    byteSwap64,
   )
 where
 
@@ -47,13 +50,35 @@ ntohs = runEDSL "ntohs" $ do
   emit $ byteSwap16 netshort
 
 byteSwap16 :: Expression -> Expression
-byteSwap16 n =
-  ((n `andInt64` constI64 0xFF) `shlInt64` constI64 8)
-    `orInt64` ((n `shrUInt64` constI64 8) `andInt64` constI64 0xFF)
+byteSwap16 n = msb `orInt64` lsb
+  where
+    msb = (n `andInt64` constI64 0xFF) `shlInt64` constI64 8
+    lsb = (n `shrUInt64` constI64 8) `andInt64` constI64 0xFF
 
 byteSwap32 :: Expression -> Expression
-byteSwap32 n =
-  ((n `andInt64` constI64 0xFF) `shlInt64` constI64 24)
-    `orInt64` ((n `andInt64` constI64 0xFF00) `shlInt64` constI64 8)
-    `orInt64` ((n `andInt64` constI64 0xFF0000) `shrUInt64` constI64 8)
-    `orInt64` ((n `andInt64` constI64 0xFF000000) `shrUInt64` constI64 24)
+byteSwap32 n = byte1 `orInt64` byte2 `orInt64` byte3 `orInt64` byte4
+  where
+    byte1 = (n `andInt64` constI64 0xFF) `shlInt64` constI64 24
+    byte2 = (n `andInt64` constI64 0xFF00) `shlInt64` constI64 8
+    byte3 = (n `andInt64` constI64 0xFF0000) `shrUInt64` constI64 8
+    byte4 = (n `andInt64` constI64 0xFF000000) `shrUInt64` constI64 24
+
+byteSwap64 :: Expression -> Expression
+byteSwap64 n =
+  byte1
+    `orInt64` byte2
+    `orInt64` byte3
+    `orInt64` byte4
+    `orInt64` byte5
+    `orInt64` byte6
+    `orInt64` byte7
+    `orInt64` byte8
+  where
+    byte1 = (n `andInt64` constI64 0xFF) `shlInt64` constI64 56
+    byte2 = (n `andInt64` constI64 0xFF00) `shlInt64` constI64 40
+    byte3 = (n `andInt64` constI64 0xFF0000) `shlInt64` constI64 24
+    byte4 = (n `andInt64` constI64 0xFF000000) `shlInt64` constI64 8
+    byte5 = (n `andInt64` constI64 0xFF00000000) `shrUInt64` constI64 8
+    byte6 = (n `andInt64` constI64 0xFF0000000000) `shrUInt64` constI64 24
+    byte7 = (n `andInt64` constI64 0xFF000000000000) `shrUInt64` constI64 40
+    byte8 = (n `andInt64` constI64 0xFF00000000000000) `shrUInt64` constI64 56

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -18,7 +18,6 @@ module Asterius.CodeGen
 where
 
 import Asterius.Builtins
-import qualified Asterius.Builtins.Endianness as Endianness
 import Asterius.CodeGen.Droppable
 import Asterius.EDSL
 import Asterius.Internals
@@ -1245,30 +1244,42 @@ marshalCmmPrimCall (GHC.MO_Ctz GHC.W8) [r] [x] =
     (extendSInt32 . ctzInt32 . orInt32 (constI32 0x100))
 -- Unhandled: MO_BSwap W8
 marshalCmmPrimCall (GHC.MO_BSwap GHC.W16) [r] [x] = do
-  dstr <- marshalTypedCmmLocalReg r I64
+  lr <- marshalTypedCmmLocalReg r I64
   xe <- marshalAndCastCmmExpr x I64
   pure
     [ UnresolvedSetLocal
-        { unresolvedLocalReg = dstr,
-          value = Endianness.byteSwap16 xe
+        { unresolvedLocalReg = lr,
+          value = Call
+            { target = "hs_bswap16",
+              operands = [xe],
+              callReturnTypes = [I64]
+            }
         }
     ]
 marshalCmmPrimCall (GHC.MO_BSwap GHC.W32) [r] [x] = do
-  dstr <- marshalTypedCmmLocalReg r I64
+  lr <- marshalTypedCmmLocalReg r I64
   xe <- marshalAndCastCmmExpr x I64
   pure
     [ UnresolvedSetLocal
-        { unresolvedLocalReg = dstr,
-          value = Endianness.byteSwap32 xe
+        { unresolvedLocalReg = lr,
+          value = Call
+            { target = "hs_bswap32",
+              operands = [xe],
+              callReturnTypes = [I64]
+            }
         }
     ]
 marshalCmmPrimCall (GHC.MO_BSwap GHC.W64) [r] [x] = do
-  dstr <- marshalTypedCmmLocalReg r I64
+  lr <- marshalTypedCmmLocalReg r I64
   xe <- marshalAndCastCmmExpr x I64
   pure
     [ UnresolvedSetLocal
-        { unresolvedLocalReg = dstr,
-          value = Endianness.byteSwap64 xe
+        { unresolvedLocalReg = lr,
+          value = Call
+            { target = "hs_bswap64",
+              operands = [xe],
+              callReturnTypes = [I64]
+            }
         }
     ]
 -- Atomic operations

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -849,111 +849,133 @@ marshalCmmPrimCall (GHC.MO_U_QuotRem w) [qr, rr] [x, y] =
           x
           y
       )
--- See also: QuotRemWord2#
-marshalCmmPrimCall (GHC.MO_U_QuotRem2 GHC.W64) [q, r] [lhsHi, lhsLo, rhs] = do
-  quotr <- marshalTypedCmmLocalReg q I64
-  remr <- marshalTypedCmmLocalReg r I64
-  (lhsHir, _) <- marshalCmmExpr lhsHi
-  (lhsLor, _) <- marshalCmmExpr lhsLo
-  (rhsr, _) <- marshalCmmExpr rhs
-  -- Smash the high and low 32 bits together to create a 64 bit
-  -- number.
-  let smash32IntTo64 hi32 lo32 =
-        Binary
-          OrInt64
-          (Binary ShlInt64 (Unary ExtendUInt32 hi32) (ConstI64 32))
-          (Unary ExtendUInt32 lo32)
-  -- mask the `n32`th block of v, counting blocks from the lowest bit.
-  let mask32 v n32 =
-        Unary WrapInt64 $
-          Binary
-            AndInt64
-            (Binary ShrUInt64 v (ConstI64 (n32 * 32)))
-            (ConstI64 0xFFFFFFFF)
-  let quotout = UnresolvedSetLocal
-        { unresolvedLocalReg = quotr,
-          value = smash32IntTo64
-            CallImport
-              { target' = "__asterius_quotrem2_quotient",
-                operands =
-                  [ mask32 lhsHir 1,
-                    mask32 lhsHir 0,
-                    mask32 lhsLor 1,
-                    mask32 lhsLor 0,
-                    mask32 rhsr 1,
-                    mask32 rhsr 0,
-                    ConstI32 1
-                  ],
-                callImportReturnTypes = [I32]
-              }
-            CallImport
-              { target' = "__asterius_quotrem2_quotient",
-                operands =
-                  [ mask32 lhsHir 1,
-                    mask32 lhsHir 0,
-                    mask32 lhsLor 1,
-                    mask32 lhsLor 0,
-                    mask32 rhsr 1,
-                    mask32 rhsr 0,
-                    ConstI32 0
-                  ],
-                callImportReturnTypes = [I32]
-              }
+marshalCmmPrimCall GHC.MO_WriteBarrier _ _ = pure []
+marshalCmmPrimCall GHC.MO_Touch _ _ = pure []
+marshalCmmPrimCall (GHC.MO_Prefetch_Data _) _ _ = pure []
+marshalCmmPrimCall (GHC.MO_Memcpy _) [] [_dst, _src, _n] = do
+  dst <- marshalAndCastCmmExpr _dst F64
+  src <- marshalAndCastCmmExpr _src F64
+  n <- marshalAndCastCmmExpr _n F64
+  pure
+    [ CallImport
+        { target' = "__asterius_memcpy",
+          operands = [dst, src, n],
+          callImportReturnTypes = []
         }
-  let remout = UnresolvedSetLocal
-        { unresolvedLocalReg = remr,
-          value = smash32IntTo64
-            CallImport
-              { target' = "__asterius_quotrem2_remainder",
-                operands =
-                  [ mask32 lhsHir 1,
-                    mask32 lhsHir 0,
-                    mask32 lhsLor 1,
-                    mask32 lhsLor 0,
-                    mask32 rhsr 1,
-                    mask32 rhsr 0,
-                    ConstI32 1
-                  ],
-                callImportReturnTypes = [I32]
-              }
-            CallImport
-              { target' = "__asterius_quotrem2_remainder",
-                operands =
-                  [ mask32 lhsHir 1,
-                    mask32 lhsHir 0,
-                    mask32 lhsLor 1,
-                    mask32 lhsLor 0,
-                    mask32 rhsr 1,
-                    mask32 rhsr 0,
-                    ConstI32 0
-                  ],
-                callImportReturnTypes = [I32]
-              }
+    ]
+marshalCmmPrimCall (GHC.MO_Memset _) [] [_dst, _c, _n] = do
+  dst <- marshalAndCastCmmExpr _dst F64
+  c <- marshalAndCastCmmExpr _c F64
+  n <- marshalAndCastCmmExpr _n F64
+  pure
+    [ CallImport
+        { target' = "__asterius_memset",
+          operands = [dst, c, n],
+          callImportReturnTypes = []
         }
-  pure [quotout, remout]
--- See also: GHC.Prim.plusWord2
--- add unsigned: return (carry, result)
-marshalCmmPrimCall (GHC.MO_Add2 GHC.W64) [o, r] [x, y] = do
+    ]
+marshalCmmPrimCall (GHC.MO_Memmove _) [] [_dst, _src, _n] = do
+  dst <- marshalAndCastCmmExpr _dst F64
+  src <- marshalAndCastCmmExpr _src F64
+  n <- marshalAndCastCmmExpr _n F64
+  pure
+    [ CallImport
+        { target' = "__asterius_memmove",
+          operands = [dst, src, n],
+          callImportReturnTypes = []
+        }
+    ]
+marshalCmmPrimCall (GHC.MO_Memcmp _) [_cres] [_ptr1, _ptr2, _n] = do
+  cres <- marshalTypedCmmLocalReg _cres I32
+  ptr1 <- marshalAndCastCmmExpr _ptr1 F64
+  ptr2 <- marshalAndCastCmmExpr _ptr2 F64
+  n <- marshalAndCastCmmExpr _n F64
+  pure
+    [ UnresolvedSetLocal
+        { unresolvedLocalReg = cres,
+          value = CallImport
+            { target' = "__asterius_memcmp",
+              operands = [ptr1, ptr2, n],
+              callImportReturnTypes = [I32]
+            }
+        }
+    ]
+marshalCmmPrimCall (GHC.MO_PopCnt GHC.W64) [r] [x] =
+  marshalCmmUnPrimCall I64 r I64 x popcntInt64
+marshalCmmPrimCall (GHC.MO_PopCnt GHC.W32) [r] [x] = do
+  marshalCmmUnPrimCall I64 r I32 x (extendSInt32 . popcntInt32)
+marshalCmmPrimCall (GHC.MO_PopCnt GHC.W16) [r] [x] = do
+  marshalCmmUnPrimCall
+    I64
+    r
+    I32
+    x
+    (extendSInt32 . popcntInt32 . andInt32 (constI32 0xFFFF))
+marshalCmmPrimCall (GHC.MO_PopCnt GHC.W8) [r] [x] = do
+  marshalCmmUnPrimCall
+    I64
+    r
+    I32
+    x
+    (extendSInt32 . popcntInt32 . andInt32 (constI32 0xFF))
+-- Unhandled: MO_Pdep Width
+-- Unhandled: MO_Pext Width
+marshalCmmPrimCall (GHC.MO_Clz GHC.W64) [r] [x] =
+  marshalCmmUnPrimCall I64 r I64 x clzInt64
+marshalCmmPrimCall (GHC.MO_Clz GHC.W32) [r] [x] =
+  marshalCmmUnPrimCall I64 r I32 x (extendSInt32 . clzInt32)
+marshalCmmPrimCall (GHC.MO_Clz GHC.W16) [r] [x] =
+  marshalCmmUnPrimCall
+    I64
+    r
+    I32
+    x
+    ( extendSInt32
+        . clzInt32
+        . orInt32 (constI32 0x8000)
+        . (`shlInt32` constI32 16)
+    )
+marshalCmmPrimCall (GHC.MO_Clz GHC.W8) [r] [x] =
+  marshalCmmUnPrimCall
+    I64
+    r
+    I32
+    x
+    ( extendSInt32
+        . clzInt32
+        . orInt32 (constI32 0x800000)
+        . (`shlInt32` constI32 24)
+    )
+marshalCmmPrimCall (GHC.MO_Ctz GHC.W64) [r] [x] =
+  marshalCmmUnPrimCall I64 r I64 x ctzInt64
+marshalCmmPrimCall (GHC.MO_Ctz GHC.W32) [r] [x] =
+  marshalCmmUnPrimCall I64 r I32 x (extendSInt32 . ctzInt32)
+marshalCmmPrimCall (GHC.MO_Ctz GHC.W16) [r] [x] =
+  marshalCmmUnPrimCall
+    I64
+    r
+    I32
+    x
+    (extendSInt32 . ctzInt32 . orInt32 (constI32 0x10000))
+marshalCmmPrimCall (GHC.MO_Ctz GHC.W8) [r] [x] =
+  marshalCmmUnPrimCall
+    I64
+    r
+    I32
+    x
+    (extendSInt32 . ctzInt32 . orInt32 (constI32 0x100))
+-- r = result, o = overflow
+-- see also: GHC.Prim.subWordC#
+marshalCmmPrimCall (GHC.MO_SubWordC GHC.W64) [r, o] [x, y] = do
   (xr, _) <- marshalCmmExpr x
   (yr, _) <- marshalCmmExpr y
   lr <- marshalTypedCmmLocalReg r I64
-  -- y + x > maxbound
-  -- y > maxbound - x
   lo <- marshalTypedCmmLocalReg o I64
-  let x_plus_y = Binary {binaryOp = AddInt64, operand0 = xr, operand1 = yr}
-  let x_minus_maxbound = Binary
-        { binaryOp = SubInt64,
-          operand0 = ConstI64 0xFFFFFFFFFFFFFFFF,
-          operand1 = xr
-        }
-  let overflow = Binary
-        { binaryOp = GtUInt64,
-          operand0 = yr,
-          operand1 = x_minus_maxbound
-        }
+  let x_minus_y = Binary {binaryOp = SubInt64, operand0 = xr, operand1 = yr}
+  let overflow = Binary {binaryOp = LtUInt64, operand0 = xr, operand1 = yr}
   let overflow_sext = Unary {unaryOp = ExtendUInt32, operand0 = overflow}
   pure
-    [ UnresolvedSetLocal {unresolvedLocalReg = lr, value = x_plus_y},
+    [ UnresolvedSetLocal {unresolvedLocalReg = lr, value = x_minus_y},
       UnresolvedSetLocal {unresolvedLocalReg = lo, value = overflow_sext}
     ]
 -- r = result, o = overflow
@@ -982,18 +1004,29 @@ marshalCmmPrimCall (GHC.MO_AddWordC GHC.W64) [r, o] [x, y] = do
     [ UnresolvedSetLocal {unresolvedLocalReg = lr, value = x_plus_y},
       UnresolvedSetLocal {unresolvedLocalReg = lo, value = overflow_sext}
     ]
--- r = result, o = overflow
--- see also: GHC.Prim.subWordC#
-marshalCmmPrimCall (GHC.MO_SubWordC GHC.W64) [r, o] [x, y] = do
+-- See also: GHC.Prim.plusWord2
+-- add unsigned: return (carry, result)
+marshalCmmPrimCall (GHC.MO_Add2 GHC.W64) [o, r] [x, y] = do
   (xr, _) <- marshalCmmExpr x
   (yr, _) <- marshalCmmExpr y
   lr <- marshalTypedCmmLocalReg r I64
+  -- y + x > maxbound
+  -- y > maxbound - x
   lo <- marshalTypedCmmLocalReg o I64
-  let x_minus_y = Binary {binaryOp = SubInt64, operand0 = xr, operand1 = yr}
-  let overflow = Binary {binaryOp = LtUInt64, operand0 = xr, operand1 = yr}
+  let x_plus_y = Binary {binaryOp = AddInt64, operand0 = xr, operand1 = yr}
+  let x_minus_maxbound = Binary
+        { binaryOp = SubInt64,
+          operand0 = ConstI64 0xFFFFFFFFFFFFFFFF,
+          operand1 = xr
+        }
+  let overflow = Binary
+        { binaryOp = GtUInt64,
+          operand0 = yr,
+          operand1 = x_minus_maxbound
+        }
   let overflow_sext = Unary {unaryOp = ExtendUInt32, operand0 = overflow}
   pure
-    [ UnresolvedSetLocal {unresolvedLocalReg = lr, value = x_minus_y},
+    [ UnresolvedSetLocal {unresolvedLocalReg = lr, value = x_plus_y},
       UnresolvedSetLocal {unresolvedLocalReg = lo, value = overflow_sext}
     ]
 -- See also: GHC.Prim.addIntC#
@@ -1127,121 +1160,88 @@ marshalCmmPrimCall (GHC.MO_U_Mul2 GHC.W64) [hi, lo] [x, y] = do
               }
         }
   pure [hiout, loout]
-marshalCmmPrimCall GHC.MO_WriteBarrier _ _ = pure []
-marshalCmmPrimCall GHC.MO_Touch _ _ = pure []
-marshalCmmPrimCall (GHC.MO_Prefetch_Data _) _ _ = pure []
-marshalCmmPrimCall (GHC.MO_Memcpy _) [] [_dst, _src, _n] = do
-  dst <- marshalAndCastCmmExpr _dst F64
-  src <- marshalAndCastCmmExpr _src F64
-  n <- marshalAndCastCmmExpr _n F64
-  pure
-    [ CallImport
-        { target' = "__asterius_memcpy",
-          operands = [dst, src, n],
-          callImportReturnTypes = []
+-- See also: QuotRemWord2#
+marshalCmmPrimCall (GHC.MO_U_QuotRem2 GHC.W64) [q, r] [lhsHi, lhsLo, rhs] = do
+  quotr <- marshalTypedCmmLocalReg q I64
+  remr <- marshalTypedCmmLocalReg r I64
+  (lhsHir, _) <- marshalCmmExpr lhsHi
+  (lhsLor, _) <- marshalCmmExpr lhsLo
+  (rhsr, _) <- marshalCmmExpr rhs
+  -- Smash the high and low 32 bits together to create a 64 bit
+  -- number.
+  let smash32IntTo64 hi32 lo32 =
+        Binary
+          OrInt64
+          (Binary ShlInt64 (Unary ExtendUInt32 hi32) (ConstI64 32))
+          (Unary ExtendUInt32 lo32)
+  -- mask the `n32`th block of v, counting blocks from the lowest bit.
+  let mask32 v n32 =
+        Unary WrapInt64 $
+          Binary
+            AndInt64
+            (Binary ShrUInt64 v (ConstI64 (n32 * 32)))
+            (ConstI64 0xFFFFFFFF)
+  let quotout = UnresolvedSetLocal
+        { unresolvedLocalReg = quotr,
+          value = smash32IntTo64
+            CallImport
+              { target' = "__asterius_quotrem2_quotient",
+                operands =
+                  [ mask32 lhsHir 1,
+                    mask32 lhsHir 0,
+                    mask32 lhsLor 1,
+                    mask32 lhsLor 0,
+                    mask32 rhsr 1,
+                    mask32 rhsr 0,
+                    ConstI32 1
+                  ],
+                callImportReturnTypes = [I32]
+              }
+            CallImport
+              { target' = "__asterius_quotrem2_quotient",
+                operands =
+                  [ mask32 lhsHir 1,
+                    mask32 lhsHir 0,
+                    mask32 lhsLor 1,
+                    mask32 lhsLor 0,
+                    mask32 rhsr 1,
+                    mask32 rhsr 0,
+                    ConstI32 0
+                  ],
+                callImportReturnTypes = [I32]
+              }
         }
-    ]
-marshalCmmPrimCall (GHC.MO_Memset _) [] [_dst, _c, _n] = do
-  dst <- marshalAndCastCmmExpr _dst F64
-  c <- marshalAndCastCmmExpr _c F64
-  n <- marshalAndCastCmmExpr _n F64
-  pure
-    [ CallImport
-        { target' = "__asterius_memset",
-          operands = [dst, c, n],
-          callImportReturnTypes = []
+  let remout = UnresolvedSetLocal
+        { unresolvedLocalReg = remr,
+          value = smash32IntTo64
+            CallImport
+              { target' = "__asterius_quotrem2_remainder",
+                operands =
+                  [ mask32 lhsHir 1,
+                    mask32 lhsHir 0,
+                    mask32 lhsLor 1,
+                    mask32 lhsLor 0,
+                    mask32 rhsr 1,
+                    mask32 rhsr 0,
+                    ConstI32 1
+                  ],
+                callImportReturnTypes = [I32]
+              }
+            CallImport
+              { target' = "__asterius_quotrem2_remainder",
+                operands =
+                  [ mask32 lhsHir 1,
+                    mask32 lhsHir 0,
+                    mask32 lhsLor 1,
+                    mask32 lhsLor 0,
+                    mask32 rhsr 1,
+                    mask32 rhsr 0,
+                    ConstI32 0
+                  ],
+                callImportReturnTypes = [I32]
+              }
         }
-    ]
-marshalCmmPrimCall (GHC.MO_Memmove _) [] [_dst, _src, _n] = do
-  dst <- marshalAndCastCmmExpr _dst F64
-  src <- marshalAndCastCmmExpr _src F64
-  n <- marshalAndCastCmmExpr _n F64
-  pure
-    [ CallImport
-        { target' = "__asterius_memmove",
-          operands = [dst, src, n],
-          callImportReturnTypes = []
-        }
-    ]
-marshalCmmPrimCall (GHC.MO_Memcmp _) [_cres] [_ptr1, _ptr2, _n] = do
-  cres <- marshalTypedCmmLocalReg _cres I32
-  ptr1 <- marshalAndCastCmmExpr _ptr1 F64
-  ptr2 <- marshalAndCastCmmExpr _ptr2 F64
-  n <- marshalAndCastCmmExpr _n F64
-  pure
-    [ UnresolvedSetLocal
-        { unresolvedLocalReg = cres,
-          value = CallImport
-            { target' = "__asterius_memcmp",
-              operands = [ptr1, ptr2, n],
-              callImportReturnTypes = [I32]
-            }
-        }
-    ]
-marshalCmmPrimCall (GHC.MO_PopCnt GHC.W64) [r] [x] =
-  marshalCmmUnPrimCall I64 r I64 x popcntInt64
-marshalCmmPrimCall (GHC.MO_PopCnt GHC.W32) [r] [x] = do
-  marshalCmmUnPrimCall I64 r I32 x (extendSInt32 . popcntInt32)
-marshalCmmPrimCall (GHC.MO_PopCnt GHC.W16) [r] [x] = do
-  marshalCmmUnPrimCall
-    I64
-    r
-    I32
-    x
-    (extendSInt32 . popcntInt32 . andInt32 (constI32 0xFFFF))
-marshalCmmPrimCall (GHC.MO_PopCnt GHC.W8) [r] [x] = do
-  marshalCmmUnPrimCall
-    I64
-    r
-    I32
-    x
-    (extendSInt32 . popcntInt32 . andInt32 (constI32 0xFF))
--- Unhandled: MO_Pdep Width
--- Unhandled: MO_Pext Width
-marshalCmmPrimCall (GHC.MO_Clz GHC.W64) [r] [x] =
-  marshalCmmUnPrimCall I64 r I64 x clzInt64
-marshalCmmPrimCall (GHC.MO_Clz GHC.W32) [r] [x] =
-  marshalCmmUnPrimCall I64 r I32 x (extendSInt32 . clzInt32)
-marshalCmmPrimCall (GHC.MO_Clz GHC.W16) [r] [x] =
-  marshalCmmUnPrimCall
-    I64
-    r
-    I32
-    x
-    ( extendSInt32
-        . clzInt32
-        . orInt32 (constI32 0x8000)
-        . (`shlInt32` constI32 16)
-    )
-marshalCmmPrimCall (GHC.MO_Clz GHC.W8) [r] [x] =
-  marshalCmmUnPrimCall
-    I64
-    r
-    I32
-    x
-    ( extendSInt32
-        . clzInt32
-        . orInt32 (constI32 0x800000)
-        . (`shlInt32` constI32 24)
-    )
-marshalCmmPrimCall (GHC.MO_Ctz GHC.W64) [r] [x] =
-  marshalCmmUnPrimCall I64 r I64 x ctzInt64
-marshalCmmPrimCall (GHC.MO_Ctz GHC.W32) [r] [x] =
-  marshalCmmUnPrimCall I64 r I32 x (extendSInt32 . ctzInt32)
-marshalCmmPrimCall (GHC.MO_Ctz GHC.W16) [r] [x] =
-  marshalCmmUnPrimCall
-    I64
-    r
-    I32
-    x
-    (extendSInt32 . ctzInt32 . orInt32 (constI32 0x10000))
-marshalCmmPrimCall (GHC.MO_Ctz GHC.W8) [r] [x] =
-  marshalCmmUnPrimCall
-    I64
-    r
-    I32
-    x
-    (extendSInt32 . ctzInt32 . orInt32 (constI32 0x100))
+  pure [quotout, remout]
 -- Unhandled: MO_BSwap W8
 marshalCmmPrimCall (GHC.MO_BSwap GHC.W16) [r] [x] = do
   lr <- marshalTypedCmmLocalReg r I64

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -18,6 +18,7 @@ module Asterius.CodeGen
 where
 
 import Asterius.Builtins
+import qualified Asterius.Builtins.Endianness as Endianness
 import Asterius.CodeGen.Droppable
 import Asterius.EDSL
 import Asterius.Internals
@@ -1242,7 +1243,34 @@ marshalCmmPrimCall (GHC.MO_Ctz GHC.W8) [r] [x] =
     I32
     x
     (extendSInt32 . ctzInt32 . orInt32 (constI32 0x100))
--- Unhandled: MO_BSwap Width
+-- Unhandled: MO_BSwap W8
+marshalCmmPrimCall (GHC.MO_BSwap GHC.W16) [r] [x] = do
+  dstr <- marshalTypedCmmLocalReg r I64
+  xe <- marshalAndCastCmmExpr x I64
+  pure
+    [ UnresolvedSetLocal
+        { unresolvedLocalReg = dstr,
+          value = Endianness.byteSwap16 xe
+        }
+    ]
+marshalCmmPrimCall (GHC.MO_BSwap GHC.W32) [r] [x] = do
+  dstr <- marshalTypedCmmLocalReg r I64
+  xe <- marshalAndCastCmmExpr x I64
+  pure
+    [ UnresolvedSetLocal
+        { unresolvedLocalReg = dstr,
+          value = Endianness.byteSwap32 xe
+        }
+    ]
+marshalCmmPrimCall (GHC.MO_BSwap GHC.W64) [r] [x] = do
+  dstr <- marshalTypedCmmLocalReg r I64
+  xe <- marshalAndCastCmmExpr x I64
+  pure
+    [ UnresolvedSetLocal
+        { unresolvedLocalReg = dstr,
+          value = Endianness.byteSwap64 xe
+        }
+    ]
 -- Atomic operations
 marshalCmmPrimCall (GHC.MO_AtomicRMW GHC.W64 amop) [dst] [addr, n] =
   marshalCmmAtomicMachOpPrimCall amop dst addr n

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -406,6 +406,7 @@ marshalCmmHeteroConvMachOp o33 o36 o63 o66 tx32 ty32 tx64 ty64 w0 w1 x = do
 
 marshalCmmMachOp ::
   GHC.MachOp -> [GHC.CmmExpr] -> CodeGen (Expression, ValueType)
+-- Integer operations (insensitive to signed/unsigned)
 marshalCmmMachOp (GHC.MO_Add w) [x, y] =
   marshalCmmBinMachOp AddInt32 I32 I32 I32 AddInt64 I64 I64 I64 w x y
 marshalCmmMachOp (GHC.MO_Sub w) [x, y] =
@@ -416,6 +417,7 @@ marshalCmmMachOp (GHC.MO_Ne w) [x, y] =
   marshalCmmBinMachOp NeInt32 I32 I32 I32 NeInt64 I64 I64 I32 w x y
 marshalCmmMachOp (GHC.MO_Mul w) [x, y] =
   marshalCmmBinMachOp MulInt32 I32 I32 I32 MulInt64 I64 I64 I64 w x y
+-- Signed multiply/divide
 marshalCmmMachOp (GHC.MO_S_Quot w) [x, y] =
   marshalCmmBinMachOp DivSInt32 I32 I32 I32 DivSInt64 I64 I64 I64 w x y
 marshalCmmMachOp (GHC.MO_S_Rem w) [x, y] =
@@ -438,10 +440,12 @@ marshalCmmMachOp (GHC.MO_S_Neg w) [x] =
               I64
             )
       )
+-- Unsigned multiply/divide
 marshalCmmMachOp (GHC.MO_U_Quot w) [x, y] =
   marshalCmmBinMachOp DivUInt32 I32 I32 I32 DivUInt64 I64 I64 I64 w x y
 marshalCmmMachOp (GHC.MO_U_Rem w) [x, y] =
   marshalCmmBinMachOp RemUInt32 I32 I32 I32 RemUInt64 I64 I64 I64 w x y
+-- Signed comparisons
 marshalCmmMachOp (GHC.MO_S_Ge w) [x, y] =
   marshalCmmBinMachOp GeSInt32 I32 I32 I32 GeSInt64 I64 I64 I32 w x y
 marshalCmmMachOp (GHC.MO_S_Le w) [x, y] =
@@ -450,6 +454,7 @@ marshalCmmMachOp (GHC.MO_S_Gt w) [x, y] =
   marshalCmmBinMachOp GtSInt32 I32 I32 I32 GtSInt64 I64 I64 I32 w x y
 marshalCmmMachOp (GHC.MO_S_Lt w) [x, y] =
   marshalCmmBinMachOp LtSInt32 I32 I32 I32 LtSInt64 I64 I64 I32 w x y
+-- Unsigned comparisons
 marshalCmmMachOp (GHC.MO_U_Ge w) [x, y] =
   marshalCmmBinMachOp GeUInt32 I32 I32 I32 GeUInt64 I64 I64 I32 w x y
 marshalCmmMachOp (GHC.MO_U_Le w) [x, y] =
@@ -458,6 +463,7 @@ marshalCmmMachOp (GHC.MO_U_Gt w) [x, y] =
   marshalCmmBinMachOp GtUInt32 I32 I32 I32 GtUInt64 I64 I64 I32 w x y
 marshalCmmMachOp (GHC.MO_U_Lt w) [x, y] =
   marshalCmmBinMachOp LtUInt32 I32 I32 I32 LtUInt64 I64 I64 I32 w x y
+-- Floating point arithmetic
 marshalCmmMachOp (GHC.MO_F_Add w) [x, y] =
   marshalCmmBinMachOp AddFloat32 F32 F32 F32 AddFloat64 F64 F64 F64 w x y
 marshalCmmMachOp (GHC.MO_F_Sub w) [x, y] =
@@ -478,6 +484,7 @@ marshalCmmMachOp (GHC.MO_F_Mul w) [x, y] =
   marshalCmmBinMachOp MulFloat32 F32 F32 F32 MulFloat64 F64 F64 F64 w x y
 marshalCmmMachOp (GHC.MO_F_Quot w) [x, y] =
   marshalCmmBinMachOp DivFloat32 F32 F32 F32 DivFloat64 F64 F64 F64 w x y
+  -- Floating point comparison
 marshalCmmMachOp (GHC.MO_F_Eq w) [x, y] =
   marshalCmmBinMachOp EqFloat32 F32 F32 I32 EqFloat64 F64 F64 I32 w x y
 marshalCmmMachOp (GHC.MO_F_Ne w) [x, y] =
@@ -490,6 +497,8 @@ marshalCmmMachOp (GHC.MO_F_Gt w) [x, y] =
   marshalCmmBinMachOp GtFloat32 F32 F32 I32 GtFloat64 F64 F64 I32 w x y
 marshalCmmMachOp (GHC.MO_F_Lt w) [x, y] =
   marshalCmmBinMachOp LtFloat32 F32 F32 I32 LtFloat64 F64 F64 I32 w x y
+-- Bitwise operations. Not all of these may be supported at all sizes,
+-- and only integral Widths are valid.
 marshalCmmMachOp (GHC.MO_And w) [x, y] =
   marshalCmmBinMachOp AndInt32 I32 I32 I32 AndInt64 I64 I64 I64 w x y
 marshalCmmMachOp (GHC.MO_Or w) [x, y] =
@@ -528,6 +537,8 @@ marshalCmmMachOp (GHC.MO_U_Shr w) [x, y] =
   marshalCmmBinMachOp ShrUInt32 I32 I32 I32 ShrUInt64 I64 I64 I64 w x y
 marshalCmmMachOp (GHC.MO_S_Shr w) [x, y] =
   marshalCmmBinMachOp ShrSInt32 I32 I32 I32 ShrSInt64 I64 I64 I64 w x y
+-- Conversions. Some of these will be NOPs.
+-- Floating-point conversions use the signed variant.
 marshalCmmMachOp (GHC.MO_SF_Conv w0 w1) [x] =
   marshalCmmHeteroConvMachOp
     ConvertSInt32ToFloat32
@@ -560,6 +571,36 @@ marshalCmmMachOp (GHC.MO_UU_Conv w0 w1) [x] =
   marshalCmmHomoConvMachOp ExtendUInt32 WrapInt64 I32 I64 w0 w1 NoSext x
 marshalCmmMachOp (GHC.MO_FF_Conv w0 w1) [x] =
   marshalCmmHomoConvMachOp PromoteFloat32 DemoteFloat64 F32 F64 w0 w1 Sext x
+-- Unhandled cases
+--   -- Signed multiply/divide
+--   MO_S_MulMayOflo Width       -- nonzero if signed multiply overflows
+--   -- Unsigned multiply/divide
+--   MO_U_MulMayOflo Width       -- nonzero if unsigned multiply overflows
+--   -- Vector element insertion and extraction operations
+--   MO_V_Insert  Length Width   -- Insert scalar into vector
+--   MO_V_Extract Length Width   -- Extract scalar from vector
+--   -- Integer vector operations
+--   MO_V_Add Length Width
+--   MO_V_Sub Length Width
+--   MO_V_Mul Length Width
+--   -- Signed vector multiply/divide
+--   MO_VS_Quot Length Width
+--   MO_VS_Rem  Length Width
+--   MO_VS_Neg  Length Width
+--   -- Unsigned vector multiply/divide
+--   MO_VU_Quot Length Width
+--   MO_VU_Rem  Length Width
+--   -- Floting point vector element insertion and extraction operations
+--   MO_VF_Insert  Length Width   -- Insert scalar into vector
+--   MO_VF_Extract Length Width   -- Extract scalar from vector
+--   -- Floating point vector operations
+--   MO_VF_Add  Length Width
+--   MO_VF_Sub  Length Width
+--   MO_VF_Neg  Length Width      -- unary negation
+--   MO_VF_Mul  Length Width
+--   MO_VF_Quot Length Width
+--   -- Alignment check (for -falignment-sanitisation)
+--   MO_AlignmentCheck Int Width
 marshalCmmMachOp op xs =
   liftIO $ throwIO $ UnsupportedCmmExpr $ showBS $ GHC.CmmMachOp op xs
 

--- a/asterius/test/endianness.hs
+++ b/asterius/test/endianness.hs
@@ -1,0 +1,7 @@
+import System.Environment
+import System.Process
+
+main :: IO ()
+main = do
+  args <- getArgs
+  callProcess "ahc-link" $ ["--input-hs", "test/endianness/endianness.hs", "--run"] <> args

--- a/asterius/test/endianness/endianness.hs
+++ b/asterius/test/endianness/endianness.hs
@@ -1,0 +1,6 @@
+
+-- import Network.Socket
+
+main :: IO ()
+main = putStrLn "This test is under construction!"
+

--- a/asterius/test/endianness/endianness.hs
+++ b/asterius/test/endianness/endianness.hs
@@ -4,21 +4,36 @@ import Data.Word
 
 main :: IO ()
 main = do
-  do let x = 10
-     print x
-     print (ntohs x)
-  do let x = 10
-     print x
-     print (ntohl x)
-  do let x = 10
-     print x
-     print (htons x)
-  do let x = 10
-     print x
-     print (htonl x)
+  do let x = 0xABCD
+     let y = 0xCDAB
+     putStr "ntohs: " >> print (ntohs x == y && x == ntohs y)
+  do let x = 0x56789ABC
+     let y = 0xBC9A7856
+     putStr "ntohl: " >> print (ntohl x == y && x == ntohl y)
+  do let x = 0xABCD
+     let y = 0xCDAB
+     putStr "htons: " >> print (htons x == y && x == htons y)
+  do let x = 0x56789ABC
+     let y = 0xBC9A7856
+     putStr "htonl: " >> print (htonl x == y && x == htonl y)
+  --
+  do let x = 0xABCD
+     let y = 0xCDAB
+     putStr "hs_bswap16: " >> print (hs_bswap16 x == y && x == hs_bswap16 y)
+  do let x = 0x56789ABC
+     let y = 0xBC9A7856
+     putStr "hs_bswap32: " >> print (hs_bswap32 x == y && x == hs_bswap32 y)
+
+  do let x = 0x0123456789ABCDEF
+     let y = 0xEFCDAB8967452301
+     putStr "hs_bswap64: " >> print (hs_bswap64 x == y && x == hs_bswap64 y)
 
 foreign import ccall safe "ntohs" ntohs :: Word16 -> Word16
 foreign import ccall safe "ntohl" ntohl :: Word32 -> Word32
 foreign import ccall safe "htons" htons :: Word16 -> Word16
 foreign import ccall safe "htonl" htonl :: Word32 -> Word32
+
+foreign import ccall safe "hs_bswap16" hs_bswap16 :: Word16 -> Word16
+foreign import ccall safe "hs_bswap32" hs_bswap32 :: Word32 -> Word32
+foreign import ccall safe "hs_bswap64" hs_bswap64 :: Word64 -> Word64
 

--- a/asterius/test/endianness/endianness.hs
+++ b/asterius/test/endianness/endianness.hs
@@ -1,5 +1,4 @@
 
--- import Network.Socket -- Well, it's not booted, this one, so we cannot test it :(
 import Data.Word
 
 main :: IO ()

--- a/asterius/test/endianness/endianness.hs
+++ b/asterius/test/endianness/endianness.hs
@@ -1,6 +1,24 @@
 
--- import Network.Socket
+-- import Network.Socket -- Well, it's not booted, this one, so we cannot test it :(
+import Data.Word
 
 main :: IO ()
-main = putStrLn "This test is under construction!"
+main = do
+  do let x = 10
+     print x
+     print (ntohs x)
+  do let x = 10
+     print x
+     print (ntohl x)
+  do let x = 10
+     print x
+     print (htons x)
+  do let x = 10
+     print x
+     print (htonl x)
+
+foreign import ccall safe "ntohs" ntohs :: Word16 -> Word16
+foreign import ccall safe "ntohl" ntohl :: Word32 -> Word32
+foreign import ccall safe "htons" htons :: Word16 -> Word16
+foreign import ccall safe "htonl" htonl :: Word32 -> Word32
 


### PR DESCRIPTION
Closes #756. This PR

Adds `Asterius.Builtins.Endianness` with implementations for
* `hs_bswap16`, `hs_bswap32`, and `hs_bswap64`.
* `htonl`, `htons`, `ntohl`, and `ntohs`, based on the `hs_bswap*` functions. Wasm uses little-endian while network order is big-endian; converting from one to the other simply means byte-swapping.

Also
* Adds a small unit test (`endianness`).
* Implements translations for [`CallishMachOp`](https://haskell-code-explorer.mfix.io/package/ghc-8.6.5/show/cmm/CmmMachOp.hs#L523) `MO_BSwap`, using `hs_bswap16`, `hs_bswap32`, and `hs_bswap64`.
* Adds a few comments about remaining unimplemented translations in `Asterius.CodeGen`.