### PR TITLE
Set No of iterations for wasm-toolkit-codec to default (100)

### DIFF
--- a/wasm-toolkit/test/wasm-toolkit-codec.hs
+++ b/wasm-toolkit/test/wasm-toolkit-codec.hs
@@ -108,7 +108,7 @@ main = do
     $ testCodecModule
       >=> quickCheck
   r <-
-    quickCheckResult $ withMaxSuccess 576460752303423488 $
+    quickCheckResult $
       conjoin
         [ testLEB128Dynamic,
           testCodecGen genModule genericShrink getModule putModule


### PR DESCRIPTION
Closes #551 by setting the number of tests for `wasm-toolkit/test/wasm-toolkit-codec.hs` to a reasonable number. Now `stack test wasm-toolkit` terminates just fine.