### PR TITLE
Remove getTableBase and getMemoryBase

### DIFF
--- a/asterius/rts/rts.symtable.mjs
+++ b/asterius/rts/rts.symtable.mjs
@@ -9,14 +9,12 @@ export class SymbolTable {
       ...func_offset_table,
       ...statics_offset_table,
     };
-    this.tableBase = table_base;
-    this.memoryBase = memory_base;
     this.symbolTable = new Map();
     for (const [k, v] of Object.entries(func_offset_table)) {
-      this.symbolTable.set(k, this.tableBase + v);
+      this.symbolTable.set(k, table_base + v);
     }
     for (const [k, v] of Object.entries(statics_offset_table)) {
-      this.symbolTable.set(k, this.memoryBase + v);
+      this.symbolTable.set(k, memory_base + v);
     }
     Object.freeze(this);
   }
@@ -26,14 +24,6 @@ export class SymbolTable {
       throw new WebAssembly.RuntimeError(`${sym} not in symbol table`);
     }
     return this.symbolTable.get(sym);
-  }
-
-  getTableBase() {
-    return this.tableBase;
-  }
-
-  getMemoryBase() {
-    return this.memoryBase;
   }
 
   allEntries() {


### PR DESCRIPTION
Instead of storing the `table_base` and `memory_base` values into the symbol table in the rts, after this PR there is only a single source for these values: ` __asterius_table_base.value` and `__asterius_memory_base.value`, respectively. This is more robust and shorter.

Factored out from #750.