### PR TITLE
Add xdg-open to the dev image and use a dummy browser

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -3,6 +3,7 @@ FROM debian:sid-slim
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV \
+  BROWSER=echo \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \
   LC_CTYPE=C.UTF-8 \
@@ -26,6 +27,7 @@ RUN \
     python3-pip \
     ripgrep \
     wabt \
+    xdg-utils \
     zlib1g-dev \
     zstd && \
   apt autoremove --purge -y && \

--- a/dev.rootless.Dockerfile
+++ b/dev.rootless.Dockerfile
@@ -5,6 +5,7 @@ ARG USERNAME=asterius
 ARG UID=1000
 
 ENV \
+  BROWSER=echo \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \
   LC_CTYPE=C.UTF-8 \
@@ -29,6 +30,7 @@ RUN \
     ripgrep \
     sudo \
     wabt \
+    xdg-utils \
     zlib1g-dev \
     zstd && \
   apt autoremove --purge -y && \


### PR DESCRIPTION
This PR adds `xdg-open` to the dev image and sets `BROWSER=echo`. Also contains some refactorings in the rootless dev image script.