### PR TITLE
Analyze used ccalls in linker output

### DIFF
--- a/asterius/src/Asterius/Internals/SYB.hs
+++ b/asterius/src/Asterius/Internals/SYB.hs
@@ -4,12 +4,15 @@
 module Asterius.Internals.SYB
   ( GenericM,
     everywhereM,
+    GenericQ,
+    everything,
   )
 where
 
 import Data.Data
   ( Data,
     gmapM,
+    gmapQl,
   )
 
 type GenericM m = forall a. Data a => a -> m a
@@ -20,3 +23,12 @@ everywhereM f = w
   where
     w :: GenericM m
     w = (>>= gmapM w) . f
+
+type GenericQ r = forall a. Data a => a -> r
+
+{-# INLINEABLE everything #-}
+everything :: forall r. Monoid r => GenericQ r -> GenericQ r
+everything f = w
+  where
+    w :: GenericQ r
+    w x = gmapQl (<>) (f x) w x

--- a/asterius/src/Asterius/Passes/FindCCall.hs
+++ b/asterius/src/Asterius/Passes/FindCCall.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Asterius.Passes.FindCCall
+  ( findCCall,
+  )
+where
+
+import Asterius.Internals.SYB
+import Asterius.Types
+import qualified Asterius.Types.SymbolSet as SS
+import qualified Data.ByteString.Char8 as CBS
+import Type.Reflection
+
+findCCall :: GenericQ [String]
+findCCall = map (CBS.unpack . entityName) . SS.toList . everything f
+  where
+    f :: GenericQ SS.SymbolSet
+    f t
+      | Just HRefl <- eqTypeRep (typeOf t) (typeRep @Expression) = case t of
+        Call {callHint = Just _, ..} -> SS.singleton target
+        _ -> SS.empty
+      | otherwise = SS.empty

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -16,6 +16,7 @@ import Asterius.Builtins
 import Asterius.JSFFI
 import Asterius.MemoryTrap
 import Asterius.Passes.DataOffsetTable
+import Asterius.Passes.FindCCall
 import Asterius.Passes.FunctionOffsetTable
 import Asterius.Passes.GCSections
 import Asterius.Types
@@ -24,6 +25,7 @@ import qualified Asterius.Types.SymbolSet as SS
 import Asterius.Types.LinkReport
 import Control.DeepSeq
 import qualified Data.Map.Lazy as LM
+import Data.String
 import Foreign
 import Language.Haskell.GHC.Toolkit.Constants
 
@@ -122,7 +124,10 @@ linkStart pic_on debug gc_sections store root_syms export_funcs =
         Asterius.Types.LinkReport.tableSlots = tbl_slots,
         staticBytes = static_bytes,
         sptEntries = sptMap merged_m,
-        bundledFFIMarshalState = ffiMarshalState merged_m
+        bundledFFIMarshalState = ffiMarshalState merged_m,
+        usedCCalls =
+          filter (not . (`SM.member` functionMap merged_m) . fromString) $
+            findCCall (functionMap merged_m)
       }
   )
   where

--- a/asterius/src/Asterius/Types/LinkReport.hs
+++ b/asterius/src/Asterius/Types/LinkReport.hs
@@ -17,7 +17,8 @@ data LinkReport
         infoTableOffsetSet :: [Word32],
         tableSlots, staticBytes :: Int,
         sptEntries :: SymbolMap (Word64, Word64),
-        bundledFFIMarshalState :: FFIMarshalState
+        bundledFFIMarshalState :: FFIMarshalState,
+        usedCCalls :: [String]
       }
   deriving (Show)
 


### PR DESCRIPTION
A part of #729 work:

* Add an SYB-style generic query function `everything`
* Implement a `FindCCall` pass that traverses the IR and looks for ccalls with type hints (which comes from a `foreign import ccall`)
* Add `usedCCalls` to `LinkReport`, and it's populated by all found ccalls *excluding* the ones already present in the wasm world. So if we have a built-in runtime function `func` and it's used by a `foreign import` somewhere, then `func` won't be present in `usedCCalls`. This ensures compatability: the external C world is only used to complement the missing bits, not to overwrite existing stuff.