### PR TITLE
Align data segments by 8 bytes instead of 16

### DIFF
--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -153,8 +153,9 @@ marshalCmmStatic st = case st of
   GHC.CmmUninitialised s -> pure $ Uninitialized s
   GHC.CmmString s -> pure $ Serialized $ BS.pack $ s <> [0]
 
-marshalCmmSectionType ::
-  EntitySymbol -> GHC.Section -> AsteriusStaticsType
+marshalCmmSectionType :: EntitySymbol -> GHC.Section -> AsteriusStaticsType
+marshalCmmSectionType _ (GHC.Section GHC.ReadOnlyData16 _) =
+  error "ReadOnlyData16"
 marshalCmmSectionType sym sec@(GHC.Section _ clbl)
   | GHC.isGcPtrLabel clbl = Closure
   | "_info" `BS.isSuffixOf` entityName sym = InfoTable

--- a/asterius/src/Asterius/Passes/DataOffsetTable.hs
+++ b/asterius/src/Asterius/Passes/DataOffsetTable.hs
@@ -24,10 +24,10 @@ import Data.Tuple
 import Foreign
 import Language.Haskell.GHC.Toolkit.Constants
 
--- | Segments are 16-bytes aligned.
+-- | Segments are 8-bytes aligned.
 {-# INLINE segAlignment #-}
 segAlignment :: Int
-segAlignment = 16
+segAlignment = 8
 
 {-# INLINEABLE sizeofStatic #-}
 sizeofStatic :: AsteriusStatic -> Word32


### PR DESCRIPTION
We used to align data segments by 16 bytes. It's a simple upper-approximation since on x64 `ReadOnlyData16` requires 16-byte alignment while others require at most 8-byte. Given `ReadOnlyData16` doesn't seem to be actually used in our pipeline, this PR reduces the alignment value to 8 bytes when laying out data segments. This will result in more compact static memory data (even so when #750 lands and `--pic` is enabled).