### PR TITLE
Re-establish a consistent view on Offset/Symbol tables

### DIFF
--- a/asterius/rts/rts.symtable.mjs
+++ b/asterius/rts/rts.symtable.mjs
@@ -1,20 +1,14 @@
 export class SymbolTable {
   constructor(
-    func_offset_table,
-    statics_offset_table,
-    table_base,
-    memory_base
+    func_symbol_table,
+    statics_symbol_table
   ) {
-    this.offsetTable = {
-      ...func_offset_table,
-      ...statics_offset_table,
-    };
     this.symbolTable = new Map();
-    for (const [k, v] of Object.entries(func_offset_table)) {
-      this.symbolTable.set(k, table_base + v);
+    for (const [k, v] of Object.entries(func_symbol_table)) {
+      this.symbolTable.set(k, v);
     }
-    for (const [k, v] of Object.entries(statics_offset_table)) {
-      this.symbolTable.set(k, memory_base + v);
+    for (const [k, v] of Object.entries(statics_symbol_table)) {
+      this.symbolTable.set(k, v);
     }
     Object.freeze(this);
   }

--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -23,7 +23,6 @@ module Asterius.Backends.Binaryen
 where
 
 import Asterius.Builtins
-import Asterius.EDSL (addInt64, constI64, extendUInt32)
 import qualified Asterius.Internals.Arena as A
 import Asterius.Internals.Barf
 import Asterius.Internals.MagicNumber
@@ -507,15 +506,7 @@ marshalExpression e = case e of
     if  | Just x <- SM.lookup unresolvedSymbol ss_sym_map ->
           lift $ Binaryen.constInt64 m $ x + fromIntegral symbolOffset
         | Just x <- SM.lookup unresolvedSymbol func_sym_map ->
-          let base =
-                GetGlobal
-                  { globalSymbol = "__asterius_table_base",
-                    valueType = I32
-                  }
-           in marshalExpression $
-                addInt64
-                  (extendUInt32 base)
-                  (constI64 $ fromIntegral x + symbolOffset)
+          lift $ Binaryen.constInt64 m $ x + fromIntegral symbolOffset
         | verbose_err ->
           marshalExpression $ barf (entityName unresolvedSymbol) [I64]
         | otherwise ->

--- a/asterius/src/Asterius/Backends/WasmToolkit.hs
+++ b/asterius/src/Asterius/Backends/WasmToolkit.hs
@@ -24,7 +24,6 @@ module Asterius.Backends.WasmToolkit
 where
 
 import Asterius.Builtins
-import Asterius.EDSL (addInt64, constI64, extendUInt32)
 import Asterius.Internals.Barf
 import Asterius.Internals.MagicNumber
 import Asterius.Passes.Relooper
@@ -759,15 +758,9 @@ makeInstructions expr =
               { i64ConstValue = x + fromIntegral symbolOffset
               }
           | Just x <- SM.lookup unresolvedSymbol func_sym_map ->
-            let base =
-                  GetGlobal
-                    { globalSymbol = "__asterius_table_base",
-                      valueType = I32
-                    }
-             in makeInstructions $
-                  addInt64
-                    (extendUInt32 base)
-                    (constI64 $ fromIntegral x + symbolOffset)
+            pure $ unitBag Wasm.I64Const
+              { i64ConstValue = x + fromIntegral symbolOffset
+              }
           | verbose_err ->
             makeInstructions $ barf (entityName unresolvedSymbol) [I64]
           | otherwise ->

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -688,26 +688,7 @@ rtsFunctionExports debug =
   ]
 
 rtsGlobalImports :: [GlobalImport]
-rtsGlobalImports =
-  [ GlobalImport
-      { internalName = "__asterius_memory_base",
-        externalModuleName = "env",
-        externalBaseName = "__memory_base",
-        globalType = GlobalType
-          { globalValueType = I32,
-            globalMutability = Immutable
-          }
-      },
-    GlobalImport
-      { internalName = "__asterius_table_base",
-        externalModuleName = "env",
-        externalBaseName = "__table_base",
-        globalType = GlobalType
-          { globalValueType = I32,
-            globalMutability = Immutable
-          }
-      }
-  ]
+rtsGlobalImports = mempty
 
 rtsGlobalExports :: [GlobalExport]
 rtsGlobalExports = mempty

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -136,8 +136,8 @@ parseTask args = case err_msgs of
 getTask :: IO Task
 getTask = parseTask <$> getArgs
 
-genSymbolOffsetDict :: SM.SymbolMap Int64 -> Builder
-genSymbolOffsetDict sym_map =
+genSymbolTableDict :: SM.SymbolMap Int64 -> Builder
+genSymbolTableDict sym_map =
   "Object.freeze({"
     <> mconcat
       ( intersperse
@@ -165,10 +165,10 @@ genReq task LinkReport {..} =
       genExportStaticObj bundledFFIMarshalState functionSymbolMap,
       ", staticsExportsStatic: ",
       genExportStaticObj bundledFFIMarshalState staticsSymbolMap,
-      ", functionsOffsetTable: ",
-      genSymbolOffsetDict func_symbol_table,
-      ", staticsOffsetTable: ",
-      genSymbolOffsetDict ss_symbol_table,
+      ", functionsSymbolTable: ",
+      genSymbolTableDict func_symbol_table,
+      ", staticsSymbolTable: ",
+      genSymbolTableDict ss_symbol_table,
       if debug task
         then mconcat [", infoTables: ", genInfoTables infoTableSet]
         else mempty,


### PR DESCRIPTION
Essentially undo the inconsistencies that came with 346275d.
* No mention of base addresses in either Haskell land or JavaScript land; these should really come with #750.
* The symbol tables are treated as symbol tables everywhere; no adding `base` as if they contained offsets.