### PR TITLE
Prevent TH runner errors from hanging the ahc process

### DIFF
--- a/asterius/rts/rts.symtable.mjs
+++ b/asterius/rts/rts.symtable.mjs
@@ -1,8 +1,13 @@
 export class SymbolTable {
-  constructor(func_offset_table, statics_offset_table, table_base, memory_base) {
+  constructor(
+    func_offset_table,
+    statics_offset_table,
+    table_base,
+    memory_base
+  ) {
     this.offsetTable = {
-       ...func_offset_table,
-       ...statics_offset_table
+      ...func_offset_table,
+      ...statics_offset_table,
     };
     this.tableBase = table_base;
     this.memoryBase = memory_base;
@@ -17,6 +22,9 @@ export class SymbolTable {
   }
 
   addressOf(sym) {
+    if (!this.symbolTable.has(sym)) {
+      throw new WebAssembly.RuntimeError(`${sym} not in symbol table`);
+    }
     return this.symbolTable.get(sym);
   }
 


### PR DESCRIPTION
When we handle the `RunTH` message and kicks off the evaluation of a splice's code, we fork a thread as a watchdog to catch potential `EvalError` in the relevant thunk. In case of such an error, we log it to `stderr` and kill the `Session`, which shall make `ahc` crash instead of infinitely hanging.

The real cause of hanging before: `readIServ` may wait for data on the iserv pipe, so when TH runner errors, the `node` process may still be alive, thus `readIServ` blocks.

Also adds another minor runtime bugfix: symbol table should check for invalid symbols instead of silently returning `undefined`.