### PR TITLE
Remove legacy memory-related runtime shims

### DIFF
--- a/asterius/rts/rts.memory.mjs
+++ b/asterius/rts/rts.memory.mjs
@@ -269,12 +269,4 @@ export class Memory {
     const buf = this.expose(_dst, n, Float64Array);
     buf.fill(c);
   }
-
-  memcmp(_ptr1, _ptr2, n) {
-    return this.components.exports.memcmp(
-      Memory.unTag(_ptr1),
-      Memory.unTag(_ptr2),
-      n
-    );
-  }
 }

--- a/asterius/rts/rts.memory.mjs
+++ b/asterius/rts/rts.memory.mjs
@@ -239,12 +239,6 @@ export class Memory {
     );
   }
 
-  memmove(_dst, _src, n) {
-    return Memory.tagData(
-      this.components.exports.memmove(Memory.unTag(_dst), Memory.unTag(_src), n)
-    );
-  }
-
   memset(_dst, c, n, size = 1) {
     // We only allow 1, 2, 4, 8. Any other size should get a runtime error.
     const ty = {

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -159,7 +159,6 @@ rtsAsteriusModule opts =
     <> strlenFunction opts
     <> debugBelch2Function opts
     <> memchrFunction opts
-    <> memcpyFunction opts
     <> memsetFunction opts
     <> memcmpFunction opts
     <> threadPausedFunction opts
@@ -438,15 +437,6 @@ rtsFunctionImports debug =
              functionType = FunctionType
                { paramTypes = [F64, F64, F64],
                  returnTypes = [F64]
-               }
-           },
-         FunctionImport
-           { internalName = "__asterius_memcpy",
-             externalModuleName = "Memory",
-             externalBaseName = "memcpy",
-             functionType = FunctionType
-               { paramTypes = [F64, F64, F64],
-                 returnTypes = []
                }
            },
          FunctionImport
@@ -1350,13 +1340,6 @@ memchrFunction _ = runEDSL "memchr" $ do
       (map convertUInt64ToFloat64 [ptr, val, num])
       F64
   emit $ truncUFloat64ToInt64 p
-
-memcpyFunction :: BuiltinsOptions -> AsteriusModule
-memcpyFunction _ = runEDSL "memcpy" $ do
-  setReturnTypes [I64]
-  [dst, src, n] <- params [I64, I64, I64]
-  callImport "__asterius_memcpy" $ map convertUInt64ToFloat64 [dst, src, n]
-  emit dst
 
 memsetFunction :: BuiltinsOptions -> AsteriusModule
 memsetFunction _ = runEDSL "memset" $ do

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -159,7 +159,6 @@ rtsAsteriusModule opts =
     <> strlenFunction opts
     <> debugBelch2Function opts
     <> memchrFunction opts
-    <> memsetFunction opts
     <> threadPausedFunction opts
     <> dirtyMutVarFunction opts
     <> dirtyMVarFunction opts
@@ -436,15 +435,6 @@ rtsFunctionImports debug =
              functionType = FunctionType
                { paramTypes = [F64, F64, F64],
                  returnTypes = [F64]
-               }
-           },
-         FunctionImport
-           { internalName = "__asterius_memset",
-             externalModuleName = "Memory",
-             externalBaseName = "memset",
-             functionType = FunctionType
-               { paramTypes = [F64, F64, F64],
-                 returnTypes = []
                }
            },
          FunctionImport
@@ -1321,13 +1311,6 @@ memchrFunction _ = runEDSL "memchr" $ do
       (map convertUInt64ToFloat64 [ptr, val, num])
       F64
   emit $ truncUFloat64ToInt64 p
-
-memsetFunction :: BuiltinsOptions -> AsteriusModule
-memsetFunction _ = runEDSL "memset" $ do
-  setReturnTypes [I64]
-  [dst, c, n] <- params [I64, I64, I64]
-  callImport "__asterius_memset" $ map convertUInt64ToFloat64 [dst, c, n]
-  emit dst
 
 threadPausedFunction :: BuiltinsOptions -> AsteriusModule
 threadPausedFunction _ = runEDSL "threadPaused" $ do

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -160,7 +160,6 @@ rtsAsteriusModule opts =
     <> debugBelch2Function opts
     <> memchrFunction opts
     <> memsetFunction opts
-    <> memcmpFunction opts
     <> threadPausedFunction opts
     <> dirtyMutVarFunction opts
     <> dirtyMVarFunction opts
@@ -446,15 +445,6 @@ rtsFunctionImports debug =
              functionType = FunctionType
                { paramTypes = [F64, F64, F64],
                  returnTypes = []
-               }
-           },
-         FunctionImport
-           { internalName = "__asterius_memcmp",
-             externalModuleName = "Memory",
-             externalBaseName = "memcmp",
-             functionType = FunctionType
-               { paramTypes = [F64, F64, F64],
-                 returnTypes = [I32]
                }
            },
          FunctionImport
@@ -1338,17 +1328,6 @@ memsetFunction _ = runEDSL "memset" $ do
   [dst, c, n] <- params [I64, I64, I64]
   callImport "__asterius_memset" $ map convertUInt64ToFloat64 [dst, c, n]
   emit dst
-
-memcmpFunction :: BuiltinsOptions -> AsteriusModule
-memcmpFunction _ = runEDSL "memcmp" $ do
-  setReturnTypes [I64]
-  [ptr1, ptr2, n] <- params [I64, I64, I64]
-  cres <-
-    callImport'
-      "__asterius_memcmp"
-      (map convertUInt64ToFloat64 [ptr1, ptr2, n])
-      I32
-  emit $ extendSInt32 cres
 
 threadPausedFunction :: BuiltinsOptions -> AsteriusModule
 threadPausedFunction _ = runEDSL "threadPaused" $ do

--- a/asterius/src/Asterius/Builtins.hs
+++ b/asterius/src/Asterius/Builtins.hs
@@ -440,15 +440,6 @@ rtsFunctionImports debug =
                }
            },
          FunctionImport
-           { internalName = "__asterius_memmove",
-             externalModuleName = "Memory",
-             externalBaseName = "memmove",
-             functionType = FunctionType
-               { paramTypes = [F64, F64, F64],
-                 returnTypes = []
-               }
-           },
-         FunctionImport
            { internalName = "__asterius_memset",
              externalModuleName = "Memory",
              externalBaseName = "memset",

--- a/asterius/src/Asterius/Builtins/Primitive.hs
+++ b/asterius/src/Asterius/Builtins/Primitive.hs
@@ -51,9 +51,7 @@ mkImport ext_mod_name ext_base_name fn_type =
 -- functions do not use them.
 primitiveImports :: [FunctionImport]
 primitiveImports =
-  [ mkImport "Memory" "memmove" $
-      FunctionType {paramTypes = [F64, F64, F64], returnTypes = []},
-    mkImport "Memory" "memset" $
+  [ mkImport "Memory" "memset" $
       FunctionType {paramTypes = [F64, F64, F64, F64], returnTypes = []},
     mkImport "Memory" "memsetFloat32" $
       FunctionType {paramTypes = [F64, F32, F64], returnTypes = []},
@@ -97,8 +95,8 @@ primitiveMemmove = runEDSL "hsprimitive_memmove" $ do
   [dst, doff, src, soff, len] <- params [I64, I64, I64, I64, I64]
   let arg1 = dst `addInt64` doff
       arg2 = src `addInt64` soff
-  callImport "__asterius_Memory_memmove" $
-    map convertUInt64ToFloat64 [arg1, arg2, len]
+  emit $ memmove arg1 arg2 len
+  emit arg1
 
 -- | @int hsprimitive_memcmp(HsWord8 *s1, HsWord8 *s2, size_t n)@
 primitiveMemcmp :: AsteriusModule

--- a/asterius/src/Asterius/Builtins/Primitive.hs
+++ b/asterius/src/Asterius/Builtins/Primitive.hs
@@ -51,9 +51,7 @@ mkImport ext_mod_name ext_base_name fn_type =
 -- functions do not use them.
 primitiveImports :: [FunctionImport]
 primitiveImports =
-  [ mkImport "Memory" "memcpy" $
-      FunctionType {paramTypes = [F64, F64, F64], returnTypes = []},
-    mkImport "Memory" "memmove" $
+  [ mkImport "Memory" "memmove" $
       FunctionType {paramTypes = [F64, F64, F64], returnTypes = []},
     mkImport "Memory" "memset" $
       FunctionType {paramTypes = [F64, F64, F64, F64], returnTypes = []},
@@ -90,8 +88,8 @@ primitiveMemcpy = runEDSL "hsprimitive_memcpy" $ do
   [dst, doff, src, soff, len] <- params [I64, I64, I64, I64, I64]
   let arg1 = dst `addInt64` doff
       arg2 = src `addInt64` soff
-  callImport "__asterius_Memory_memcpy" $
-    map convertUInt64ToFloat64 [arg1, arg2, len]
+  emit $ memcpy arg1 arg2 len
+  emit arg1
 
 -- | @void hsprimitive_memmove(void *dst, ptrdiff_t doff, void *src, ptrdiff_t soff, size_t len)@
 primitiveMemmove :: AsteriusModule

--- a/asterius/src/Asterius/Builtins/Primitive.hs
+++ b/asterius/src/Asterius/Builtins/Primitive.hs
@@ -56,9 +56,7 @@ primitiveImports =
     mkImport "Memory" "memsetFloat32" $
       FunctionType {paramTypes = [F64, F32, F64], returnTypes = []},
     mkImport "Memory" "memsetFloat64" $
-      FunctionType {paramTypes = [F64, F64, F64], returnTypes = []},
-    mkImport "Memory" "memcmp" $
-      FunctionType {paramTypes = [F64, F64, F64], returnTypes = [F64]}
+      FunctionType {paramTypes = [F64, F64, F64], returnTypes = []}
   ]
 
 -- -------------------------------------------------------------------------
@@ -102,13 +100,8 @@ primitiveMemmove = runEDSL "hsprimitive_memmove" $ do
 primitiveMemcmp :: AsteriusModule
 primitiveMemcmp = runEDSL "hsprimitive_memcmp" $ do
   setReturnTypes [I64]
-  args <- params [I64, I64, I64]
-  truncSFloat64ToInt64
-    <$> callImport'
-      "__asterius_Memory_memcmp"
-      (map convertUInt64ToFloat64 args)
-      F64
-    >>= emit
+  [lhs, rhs, n] <- params [I64, I64, I64]
+  emit $ extendSInt32 $ memcmp lhs rhs n
 
 -- | @void hsprimitive_memset_XXX (XXX *p, ptrdiff_t off, size_t n, XXX x)@
 mkPrimitiveMemsetUInt ::

--- a/asterius/src/Asterius/Builtins/SM.hs
+++ b/asterius/src/Asterius/Builtins/SM.hs
@@ -38,15 +38,11 @@ growStack = runEDSL "growStack" $ do
       next_stack_obj
         `addInt64` next_stack_obj_size
         `subInt64` prev_stack_used
-  _ <-
-    call'
-      "memcpy"
-      [next_stack_obj, prev_stack_obj, constI64 offset_StgStack_stack]
-      I64
+  emit $ memcpy next_stack_obj prev_stack_obj (constI64 offset_StgStack_stack)
   storeI32 next_stack_obj offset_StgStack_stack_size
     $ wrapInt64
     $ (next_stack_obj_size `subInt64` constI64 offset_StgStack_stack)
       `divUInt64` constI64 8
   storeI64 next_stack_obj offset_StgStack_sp next_sp
-  _ <- call' "memcpy" [next_sp, prev_sp, prev_stack_used] I64
+  emit $ memcpy next_sp prev_sp prev_stack_used
   emit next_stack_obj

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -865,13 +865,7 @@ marshalCmmPrimCall (GHC.MO_Memset _) [] [_dst, _c, _n] = do
   dst <- marshalAndCastCmmExpr _dst F64
   c <- marshalAndCastCmmExpr _c F64
   n <- marshalAndCastCmmExpr _n F64
-  pure
-    [ CallImport
-        { target' = "__asterius_memset",
-          operands = [dst, c, n],
-          callImportReturnTypes = []
-        }
-    ]
+  pure [memset dst c n]
 marshalCmmPrimCall (GHC.MO_Memmove _) [] [_dst, _src, _n] = do
   dst <- marshalAndCastCmmExpr _dst I64
   src <- marshalAndCastCmmExpr _src I64

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -857,17 +857,10 @@ marshalCmmPrimCall GHC.MO_WriteBarrier _ _ = pure []
 marshalCmmPrimCall GHC.MO_Touch _ _ = pure []
 marshalCmmPrimCall (GHC.MO_Prefetch_Data _) _ _ = pure []
 marshalCmmPrimCall (GHC.MO_Memcpy _) [] [_dst, _src, _n] = do
-  dst <- marshalAndCastCmmExpr _dst I32
-  src <- marshalAndCastCmmExpr _src I32
-  n <- marshalAndCastCmmExpr _n I32
-  pure
-    [ Drop { dropValue = Call
-        { target = "memcpy",
-          operands = [dst, src, n],
-          callReturnTypes = [I32],
-          callHint = Just ([AddrHint, AddrHint, NoHint], [AddrHint])
-        }}
-    ]
+  dst <- marshalAndCastCmmExpr _dst I64
+  src <- marshalAndCastCmmExpr _src I64
+  n <- marshalAndCastCmmExpr _n I64
+  pure [memcpy dst src n]
 marshalCmmPrimCall (GHC.MO_Memset _) [] [_dst, _c, _n] = do
   dst <- marshalAndCastCmmExpr _dst F64
   c <- marshalAndCastCmmExpr _c F64

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -873,16 +873,10 @@ marshalCmmPrimCall (GHC.MO_Memset _) [] [_dst, _c, _n] = do
         }
     ]
 marshalCmmPrimCall (GHC.MO_Memmove _) [] [_dst, _src, _n] = do
-  dst <- marshalAndCastCmmExpr _dst F64
-  src <- marshalAndCastCmmExpr _src F64
-  n <- marshalAndCastCmmExpr _n F64
-  pure
-    [ CallImport
-        { target' = "__asterius_memmove",
-          operands = [dst, src, n],
-          callImportReturnTypes = []
-        }
-    ]
+  dst <- marshalAndCastCmmExpr _dst I64
+  src <- marshalAndCastCmmExpr _src I64
+  n <- marshalAndCastCmmExpr _n I64
+  pure [memmove dst src n]
 marshalCmmPrimCall (GHC.MO_Memcmp _) [_cres] [_ptr1, _ptr2, _n] = do
   cres <- marshalTypedCmmLocalReg _cres I32
   ptr1 <- marshalAndCastCmmExpr _ptr1 F64

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -885,11 +885,7 @@ marshalCmmPrimCall (GHC.MO_Memcmp _) [_cres] [_ptr1, _ptr2, _n] = do
   pure
     [ UnresolvedSetLocal
         { unresolvedLocalReg = cres,
-          value = CallImport
-            { target' = "__asterius_memcmp",
-              operands = [ptr1, ptr2, n],
-              callImportReturnTypes = [I32]
-            }
+          value = memcmp ptr1 ptr2 n
         }
     ]
 marshalCmmPrimCall (GHC.MO_PopCnt GHC.W64) [r] [x] =

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -862,9 +862,9 @@ marshalCmmPrimCall (GHC.MO_Memcpy _) [] [_dst, _src, _n] = do
   n <- marshalAndCastCmmExpr _n I64
   pure [memcpy dst src n]
 marshalCmmPrimCall (GHC.MO_Memset _) [] [_dst, _c, _n] = do
-  dst <- marshalAndCastCmmExpr _dst F64
-  c <- marshalAndCastCmmExpr _c F64
-  n <- marshalAndCastCmmExpr _n F64
+  dst <- marshalAndCastCmmExpr _dst I64
+  c <- marshalAndCastCmmExpr _c I64
+  n <- marshalAndCastCmmExpr _n I64
   pure [memset dst c n]
 marshalCmmPrimCall (GHC.MO_Memmove _) [] [_dst, _src, _n] = do
   dst <- marshalAndCastCmmExpr _dst I64
@@ -873,9 +873,9 @@ marshalCmmPrimCall (GHC.MO_Memmove _) [] [_dst, _src, _n] = do
   pure [memmove dst src n]
 marshalCmmPrimCall (GHC.MO_Memcmp _) [_cres] [_ptr1, _ptr2, _n] = do
   cres <- marshalTypedCmmLocalReg _cres I32
-  ptr1 <- marshalAndCastCmmExpr _ptr1 F64
-  ptr2 <- marshalAndCastCmmExpr _ptr2 F64
-  n <- marshalAndCastCmmExpr _n F64
+  ptr1 <- marshalAndCastCmmExpr _ptr1 I64
+  ptr2 <- marshalAndCastCmmExpr _ptr2 I64
+  n <- marshalAndCastCmmExpr _n I64
   pure
     [ UnresolvedSetLocal
         { unresolvedLocalReg = cres,

--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -857,15 +857,16 @@ marshalCmmPrimCall GHC.MO_WriteBarrier _ _ = pure []
 marshalCmmPrimCall GHC.MO_Touch _ _ = pure []
 marshalCmmPrimCall (GHC.MO_Prefetch_Data _) _ _ = pure []
 marshalCmmPrimCall (GHC.MO_Memcpy _) [] [_dst, _src, _n] = do
-  dst <- marshalAndCastCmmExpr _dst F64
-  src <- marshalAndCastCmmExpr _src F64
-  n <- marshalAndCastCmmExpr _n F64
+  dst <- marshalAndCastCmmExpr _dst I32
+  src <- marshalAndCastCmmExpr _src I32
+  n <- marshalAndCastCmmExpr _n I32
   pure
-    [ CallImport
-        { target' = "__asterius_memcpy",
+    [ Drop { dropValue = Call
+        { target = "memcpy",
           operands = [dst, src, n],
-          callImportReturnTypes = []
-        }
+          callReturnTypes = [I32],
+          callHint = Just ([AddrHint, AddrHint, NoHint], [AddrHint])
+        }}
     ]
 marshalCmmPrimCall (GHC.MO_Memset _) [] [_dst, _c, _n] = do
   dst <- marshalAndCastCmmExpr _dst F64

--- a/asterius/src/Asterius/EDSL.hs
+++ b/asterius/src/Asterius/EDSL.hs
@@ -70,6 +70,7 @@ module Asterius.EDSL
     switchI64,
     module Asterius.EDSL.BinaryOp,
     module Asterius.EDSL.UnaryOp,
+    module Asterius.EDSL.LibC,
     notInt64,
     nandInt64,
     symbol,
@@ -88,6 +89,7 @@ module Asterius.EDSL
 where
 
 import Asterius.EDSL.BinaryOp
+import Asterius.EDSL.LibC
 import Asterius.EDSL.UnaryOp
 import Asterius.Internals
 import Asterius.Internals.MagicNumber

--- a/asterius/src/Asterius/EDSL/LibC.hs
+++ b/asterius/src/Asterius/EDSL/LibC.hs
@@ -4,6 +4,15 @@ module Asterius.EDSL.LibC where
 
 import Asterius.Types
 
+memcmp :: Expression -> Expression -> Expression -> Expression
+memcmp lhs rhs n =
+  Call
+    { target = "memcmp",
+      operands = [lhs, rhs, n],
+      callReturnTypes = [I32],
+      callHint = Just ([AddrHint, AddrHint, NoHint], [SignedHint])
+    }
+
 memcpy :: Expression -> Expression -> Expression -> Expression
 memcpy dst src n =
   Call

--- a/asterius/src/Asterius/EDSL/LibC.hs
+++ b/asterius/src/Asterius/EDSL/LibC.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Asterius.EDSL.LibC where
+
+import Asterius.Types
+
+memcpy :: Expression -> Expression -> Expression -> Expression
+memcpy dst src n =
+  Call
+    { target = "memcpy",
+      operands = [dst, src, n],
+      callReturnTypes = [],
+      callHint = Just ([AddrHint, AddrHint, NoHint], [AddrHint])
+    }

--- a/asterius/src/Asterius/EDSL/LibC.hs
+++ b/asterius/src/Asterius/EDSL/LibC.hs
@@ -30,3 +30,12 @@ memmove dst src n =
       callReturnTypes = [],
       callHint = Just ([AddrHint, AddrHint, NoHint], [AddrHint])
     }
+
+memset :: Expression -> Expression -> Expression -> Expression
+memset dst c n =
+  Call
+    { target = "memset",
+      operands = [dst, c, n],
+      callReturnTypes = [],
+      callHint = Just ([AddrHint, NoHint, NoHint], [AddrHint])
+    }

--- a/asterius/src/Asterius/EDSL/LibC.hs
+++ b/asterius/src/Asterius/EDSL/LibC.hs
@@ -12,3 +12,12 @@ memcpy dst src n =
       callReturnTypes = [],
       callHint = Just ([AddrHint, AddrHint, NoHint], [AddrHint])
     }
+
+memmove :: Expression -> Expression -> Expression -> Expression
+memmove dst src n =
+  Call
+    { target = "memmove",
+      operands = [dst, src, n],
+      callReturnTypes = [],
+      callHint = Just ([AddrHint, AddrHint, NoHint], [AddrHint])
+    }

--- a/asterius/src/Asterius/JSGen/LibC.hs
+++ b/asterius/src/Asterius/JSGen/LibC.hs
@@ -32,11 +32,12 @@ defLibCOpts =
       exports =
         [ "aligned_alloc",
           "free",
-          "strlen",
           "memchr",
+          "memcmp",
           "memcpy",
           "memmove",
-          "memcmp"
+          "memset",
+          "strlen"
         ]
     }
 


### PR DESCRIPTION
We now use memory management functions in `libc` instead of the imported JavaScript functions.

`primitive` related shims are not removed in this PR for now since there's a behavior change that requires debugging.