### PR TITLE
Generalize tableOffset in FunctionTable

### DIFF
--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -589,10 +589,10 @@ marshalFunctionExport m FunctionExport {..} = do
 marshalFunctionTable :: Binaryen.Module -> Int -> FunctionTable -> CodeGen ()
 marshalFunctionTable m tbl_slots FunctionTable {..} = do
   a <- askArena
+  o <- marshalExpression tableOffset
   lift $ do
     func_name_ptrs <- for tableFunctionNames $ marshalBS a
     (fnp, fnl) <- marshalV a func_name_ptrs
-    o <- Binaryen.constInt32 m (fromIntegral tableOffset)
     Binaryen.setFunctionTable
       m
       (fromIntegral tbl_slots)

--- a/asterius/src/Asterius/Passes/FunctionSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/FunctionSymbolTable.hs
@@ -22,5 +22,5 @@ makeFunctionSymbolTable AsteriusModule {..} func_start_addr =
 makeFunctionTable :: SM.SymbolMap Int64 -> Int64 -> FunctionTable
 makeFunctionTable func_sym_map func_start_addr = FunctionTable
   { tableFunctionNames = map entityName $ SM.keys func_sym_map,
-    tableOffset = fromIntegral $ unTag func_start_addr
+    tableOffset = ConstI32 $ fromIntegral $ unTag func_start_addr
   }

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -526,7 +526,7 @@ data FunctionExport
 data FunctionTable
   = FunctionTable
       { tableFunctionNames :: [BS.ByteString],
-        tableOffset :: BinaryenIndex
+        tableOffset :: Expression
       }
   deriving (Show, Data)
 


### PR DESCRIPTION
Binaryen allows for the table offset in a function table to be an arbitrary expression, but until now the Asterius IR would only allow integers to be used here. This PR lifts this restriction. This change should allow us to change the offset dynamically in the future.

Factored out from https://github.com/tweag/asterius/pull/750.