### PR TITLE
Cheap tracing pass in debug mode

### DIFF
--- a/asterius/rts/rts.exception.mjs
+++ b/asterius/rts/rts.exception.mjs
@@ -148,19 +148,19 @@ export class ExceptionHelper {
     Asterius to report missing symbols. Instead of finding the error message to
     print in a data segment (like `barf` does), this approach accumulates it
     (character by character) into an internal buffer using `barf_push`. Then, a
-    call to `barf_throw` reads this buffer and throws the error.
+    call to `barf_signal` reads this buffer and throws the error.
 
     The related logic can be found in two places in the Asterius compiler:
 
     * In the rts builtins (`Asterius.Builtins`) module, we import `barf_push`
-      (and `barf_throw`) as `__asterius_barf_push` (and
-      `__asterius_barf_throw`), and make a `barf_push` (and `barf_throw`)
+      (and `barf_signal`) as `__asterius_barf_push` (and
+      `__asterius_barf_signal`), and make a `barf_push` (and `barf_signal`)
       function wrapper which handles the i64/f64 conversion workaround.
 
     * In `Asterius.Internals.Barf` we implement `barf`, which converts a single
       `Barf` expression to a series of calls to `barf_push`, each taking (the
       ascii code of) a single character of the error message, followed by a
-      call to `barf_throw`.
+      call to `barf_signal`.
 
     In the backend (`Asterius.Backends.Binaryen*`), when we encounter an unresolved
     symbol `sym`, if @verbose_err@ is on, we insert a `barf` call there. So
@@ -168,10 +168,14 @@ export class ExceptionHelper {
     the symbol name from the js error message.
   */
   barf_push(c) {
-      this.errorBuffer += String.fromCodePoint(c);
+    this.errorBuffer += String.fromCodePoint(c);
   }
 
-  barf_throw() {
-    throw new WebAssembly.RuntimeError(`barf_throw: ${this.errorBuffer}`);
+  barf_signal(f) {
+    const buf = this.errorBuffer;
+    this.errorBuffer = "";
+    if (f) {
+      throw new WebAssembly.RuntimeError(`barf_signal: ${buf}`);
+    }
   }
 }

--- a/asterius/rts/rts.exception.mjs
+++ b/asterius/rts/rts.exception.mjs
@@ -176,6 +176,8 @@ export class ExceptionHelper {
     this.errorBuffer = "";
     if (f) {
       throw new WebAssembly.RuntimeError(`barf_signal: ${buf}`);
+    } else {
+      console.error(`[DEBUG] ${buf}`);
     }
   }
 }

--- a/asterius/src/Asterius/Builtins/Barf.hs
+++ b/asterius/src/Asterius/Builtins/Barf.hs
@@ -19,33 +19,23 @@ barfImports =
         functionType = FunctionType {paramTypes = [F64], returnTypes = []}
       },
     FunctionImport
-      { internalName = "__asterius_barf_push",
+      { internalName = "barf_push",
         externalModuleName = "ExceptionHelper",
         externalBaseName = "barf_push",
-        functionType = FunctionType {paramTypes = [F64], returnTypes = []}
+        functionType = FunctionType {paramTypes = [I32], returnTypes = []}
       },
     FunctionImport
-      { internalName = "__asterius_barf_throw",
+      { internalName = "barf_signal",
         externalModuleName = "ExceptionHelper",
-        externalBaseName = "barf_throw",
-        functionType = FunctionType {paramTypes = [], returnTypes = []}
+        externalBaseName = "barf_signal",
+        functionType = FunctionType {paramTypes = [I32], returnTypes = []}
       }
   ]
 
 barfCBits :: AsteriusModule
-barfCBits = barfFunction <> barfPushFunction <> barfThrowFunction
+barfCBits = barfFunction
 
 barfFunction :: AsteriusModule
 barfFunction = runEDSL "barf" $ do
   s <- param I64
   callImport "__asterius_barf" [convertUInt64ToFloat64 s]
-
-barfPushFunction :: AsteriusModule
-barfPushFunction = runEDSL "barf_push" $ do
-  s <- param I64
-  callImport "__asterius_barf_push" [convertUInt64ToFloat64 s]
-
-barfThrowFunction :: AsteriusModule
-barfThrowFunction = runEDSL "barf_throw" $ do
-  _ <- params []
-  callImport "__asterius_barf_throw" []

--- a/asterius/src/Asterius/Ld.hs
+++ b/asterius/src/Asterius/Ld.hs
@@ -55,8 +55,6 @@ rtsUsedSymbols :: SS.SymbolSet
 rtsUsedSymbols =
   SS.fromList
     [ "barf",
-      "barf_push",
-      "barf_throw",
       "base_AsteriusziTopHandler_runIO_closure",
       "base_AsteriusziTopHandler_runNonIO_closure",
       "base_AsteriusziTypesziJSException_mkJSException_closure",

--- a/asterius/src/Asterius/Passes/Tracing.hs
+++ b/asterius/src/Asterius/Passes/Tracing.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Asterius.Passes.Tracing
+  ( traceModule,
+  )
+where
+
+import Asterius.Types
+import qualified Asterius.Types.SymbolMap as SM
+import qualified Data.ByteString.Char8 as CBS
+import Data.Char
+
+traceModule :: AsteriusModule -> AsteriusModule
+traceModule m = m {functionMap = SM.mapWithKey traceFunction (functionMap m)}
+
+traceFunction :: EntitySymbol -> Function -> Function
+traceFunction sym Function {..} =
+  Function
+    { functionType = functionType,
+      varTypes = varTypes,
+      body =
+        Block
+          { name = "",
+            bodys =
+              [ CallImport
+                  { target' = "barf_push",
+                    operands = [ConstI32 $ fromIntegral $ ord c],
+                    callImportReturnTypes = []
+                  }
+                | c <- CBS.unpack (entityName sym)
+              ]
+                <> [ CallImport
+                       { target' = "barf_signal",
+                         operands = [ConstI32 0],
+                         callImportReturnTypes = []
+                       },
+                     body
+                   ],
+            blockReturnTypes = returnTypes functionType
+          }
+    }

--- a/asterius/src/Asterius/Resolve.hs
+++ b/asterius/src/Asterius/Resolve.hs
@@ -19,6 +19,7 @@ import Asterius.Passes.DataOffsetTable
 import Asterius.Passes.FindCCall
 import Asterius.Passes.FunctionOffsetTable
 import Asterius.Passes.GCSections
+import Asterius.Passes.Tracing
 import Asterius.Types
 import qualified Asterius.Types.SymbolMap as SM
 import qualified Asterius.Types.SymbolSet as SS
@@ -130,7 +131,7 @@ linkStart pic_on debug gc_sections store root_syms export_funcs =
       | otherwise = fromCachedModule store
     !merged_m0_evaluated = force merged_m0
     !merged_m1
-      | debug = addMemoryTrap merged_m0_evaluated
+      | debug = traceModule $ addMemoryTrap merged_m0_evaluated
       | otherwise = merged_m0_evaluated
     (!result_m, !merged_m, !ss_off_map, !fn_off_map, !tbl_slots, !static_bytes) =
       resolveAsteriusModule pic_on debug merged_m1


### PR DESCRIPTION
* `barf_throw` is renamed to `barf_signal` and takes a boolean flag to indicate whether an exception should be raised.
* When debug mode is on, each function uses `barf_push`/`barf_signal` to emit its function name as a tracing message.