### PR TITLE
Implement data segment overlap check

### DIFF
--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -716,6 +716,7 @@ marshalModule pic_on verbose_err tail_calls ss_off_map fn_off_map hs_mod@Module 
       marshalFunctionTable m tableSlots functionTable
       marshalTableImport m tableImport
       marshalMemorySegments memoryMBlocks memorySegments
+      marshalMemoryImport m memoryImport
       lift $ checkOverlapDataSegment m
     lim_segs <- marshalBS a "limit-segments"
     (lim_segs_p, _) <- marshalV a [lim_segs]

--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -716,8 +716,8 @@ marshalModule pic_on verbose_err tail_calls ss_off_map fn_off_map hs_mod@Module 
       marshalFunctionTable m tableSlots functionTable
       marshalTableImport m tableImport
       marshalMemorySegments memoryMBlocks memorySegments
+      unless pic_on $ lift $ checkOverlapDataSegment m
       marshalMemoryImport m memoryImport
-      lift $ checkOverlapDataSegment m
     lim_segs <- marshalBS a "limit-segments"
     (lim_segs_p, _) <- marshalV a [lim_segs]
     Binaryen.Module.runPasses m lim_segs_p 1

--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -22,6 +22,7 @@ module Asterius.Backends.Binaryen
   )
 where
 
+import Asterius.Backends.Binaryen.CheckOverlapDataSegment
 import Asterius.Builtins
 import Asterius.EDSL (mkDynamicDataAddress, mkDynamicFunctionAddress)
 import qualified Asterius.Internals.Arena as A
@@ -715,7 +716,7 @@ marshalModule pic_on verbose_err tail_calls ss_off_map fn_off_map hs_mod@Module 
       marshalFunctionTable m tableSlots functionTable
       marshalTableImport m tableImport
       marshalMemorySegments memoryMBlocks memorySegments
-      marshalMemoryImport m memoryImport
+      lift $ checkOverlapDataSegment m
     lim_segs <- marshalBS a "limit-segments"
     (lim_segs_p, _) <- marshalV a [lim_segs]
     Binaryen.Module.runPasses m lim_segs_p 1

--- a/asterius/src/Asterius/Backends/Binaryen/CheckOverlapDataSegment.hs
+++ b/asterius/src/Asterius/Backends/Binaryen/CheckOverlapDataSegment.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Asterius.Backends.Binaryen.CheckOverlapDataSegment
+  ( checkOverlapDataSegment,
+  )
+where
+
+import qualified Binaryen.Module as Binaryen
+import Control.Monad
+import Data.List
+import Data.Traversable
+
+checkOverlapDataSegment :: Binaryen.Module -> IO ()
+checkOverlapDataSegment m = do
+  (n :: Int) <- fromIntegral <$> Binaryen.getNumMemorySegments m
+  segs <- fmap (sortOn fst) $
+    for [0 .. n - 1] $ \_i -> do
+      let i = fromIntegral _i
+      (o :: Int) <- fromIntegral <$> Binaryen.getMemorySegmentByteOffset m i
+      (l :: Int) <- fromIntegral <$> Binaryen.getMemorySegmentByteLength m i
+      pure (o, l)
+  let f = and [o0 + l0 <= o1 | ((o0, l0), (o1, _)) <- zip segs (tail segs)]
+  unless f $ fail "OVERLAPPING DATA SEGMENT"


### PR DESCRIPTION
Accidentally overlapping data segments cost us a ton of debugging time when working on #729. It's reasonable to make a mandatory pass to prevent future regressions.