### PR TITLE
Fix ahc-dist broken when handling ahc-cabal v2 build output

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -322,14 +322,23 @@ jobs:
       - name: test-cabal
         run: |
           . ./.envrc
-          ahc-cabal v1-update
-          ln -s ghc-toolkit/boot-libs/cabal.config cabal.config
+          pushd ghc-toolkit/boot-libs
+
+          ahc-cabal update
+
+          pushd $(mktemp -d)
+          ahc-cabal v2-install --installdir . hello
+          ahc-dist --input-exe hello --run
+          popd
+
           ahc-cabal v1-install --ghc-option=-j2 \
             Cabal
           ahc-cabal v1-install -j2 \
             diagrams \
-            servant \
+            miso \
             singletons
+
+          popd
 
   gen-pkgs:
     name: gen-pkgs

--- a/asterius/app/ahc-cabal.hs
+++ b/asterius/app/ahc-cabal.hs
@@ -20,9 +20,9 @@ main = do
       <> (dataDir </> ".boot" </> "asterius_lib")
       <> "\nprogram-locations\n  ar-location: "
       <> ahcAr
-      <> "\n  ghc-location: "
+      <> "\nwith-compiler: "
       <> ahc
-      <> "\n  ghc-pkg-location: "
+      <> "\nwith-hc-pkg:"
       <> ahcPkg
       <> "\n"
       <> ahc_cabal_config


### PR DESCRIPTION
Closes #755, also adds a simple v2 build test in `test-cabal` CI job to prevent regression.

Why on earth does the `with-compiler` cabal config field behaves differently from `ghc-location`??? And the former is marked as deprecated, but works, while the latter one doesn't???