### PR TITLE
Remove duplication between test-binaryen and test-wasm-toolkit

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -110,31 +110,31 @@ jobs:
           stack test asterius:sizeof_md5context --test-arguments="--backend=$ASTERIUS_BACKEND"
           stack test asterius:largenum --test-arguments="--backend=$ASTERIUS_BACKEND"
 
-          stack test asterius:bytearray --test-arguments="--yolo"
-          stack test asterius:bytearray --test-arguments="--gc-threshold=128"
-          stack test asterius:fib --test-arguments="--no-gc-sections"
+          stack test asterius:bytearray --test-arguments="--yolo --backend=$ASTERIUS_BACKEND"
+          stack test asterius:bytearray --test-arguments="--gc-threshold=128 --backend=$ASTERIUS_BACKEND"
+          stack test asterius:fib --test-arguments="--no-gc-sections --backend=$ASTERIUS_BACKEND"
 
-          stack test asterius:fib --test-arguments="--debug" > /dev/null
-          stack test asterius:jsffi --test-arguments="--debug" > /dev/null
-          stack test asterius:array --test-arguments="--debug" > /dev/null
-          stack test asterius:stableptr --test-arguments="--debug" > /dev/null
-          stack test asterius:rtsapi --test-arguments="--debug" > /dev/null
-          stack test asterius:teletype --test-arguments="--debug" > /dev/null
-          # stack test asterius:bytearray --test-arguments="--debug" > /dev/null
-          stack test asterius:bigint --test-arguments="--debug" > /dev/null
-          stack test asterius:exception --test-arguments="--debug" > /dev/null
+          stack test asterius:fib --test-arguments="--debug --backend=$ASTERIUS_BACKEND" > /dev/null
+          stack test asterius:jsffi --test-arguments="--debug --backend=$ASTERIUS_BACKEND" > /dev/null
+          stack test asterius:array --test-arguments="--debug --backend=$ASTERIUS_BACKEND" > /dev/null
+          stack test asterius:stableptr --test-arguments="--debug --backend=$ASTERIUS_BACKEND" > /dev/null
+          stack test asterius:rtsapi --test-arguments="--debug --backend=$ASTERIUS_BACKEND" > /dev/null
+          stack test asterius:teletype --test-arguments="--debug --backend=$ASTERIUS_BACKEND" > /dev/null
+          # stack test asterius:bytearray --test-arguments="--debug --backend=$ASTERIUS_BACKEND" > /dev/null
+          stack test asterius:bigint --test-arguments="--debug --backend=$ASTERIUS_BACKEND" > /dev/null
+          stack test asterius:exception --test-arguments="--debug --backend=$ASTERIUS_BACKEND" > /dev/null
 
-          stack test asterius:fib --test-arguments="--tail-calls"
-          stack test asterius:fib --test-arguments="--tail-calls --no-gc-sections"
+          stack test asterius:fib --test-arguments="--tail-calls --backend=$ASTERIUS_BACKEND"
+          stack test asterius:fib --test-arguments="--tail-calls --no-gc-sections --backend=$ASTERIUS_BACKEND"
 
-          stack test asterius:nomain
-          stack test asterius:nomain --test-arguments="--tail-calls"
+          stack test asterius:nomain --test-arguments="--backend=$ASTERIUS_BACKEND"
+          stack test asterius:nomain --test-arguments="--tail-calls --backend=$ASTERIUS_BACKEND"
 
-          stack test asterius:th
+          stack test asterius:th --test-arguments="--backend=$ASTERIUS_BACKEND"
 
-          stack test asterius:primitive
+          stack test asterius:primitive --test-arguments="--backend=$ASTERIUS_BACKEND"
 
-          stack test asterius:argv
+          stack test asterius:argv --test-arguments="--backend=$ASTERIUS_BACKEND"
 
   ghc-testsuite:
     name: ghc-testsuite


### PR DESCRIPTION
Since the default backend is binaryend, the tests in `.github/workflows/pipeline.yml` that have no explicit backend are basically executed the same way by both `test-binaryen` and `test-wasm-toolkit`. Instead of running the same test twice, we might as well test the `wasm-toolkit` backend a little more.