### PR TITLE
Set up wasi-sdk

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -94,6 +94,8 @@ jobs:
 
       - name: test
         run: |
+          export WASI_SDK_PATH=/opt/wasi-sdk
+
           stack test asterius:fib --test-arguments="$ASTERIUS_WITH_PIC"
           stack test asterius:jsffi --test-arguments="$ASTERIUS_WITH_PIC"
           stack test asterius:array --test-arguments="$ASTERIUS_WITH_PIC"
@@ -173,6 +175,7 @@ jobs:
 
       - name: ghc-testsuite
         run: |
+          export WASI_SDK_PATH=/opt/wasi-sdk
           export GHCRTS=-N2
           stack test asterius:ghc-testsuite --test-arguments="-j2 --timeout=300s" || true
 
@@ -219,6 +222,7 @@ jobs:
 
       - name: profile
         run: |
+          export WASI_SDK_PATH=/opt/wasi-sdk
           . ./.envrc
 
           mkdir /tmp/asterius-profile
@@ -321,6 +325,7 @@ jobs:
 
       - name: test-cabal
         run: |
+          export WASI_SDK_PATH=/opt/wasi-sdk
           . ./.envrc
           pushd ghc-toolkit/boot-libs
 

--- a/.github/workflows/setup-deps.sh
+++ b/.github/workflows/setup-deps.sh
@@ -18,3 +18,6 @@ curl \
   http://deb.debian.org/debian/pool/main/b/binaryen/binaryen_97-1_amd64.deb
 sudo dpkg -i /tmp/binaryen.deb
 rm /tmp/binaryen.deb
+
+sudo mkdir -p /opt/wasi-sdk
+curl -L https://github.com/TerrorJack/wasi-sdk/releases/download/201014/wasi-sdk-11.5g3cbd9d212e9a-linux.tar.gz | sudo tar xz -C /opt/wasi-sdk --strip-components=1

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -6,7 +6,8 @@ ENV \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \
   LC_CTYPE=C.UTF-8 \
-  PATH=/root/.asterius-local-install-root/bin:/root/.asterius-snapshot-install-root/bin:/root/.asterius-compiler-bin:/root/.local/bin:/root/.nvm/versions/node/v14.13.1/bin:${PATH}
+  PATH=/root/.asterius-local-install-root/bin:/root/.asterius-snapshot-install-root/bin:/root/.asterius-compiler-bin:/root/.local/bin:/root/.nvm/versions/node/v14.13.1/bin:${PATH} \
+  WASI_SDK_PATH=/opt/wasi-sdk
 
 RUN \
   apt update && \
@@ -21,8 +22,12 @@ RUN \
     libffi-dev \
     libgmp-dev \
     libncurses-dev \
+    libtinfo5 \
+    libxml2 \
     python3-minimal \
     zlib1g-dev && \
+  mkdir -p ${WASI_SDK_PATH} && \
+  (curl -L https://github.com/TerrorJack/wasi-sdk/releases/download/201014/wasi-sdk-11.5g3cbd9d212e9a-linux.tar.gz | tar xz -C ${WASI_SDK_PATH} --strip-components=1) && \
   cp \
     /etc/skel/.bash_logout \
     /etc/skel/.bashrc \
@@ -107,4 +112,5 @@ RUN \
   alex --version && \
   cabal --version && \
   node --version && \
-  wasm-opt --version
+  wasm-opt --version && \
+  wasm-ld --version

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -7,7 +7,8 @@ ENV \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \
   LC_CTYPE=C.UTF-8 \
-  PATH=/root/.local/bin:/root/.nvm/versions/node/v14.13.1/bin:${PATH}
+  PATH=/root/.local/bin:/root/.nvm/versions/node/v14.13.1/bin:${PATH} \
+  WASI_SDK_PATH=/opt/wasi-sdk
 
 RUN \
   apt update && \
@@ -23,6 +24,7 @@ RUN \
     libffi-dev \
     libgmp-dev \
     libncurses-dev \
+    libtinfo5 \
     openssh-client \
     python3-pip \
     ripgrep \
@@ -30,6 +32,8 @@ RUN \
     xdg-utils \
     zlib1g-dev \
     zstd && \
+  mkdir -p ${WASI_SDK_PATH} && \
+  (curl -L https://github.com/TerrorJack/wasi-sdk/releases/download/201014/wasi-sdk-11.5g3cbd9d212e9a-linux.tar.gz | tar xz -C ${WASI_SDK_PATH} --strip-components=1) && \
   apt autoremove --purge -y && \
   apt clean && \
   rm -rf -v /var/lib/apt/lists/* && \

--- a/dev.rootless.Dockerfile
+++ b/dev.rootless.Dockerfile
@@ -42,7 +42,8 @@ ENV \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \
   LC_CTYPE=C.UTF-8 \
-  PATH=/home/${USERNAME}/.local/bin:/home/${USERNAME}/.nvm/versions/node/v14.13.1/bin:${PATH}
+  PATH=/home/${USERNAME}/.local/bin:/home/${USERNAME}/.nvm/versions/node/v14.13.1/bin:${PATH} \
+  WASI_SDK_PATH=/opt/wasi-sdk
 
 RUN \
   sudo apt update && \
@@ -58,6 +59,7 @@ RUN \
     libffi-dev \
     libgmp-dev \
     libncurses-dev \
+    libtinfo5 \
     openssh-client \
     python3-pip \
     ripgrep \
@@ -65,6 +67,8 @@ RUN \
     xdg-utils \
     zlib1g-dev \
     zstd && \
+  sudo mkdir -p ${WASI_SDK_PATH} && \
+  (curl -L https://github.com/TerrorJack/wasi-sdk/releases/download/201014/wasi-sdk-11.5g3cbd9d212e9a-linux.tar.gz | sudo tar xz -C ${WASI_SDK_PATH} --strip-components=1) && \
   sudo apt autoremove --purge -y && \
   sudo apt clean && \
   sudo rm -rf -v \

--- a/docs/building.md
+++ b/docs/building.md
@@ -43,6 +43,7 @@ needed in the local environment:
 * `cabal` (at least `v3.0.0.0`)
 * `node`, `npm` (at least `v12`)
 * `g++`, `python3` (may be required by `node-gyp`)
+* `wasi-sdk` (the `WASI_SDK_PATH` environment variable is required)
 
 ### Building `asterius`
 


### PR DESCRIPTION
Another prerequisite for #729. We now require `wasi-sdk` to be set up in the user environment, and `WASI_SDK_PATH` is expected to point to its installation path (`/opt/wasi-sdk` when using the official builds). We also set up `wasi-sdk` on CI and our prebuilt images.