### PR TITLE
Fix barf regression

### DIFF
--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -318,6 +318,7 @@ marshalExpression e = case e of
       Binaryen.switch m nsp (fromIntegral nl) dn c (coerce nullPtr)
   Call {..} -> do
     func_sym_map <- askFunctionsSymbolMap
+    ss_sym_map <- askStaticsSymbolMap
     if
         | target `SM.member` func_sym_map -> do
           os <-
@@ -338,7 +339,7 @@ marshalExpression e = case e of
             (ops, osl) <- marshalV a os
             tp <- marshalBS a (entityName target)
             Binaryen.call m tp ops (fromIntegral osl) rts
-        | ("__asterius_barf_" <> target) `SM.member` func_sym_map ->
+        | ("__asterius_barf_" <> target) `SM.member` ss_sym_map ->
           marshalExpression $
             barf target callReturnTypes
         | otherwise -> do
@@ -523,7 +524,7 @@ marshalExpression e = case e of
                 addInt64
                   (extendUInt32 base)
                   (constI64 $ fromIntegral x + symbolOffset)
-        | ("__asterius_barf_" <> unresolvedSymbol) `SM.member` func_sym_map ->
+        | ("__asterius_barf_" <> unresolvedSymbol) `SM.member` ss_sym_map ->
           marshalExpression $ barf unresolvedSymbol [I64]
         | otherwise ->
           lift $ Binaryen.constInt64 m invalidAddress

--- a/asterius/src/Asterius/Backends/WasmToolkit.hs
+++ b/asterius/src/Asterius/Backends/WasmToolkit.hs
@@ -592,8 +592,8 @@ makeInstructions expr =
               makeInstructions
           pure $ unionManyBags xs `snocBag` Wasm.Call {callFunctionIndex = i}
         _ -> do
-          func_sym_map <- askFunctionsSymbolMap
-          if SM.member ("__asterius_barf_" <> target) func_sym_map
+          ss_sym_map <- askStaticsSymbolMap
+          if SM.member ("__asterius_barf_" <> target) ss_sym_map
             then makeInstructions $ barf target callReturnTypes
             else pure $ unitBag Wasm.Unreachable
     CallImport {..} -> do
@@ -713,7 +713,7 @@ makeInstructions expr =
           Just i -> pure $
             unitBag Wasm.ReturnCall {returnCallFunctionIndex = i}
           _
-            | ("__asterius_barf_" <> returnCallTarget64) `SM.member` func_sym_map ->
+            | ("__asterius_barf_" <> returnCallTarget64) `SM.member` ss_sym_map ->
               makeInstructions $ barf returnCallTarget64 []
             | otherwise ->
               pure $ unitBag Wasm.Unreachable
@@ -731,7 +731,7 @@ makeInstructions expr =
                 valueType = I64
               }
           _
-            | ("__asterius_barf_" <> returnCallTarget64) `SM.member` func_sym_map ->
+            | ("__asterius_barf_" <> returnCallTarget64) `SM.member` ss_sym_map ->
               makeInstructions $ barf returnCallTarget64 []
             | otherwise ->
               pure $ unitBag Wasm.Unreachable
@@ -784,7 +784,7 @@ makeInstructions expr =
                   addInt64
                     (extendUInt32 base)
                     (constI64 $ fromIntegral x + symbolOffset)
-          | ("__asterius_barf_" <> unresolvedSymbol) `SM.member` func_sym_map ->
+          | ("__asterius_barf_" <> unresolvedSymbol) `SM.member` ss_sym_map ->
             makeInstructions $ barf unresolvedSymbol [I64]
           | otherwise ->
             pure $ unitBag Wasm.I64Const


### PR DESCRIPTION
I found the culprit of https://github.com/tweag/asterius/issues/757: https://github.com/tweag/asterius/pull/743 looks up symbols in the wrong symbol table I believe. Both in `WasmToolkit` and `Binaryen`. It fails to find the corresponding static (cause it wrongly looks into the `func_sym_map` instead of the `ss_sym_map`), so it falls back to emitting a plain `unreachable`. This PR addresses this regression.

I still think that it'd be nice to switch to the new translation for `Barf`s as described in https://github.com/tweag/asterius/issues/757 but for now this patch should give us the expected behavior.


