### PR TITLE
Add optional type hints to C FFI

### DIFF
--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -846,7 +846,8 @@ generateWrapperFunction func_sym Function {functionType = FunctionType {..}} =
               | (i, wrapper_param_type, from_wrapper_param_type) <-
                   wrapper_param_types
             ],
-          callReturnTypes = returnTypes
+          callReturnTypes = returnTypes,
+          callHint = Nothing
         }
     }
   where

--- a/asterius/src/Asterius/EDSL.hs
+++ b/asterius/src/Asterius/EDSL.hs
@@ -359,12 +359,26 @@ mkDynamicFunctionAddress off =
     `orInt64` ConstI64 (functionTag `shiftL` 32)
 
 call :: EntitySymbol -> [Expression] -> EDSL ()
-call f xs = emit Call {target = f, operands = xs, callReturnTypes = []}
+call f xs =
+  emit
+    Call
+      { target = f,
+        operands = xs,
+        callReturnTypes = [],
+        callHint = Nothing
+      }
 
 call' :: EntitySymbol -> [Expression] -> ValueType -> EDSL Expression
 call' f xs vt = do
   lr <- mutLocal vt
-  putLVal lr Call {target = f, operands = xs, callReturnTypes = [vt]}
+  putLVal
+    lr
+    Call
+      { target = f,
+        operands = xs,
+        callReturnTypes = [vt],
+        callHint = Nothing
+      }
   pure $ getLVal lr
 
 -- | Call a function with no return value

--- a/asterius/src/Asterius/Internals/Barf.hs
+++ b/asterius/src/Asterius/Internals/Barf.hs
@@ -23,14 +23,16 @@ barf msg vts =
         [ Call
             { target = "barf_push",
               operands = [ConstI64 $ fromIntegral $ ord c],
-              callReturnTypes = []
+              callReturnTypes = [],
+              callHint = Nothing
             }
           | c <- CBS.unpack msg
         ]
           ++ [ Call
                  { target = "barf_throw",
                    operands = [],
-                   callReturnTypes = []
+                   callReturnTypes = [],
+                   callHint = Nothing
                  }
              ]
           ++ [Unreachable],

--- a/asterius/src/Asterius/Types.hs
+++ b/asterius/src/Asterius/Types.hs
@@ -31,6 +31,7 @@ module Asterius.Types
     FunctionType (..),
     UnaryOp (..),
     BinaryOp (..),
+    FFIHint (..),
     Expression (..),
     Function (..),
     FunctionImport (..),
@@ -366,6 +367,12 @@ data GlobalType
       }
   deriving (Eq, Ord, Show, Data)
 
+data FFIHint
+  = NoHint
+  | AddrHint
+  | SignedHint
+  deriving (Show, Data)
+
 data Expression
   = Block
       { name :: BS.ByteString,
@@ -392,7 +399,8 @@ data Expression
   | Call
       { target :: EntitySymbol,
         operands :: [Expression],
-        callReturnTypes :: [ValueType]
+        callReturnTypes :: [ValueType],
+        callHint :: Maybe ([FFIHint], [FFIHint])
       }
   | CallImport
       { target' :: BS.ByteString,
@@ -698,6 +706,8 @@ $(genNFData ''GlobalType)
 
 $(genNFData ''Global)
 
+$(genNFData ''FFIHint)
+
 $(genNFData ''Expression)
 
 $(genNFData ''Function)
@@ -771,6 +781,8 @@ $(genBinary ''Mutability)
 $(genBinary ''GlobalType)
 
 $(genBinary ''Global)
+
+$(genBinary ''FFIHint)
 
 $(genBinary ''Expression)
 


### PR DESCRIPTION
This PR adds a `FFIHint` type that models `ForeignHint` in GHC API, and uses it to annotate argument/result types of C FFI. Since we use the `Call` node for both regular C FFI (as in `foreign import ccall`) and runtime intrinsic calls, this hint is optional and should only exist if the callee is indeed a C function.

Adding type hints is a prerequisite to support calling a C function in the `wasi-sdk` world, since we need to cast between 32/64 bit pointers when marshaling such a call. Without modifying the IR, we would need to use JavaScript wrappers for each such function, which brings too much boilerplate and extra overhead.