### PR TITLE
Toolchain update

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -15,13 +15,13 @@ jobs:
         uses: actions/setup-haskell@v1
         with:
           cabal-version: 3.2.0.0
-          stack-version: 2.3.3
+          stack-version: 2.5.0.1
           enable-stack: true
 
       - name: setup-node-14
-        uses: actions/setup-node@v2.0.0
+        uses: actions/setup-node@v2.1.1
         with:
-          node-version: 14.11.0
+          node-version: 14.12.0
 
       - name: checkout
         uses: actions/checkout@v2
@@ -60,13 +60,13 @@ jobs:
         uses: actions/setup-haskell@v1
         with:
           cabal-version: 3.2.0.0
-          stack-version: 2.3.3
+          stack-version: 2.5.0.1
           enable-stack: true
 
       - name: setup-node-14
-        uses: actions/setup-node@v2.0.0
+        uses: actions/setup-node@v2.1.1
         with:
-          node-version: 14.11.0
+          node-version: 14.12.0
 
       - name: checkout
         uses: actions/checkout@v2
@@ -148,13 +148,13 @@ jobs:
         uses: actions/setup-haskell@v1
         with:
           cabal-version: 3.2.0.0
-          stack-version: 2.3.3
+          stack-version: 2.5.0.1
           enable-stack: true
 
       - name: setup-node-14
-        uses: actions/setup-node@v2.0.0
+        uses: actions/setup-node@v2.1.1
         with:
-          node-version: 14.11.0
+          node-version: 14.12.0
 
       - name: checkout
         uses: actions/checkout@v2
@@ -191,13 +191,13 @@ jobs:
         uses: actions/setup-haskell@v1
         with:
           cabal-version: 3.2.0.0
-          stack-version: 2.3.3
+          stack-version: 2.5.0.1
           enable-stack: true
 
       - name: setup-node-14
-        uses: actions/setup-node@v2.0.0
+        uses: actions/setup-node@v2.1.1
         with:
-          node-version: 14.11.0
+          node-version: 14.12.0
 
       - name: checkout
         uses: actions/checkout@v2
@@ -249,13 +249,13 @@ jobs:
         uses: actions/setup-haskell@v1
         with:
           cabal-version: 3.2.0.0
-          stack-version: 2.3.3
+          stack-version: 2.5.0.1
           enable-stack: true
 
       - name: setup-node-14
-        uses: actions/setup-node@v2.0.0
+        uses: actions/setup-node@v2.1.1
         with:
-          node-version: 14.11.0
+          node-version: 14.12.0
 
       - name: checkout
         uses: actions/checkout@v2
@@ -296,13 +296,13 @@ jobs:
         uses: actions/setup-haskell@v1
         with:
           cabal-version: 3.2.0.0
-          stack-version: 2.3.3
+          stack-version: 2.5.0.1
           enable-stack: true
 
       - name: setup-node-14
-        uses: actions/setup-node@v2.0.0
+        uses: actions/setup-node@v2.1.1
         with:
-          node-version: 14.11.0
+          node-version: 14.12.0
 
       - name: checkout
         uses: actions/checkout@v2
@@ -348,7 +348,7 @@ jobs:
       - name: setup-haskell
         uses: actions/setup-haskell@v1
         with:
-          stack-version: 2.3.3
+          stack-version: 2.5.0.1
           enable-stack: true
           stack-no-global: true
 
@@ -413,12 +413,12 @@ jobs:
       - name: setup-python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8.5
+          python-version: 3.8.6
 
       - name: setup-node-14
-        uses: actions/setup-node@v2.0.0
+        uses: actions/setup-node@v2.1.1
         with:
-          node-version: 14.11.0
+          node-version: 14.12.0
 
       - name: setup-deps
         run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: setup-haskell
-        uses: actions/setup-haskell@v1
+        uses: actions/setup-haskell@main
         with:
           cabal-version: 3.2.0.0
           stack-version: 2.5.0.1
@@ -57,7 +57,7 @@ jobs:
     steps:
 
       - name: setup-haskell
-        uses: actions/setup-haskell@v1
+        uses: actions/setup-haskell@main
         with:
           cabal-version: 3.2.0.0
           stack-version: 2.5.0.1
@@ -145,7 +145,7 @@ jobs:
     steps:
 
       - name: setup-haskell
-        uses: actions/setup-haskell@v1
+        uses: actions/setup-haskell@main
         with:
           cabal-version: 3.2.0.0
           stack-version: 2.5.0.1
@@ -188,7 +188,7 @@ jobs:
     steps:
 
       - name: setup-haskell
-        uses: actions/setup-haskell@v1
+        uses: actions/setup-haskell@main
         with:
           cabal-version: 3.2.0.0
           stack-version: 2.5.0.1
@@ -246,7 +246,7 @@ jobs:
     steps:
 
       - name: setup-haskell
-        uses: actions/setup-haskell@v1
+        uses: actions/setup-haskell@main
         with:
           cabal-version: 3.2.0.0
           stack-version: 2.5.0.1
@@ -293,7 +293,7 @@ jobs:
     steps:
 
       - name: setup-haskell
-        uses: actions/setup-haskell@v1
+        uses: actions/setup-haskell@main
         with:
           cabal-version: 3.2.0.0
           stack-version: 2.5.0.1
@@ -346,7 +346,7 @@ jobs:
     steps:
 
       - name: setup-haskell
-        uses: actions/setup-haskell@v1
+        uses: actions/setup-haskell@main
         with:
           stack-version: 2.5.0.1
           enable-stack: true

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
 
       - name: setup-haskell
-        uses: actions/setup-haskell@main
+        uses: actions/setup-haskell@v1
         with:
           cabal-version: 3.2.0.0
-          stack-version: 2.5.0.1
+          stack-version: 2.3.3
           enable-stack: true
 
       - name: setup-node-14
@@ -57,10 +57,10 @@ jobs:
     steps:
 
       - name: setup-haskell
-        uses: actions/setup-haskell@main
+        uses: actions/setup-haskell@v1
         with:
           cabal-version: 3.2.0.0
-          stack-version: 2.5.0.1
+          stack-version: 2.3.3
           enable-stack: true
 
       - name: setup-node-14
@@ -145,10 +145,10 @@ jobs:
     steps:
 
       - name: setup-haskell
-        uses: actions/setup-haskell@main
+        uses: actions/setup-haskell@v1
         with:
           cabal-version: 3.2.0.0
-          stack-version: 2.5.0.1
+          stack-version: 2.3.3
           enable-stack: true
 
       - name: setup-node-14
@@ -188,10 +188,10 @@ jobs:
     steps:
 
       - name: setup-haskell
-        uses: actions/setup-haskell@main
+        uses: actions/setup-haskell@v1
         with:
           cabal-version: 3.2.0.0
-          stack-version: 2.5.0.1
+          stack-version: 2.3.3
           enable-stack: true
 
       - name: setup-node-14
@@ -246,10 +246,10 @@ jobs:
     steps:
 
       - name: setup-haskell
-        uses: actions/setup-haskell@main
+        uses: actions/setup-haskell@v1
         with:
           cabal-version: 3.2.0.0
-          stack-version: 2.5.0.1
+          stack-version: 2.3.3
           enable-stack: true
 
       - name: setup-node-14
@@ -293,10 +293,10 @@ jobs:
     steps:
 
       - name: setup-haskell
-        uses: actions/setup-haskell@main
+        uses: actions/setup-haskell@v1
         with:
           cabal-version: 3.2.0.0
-          stack-version: 2.5.0.1
+          stack-version: 2.3.3
           enable-stack: true
 
       - name: setup-node-14
@@ -346,9 +346,9 @@ jobs:
     steps:
 
       - name: setup-haskell
-        uses: actions/setup-haskell@main
+        uses: actions/setup-haskell@v1
         with:
-          stack-version: 2.5.0.1
+          stack-version: 2.3.3
           enable-stack: true
           stack-no-global: true
 

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -6,7 +6,7 @@ ENV \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \
   LC_CTYPE=C.UTF-8 \
-  PATH=/root/.asterius-local-install-root/bin:/root/.asterius-snapshot-install-root/bin:/root/.asterius-compiler-bin:/root/.local/bin:/root/.nvm/versions/node/v14.11.0/bin:${PATH}
+  PATH=/root/.asterius-local-install-root/bin:/root/.asterius-snapshot-install-root/bin:/root/.asterius-compiler-bin:/root/.local/bin:/root/.nvm/versions/node/v14.12.0/bin:${PATH}
 
 RUN \
   apt update && \
@@ -32,15 +32,15 @@ RUN \
 WORKDIR /root
 
 RUN \
-  (curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash) && \
-  bash -c ". ~/.nvm/nvm.sh && nvm install 14.11.0" && \
+  (curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.36.0/install.sh | bash) && \
+  bash -c ". ~/.nvm/nvm.sh && nvm install 14.12.0" && \
   npm config set unsafe-perm true && \
   npm install -g \
     @cloudflare/wrangler \
     webpack@next \
     webpack-cli && \
   mkdir -p ~/.local/bin && \
-  curl -L https://github.com/commercialhaskell/stack/releases/download/v2.3.3/stack-2.3.3-linux-x86_64-bin -o ~/.local/bin/stack && \
+  curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.0.1/stack-2.5.0.1-linux-x86_64-bin -o ~/.local/bin/stack && \
   chmod +x ~/.local/bin/stack && \
   curl -L https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz | tar xJ -C ~/.local/bin 'cabal'
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -7,7 +7,7 @@ ENV \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \
   LC_CTYPE=C.UTF-8 \
-  PATH=/root/.local/bin:/root/.nvm/versions/node/v14.11.0/bin:${PATH}
+  PATH=/root/.local/bin:/root/.nvm/versions/node/v14.12.0/bin:${PATH}
 
 RUN \
   apt update && \
@@ -42,11 +42,11 @@ RUN \
 WORKDIR /root
 
 RUN \
-  (curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash) && \
-  bash -c ". ~/.nvm/nvm.sh && nvm install 14.11.0" && \
+  (curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.36.0/install.sh | bash) && \
+  bash -c ". ~/.nvm/nvm.sh && nvm install 14.12.0" && \
   echo "eval \"\$(direnv hook bash)\"" >> ~/.bashrc && \
   mkdir -p ~/.local/bin && \
-  curl -L https://github.com/commercialhaskell/stack/releases/download/v2.3.3/stack-2.3.3-linux-x86_64-bin -o ~/.local/bin/stack && \
+  curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.0.1/stack-2.5.0.1-linux-x86_64-bin -o ~/.local/bin/stack && \
   chmod +x ~/.local/bin/stack && \
   curl -L https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz | tar xJ -C ~/.local/bin 'cabal' && \
   npm config set unsafe-perm true && \

--- a/dev.rootless.Dockerfile
+++ b/dev.rootless.Dockerfile
@@ -42,7 +42,7 @@ ENV \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \
   LC_CTYPE=C.UTF-8 \
-  PATH=/home/${USERNAME}/.local/bin:/home/${USERNAME}/.nvm/versions/node/v14.11.0/bin:${PATH}
+  PATH=/home/${USERNAME}/.local/bin:/home/${USERNAME}/.nvm/versions/node/v14.12.0/bin:${PATH}
 
 RUN \
   sudo apt update && \
@@ -73,11 +73,11 @@ RUN \
     /var/tmp/*
 
 RUN \
-  (curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash) && \
-  bash -c ". ~/.nvm/nvm.sh && nvm install 14.11.0" && \
+  (curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.36.0/install.sh | bash) && \
+  bash -c ". ~/.nvm/nvm.sh && nvm install 14.12.0" && \
   echo "eval \"\$(direnv hook bash)\"" >> ~/.bashrc && \
   mkdir -p ~/.local/bin && \
-  curl -L https://github.com/commercialhaskell/stack/releases/download/v2.3.3/stack-2.3.3-linux-x86_64-bin -o ~/.local/bin/stack && \
+  curl -L https://github.com/commercialhaskell/stack/releases/download/v2.5.0.1/stack-2.5.0.1-linux-x86_64-bin -o ~/.local/bin/stack && \
   chmod +x ~/.local/bin/stack && \
   curl -L https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz | tar xJ -C ~/.local/bin 'cabal' && \
   npm install -g \


### PR DESCRIPTION
Not updating the stackage snapshot this time, since we may switch to a `nixpkgs`-based snapshot generator recently.

* Update `stack` to `2.5.0.1` in the images to address the `casa.fpcomplete.com` timeout problem.
* Update `node` to `14.12.0`
* Update `nvm` to `0.36.0`
* Update `python` to `3.8.6`