### PR TITLE
Generalize DataSegment

### DIFF
--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -601,7 +601,7 @@ marshalMemorySegments mbs segs = do
         =<< for
           segs
           ( \DataSegment {..} ->
-              flip runReaderT env $ marshalExpression $ ConstI32 offset
+              flip runReaderT env $ marshalExpression offset
           )
     (seg_sizes, _) <- marshalV a $ map (fromIntegral . BS.length . content) segs
     Binaryen.setMemory

--- a/asterius/src/Asterius/Passes/DataSymbolTable.hs
+++ b/asterius/src/Asterius/Passes/DataSymbolTable.hs
@@ -58,9 +58,9 @@ makeSegment sym_map off static =
         let address = case SM.lookup sym sym_map of
               Just addr -> addr + fromIntegral o
               _ -> invalidAddress
-         in Just DataSegment {content = encodeStorable address, offset = off}
+         in Just DataSegment {content = encodeStorable address, offset = ConstI32 off}
       Uninitialized {} -> Nothing
-      Serialized buf -> Just DataSegment {content = buf, offset = off}
+      Serialized buf -> Just DataSegment {content = buf, offset = ConstI32 off}
   )
 
 {-# INLINEABLE makeMemory #-}

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -533,7 +533,7 @@ data FunctionTable
 data DataSegment
   = DataSegment
       { content :: BS.ByteString,
-        offset :: Int32
+        offset :: Expression
       }
   deriving (Show, Data)
 


### PR DESCRIPTION
Binaryen allows for the offset in segments to be an arbitrary expression, but until now the Asterius IR would only allow `Int32` to be used here. This PR lifts this restriction. This change should allow us to change the offset dynamically in the future (and thus unblock #750).