### PR TITLE
Turn __asterius_pc into a global

### DIFF
--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -444,21 +444,14 @@ marshalExpression e = case e of
         Binaryen.returnCall m dst nullPtr 0 Binaryen.none
     -- Case 2: Tail calls are off
     False -> do
-      ss_sym_map <- askStaticsSymbolMap
       func_sym_map <- askFunctionsSymbolMap
       case SM.lookup returnCallTarget64 func_sym_map of
         Just t -> do
           s <-
             marshalExpression
-              Store
-                { bytes = 8,
-                  offset = 0,
-                  ptr =
-                    ConstI32
-                      $ fromIntegral
-                      $ unTag (ss_sym_map SM.! "__asterius_pc"),
-                  value = ConstI64 t,
-                  valueType = I64
+              SetGlobal
+                { globalSymbol = "__asterius_pc",
+                  value = ConstI64 t
                 }
           m <- askModuleRef
           a <- askArena
@@ -487,18 +480,11 @@ marshalExpression e = case e of
           Binaryen.none
     -- Case 2: Tail calls are off
     False -> do
-      ss_sym_map <- askStaticsSymbolMap
       s <-
         marshalExpression
-          Store
-            { bytes = 8,
-              offset = 0,
-              ptr =
-                ConstI32
-                  $ fromIntegral
-                  $ unTag (ss_sym_map SM.! "__asterius_pc"),
-              value = returnCallIndirectTarget64,
-              valueType = I64
+          SetGlobal
+            { globalSymbol = "__asterius_pc",
+              value = returnCallIndirectTarget64
             }
       m <- askModuleRef
       a <- askArena

--- a/asterius/src/Asterius/EDSL.hs
+++ b/asterius/src/Asterius/EDSL.hs
@@ -31,6 +31,7 @@ module Asterius.EDSL
     i32Local,
     i64MutLocal,
     global,
+    newGlobal,
     pointer,
     pointerI64,
     pointerI32,
@@ -232,6 +233,15 @@ global :: UnresolvedGlobalReg -> LVal
 global gr = LVal
   { getLVal = unresolvedGetGlobal gr,
     putLVal = emit . unresolvedSetGlobal gr
+  }
+
+newGlobal :: EntitySymbol -> GlobalType -> LVal
+newGlobal k GlobalType {..} = LVal
+  { getLVal = GetGlobal
+      { globalSymbol = k,
+        valueType = globalValueType
+      },
+    putLVal = emit . SetGlobal k
   }
 
 pointer :: ValueType -> BinaryenIndex -> Expression -> Int -> LVal


### PR DESCRIPTION
Until now `__asterius_pc` has been a static (data segment). This means that `__asterius_pc` should be adjusted as well when #750 lands, which complicates the backends. Instead, this PR turns it into a global which can be referred to by name, thus avoiding this problem altogether.

Factored out from #750.