### PR TITLE
Disable binaryen optimize/shrink passes in debug mode

### DIFF
--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -114,6 +114,8 @@ parseTask args = case err_msgs of
             \t ->
               t
                 { backend = Binaryen,
+                  optimizeLevel = 0,
+                  shrinkLevel = 0,
                   debug = True,
                   outputIR = True,
                   verboseErr = True


### PR DESCRIPTION
This PR makes `--debug` imply `--optimize-level=0` and `--shrink-level=0`. When working under debug mode, it's sensible to avoid running any `binaryen` passes at all, so to reduce the possibility of codegen bugs. Should also speed up the CI a bit.