### PR TITLE
Use node wasi interface & misc other fixes

### DIFF
--- a/asterius/rts/browser/rts.wasi.mjs
+++ b/asterius/rts/browser/rts.wasi.mjs
@@ -1,15 +1,231 @@
+import { modulify } from "./rts.modulify.mjs";
+
 export class WASI {
   constructor() {}
 
+  get wasiImport() {
+    return modulify(this);
+  }
+
+  initialize() {}
+
+  args_get() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: args_get");
+  }
+
+  args_sizes_get() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: args_sizes_get"
+    );
+  }
+
+  environ_get() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: environ_get");
+  }
+
+  environ_sizes_get() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: environ_sizes_get"
+    );
+  }
+
+  clock_res_get() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: clock_res_get"
+    );
+  }
+
+  clock_time_get() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: clock_time_get"
+    );
+  }
+
+  fd_advise() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_advise");
+  }
+
+  fd_allocate() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_allocate");
+  }
+
   fd_close() {
-    throw new WebAssembly.RuntimeError(`Unsupported wasi interface: fd_close`);
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_close");
+  }
+
+  fd_datasync() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_datasync");
+  }
+
+  fd_fdstat_get() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: fd_fdstat_get"
+    );
+  }
+
+  fd_fdstat_set_flags() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: fd_fdstat_set_flags"
+    );
+  }
+
+  fd_fdstat_set_rights() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: fd_fdstat_set_rights"
+    );
+  }
+
+  fd_filestat_get() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: fd_filestat_get"
+    );
+  }
+
+  fd_filestat_set_size() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: fd_filestat_set_size"
+    );
+  }
+
+  fd_filestat_set_times() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: fd_filestat_set_times"
+    );
+  }
+
+  fd_pread() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_pread");
+  }
+
+  fd_prestat_get() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: fd_prestat_get"
+    );
+  }
+
+  fd_prestat_dir_name() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: fd_prestat_dir_name"
+    );
+  }
+
+  fd_pwrite() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_pwrite");
+  }
+
+  fd_read() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_read");
+  }
+
+  fd_readdir() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_readdir");
+  }
+
+  fd_renumber() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_renumber");
   }
 
   fd_seek() {
-    throw new WebAssembly.RuntimeError(`Unsupported wasi interface: fd_seek`);
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_seek");
+  }
+
+  fd_sync() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_sync");
+  }
+
+  fd_tell() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_tell");
   }
 
   fd_write() {
-    throw new WebAssembly.RuntimeError(`Unsupported wasi interface: fd_write`);
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_write");
+  }
+
+  path_create_directory() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: path_create_directory"
+    );
+  }
+
+  path_filestat_get() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: path_filestat_get"
+    );
+  }
+
+  path_filestat_set_times() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: path_filestat_set_times"
+    );
+  }
+
+  path_link() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: path_link");
+  }
+
+  path_open() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: path_open");
+  }
+
+  path_readlink() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: path_readlink"
+    );
+  }
+
+  path_remove_directory() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: path_remove_directory"
+    );
+  }
+
+  path_rename() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: path_rename");
+  }
+
+  path_symlink() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: path_symlink"
+    );
+  }
+
+  path_unlink_file() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: path_unlink_file"
+    );
+  }
+
+  poll_oneoff() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: poll_oneoff");
+  }
+
+  proc_exit() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: proc_exit");
+  }
+
+  proc_raise() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: proc_raise");
+  }
+
+  sched_yield() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: sched_yield");
+  }
+
+  random_get() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: random_get");
+  }
+
+  sock_recv() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: sock_recv");
+  }
+
+  sock_send() {
+    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: sock_send");
+  }
+
+  sock_shutdown() {
+    throw new WebAssembly.RuntimeError(
+      "Unsupported wasi syscall: sock_shutdown"
+    );
   }
 }

--- a/asterius/rts/node/rts.wasi.mjs
+++ b/asterius/rts/node/rts.wasi.mjs
@@ -1,15 +1,21 @@
+import wasi from "wasi";
+
 export class WASI {
-  constructor() {}
-
-  fd_close() {
-    throw new WebAssembly.RuntimeError(`Unsupported wasi interface: fd_close`);
+  constructor(progName) {
+    this.wasi = new wasi.WASI({
+      args: [progName],
+      env: process.env,
+      preopens: { "/": "/" },
+      returnOnExit: true,
+    });
+    Object.freeze(this);
   }
 
-  fd_seek() {
-    throw new WebAssembly.RuntimeError(`Unsupported wasi interface: fd_seek`);
+  get wasiImport() {
+    return this.wasi.wasiImport;
   }
 
-  fd_write() {
-    throw new WebAssembly.RuntimeError(`Unsupported wasi interface: fd_write`);
+  initialize(i) {
+    this.wasi.initialize(i);
   }
 }

--- a/asterius/rts/rts.mjs
+++ b/asterius/rts/rts.mjs
@@ -137,7 +137,7 @@ export async function newAsteriusInstance(req) {
       __asterius_info_tables,
       __asterius_symbol_table
     );
-  const __asterius_wasi = new WASI();
+  const __asterius_wasi = new WASI(req.progName);
   __asterius_scheduler.exports = __asterius_exports;
 
   __asterius_components.memory = __asterius_memory;
@@ -165,7 +165,7 @@ export async function newAsteriusInstance(req) {
   const importObject = Object.assign(
     req.jsffiFactory(__asterius_jsffi_instance),
     {
-      wasi_snapshot_preview1: modulify(__asterius_wasi),
+      wasi_snapshot_preview1: __asterius_wasi.wasiImport,
       env: {
         __memory_base: __asterius_memory_base,
         __table_base: __asterius_table_base
@@ -226,6 +226,8 @@ export async function newAsteriusInstance(req) {
     if (req.pic) {
       i.exports.__wasm_apply_relocs();
     }
+
+    __asterius_wasi.initialize(i);
 
     Object.assign(__asterius_exports, i.exports);
 

--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -747,9 +747,6 @@ marshalModule static_bytes pic_on verbose_err tail_calls ss_off_map fn_off_map u
       case memoryImport of
         Just mem_import -> marshalMemoryImport m mem_import
         _ -> pure ()
-    lim_segs <- marshalBS a "limit-segments"
-    (lim_segs_p, _) <- marshalV a [lim_segs]
-    Binaryen.Module.runPasses m lim_segs_p 1
   pure m
 
 relooperAddBlock ::

--- a/asterius/src/Asterius/Backends/Binaryen.hs
+++ b/asterius/src/Asterius/Backends/Binaryen.hs
@@ -55,6 +55,7 @@ import Control.Monad
 import Control.Monad.Cont
 import Control.Monad.Reader
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as CBS
 import qualified Data.ByteString.Unsafe as BS
 import Data.Foldable
 import Data.List
@@ -700,8 +701,14 @@ marshalModule ::
   Module ->
   IO Binaryen.Module
 marshalModule static_bytes pic_on verbose_err tail_calls ss_off_map fn_off_map used_ccalls hs_mod@Module {..} = do
+  let exports_keep = exports defLibCOpts
   m <- do
-    bs <- genLibC defLibCOpts {globalBase = (fromIntegral defaultMemoryBase + static_bytes) `roundup` 0x400, exports = exports defLibCOpts <> used_ccalls}
+    bs <-
+      genLibC
+        defLibCOpts
+          { globalBase = (fromIntegral defaultMemoryBase + static_bytes) `roundup` 0x400,
+            exports = exports_keep <> used_ccalls
+          }
     BS.unsafeUseAsCStringLen bs $
         \(p, l) -> Binaryen.Module.read p (fromIntegral l)
   checkOverlapDataSegment m
@@ -711,6 +718,11 @@ marshalModule static_bytes pic_on verbose_err tail_calls ss_off_map fn_off_map u
       <> [Binaryen.mvp]
   A.with $ \a -> do
     libc_func_names <- binaryenModuleExportNames m
+    for_ libc_func_names $
+      \(_, ext_name) ->
+        unless (CBS.unpack ext_name `elem` exports_keep) $ do
+          p <- marshalBS a ext_name
+          Binaryen.removeExport m p
     libc_func_info <- fmap M.fromList $ for libc_func_names $ \(in_name, ext_name) -> (ext_name,) . (in_name,) <$> binaryenFunctionType m in_name
     let env =
           MarshalEnv

--- a/asterius/src/Asterius/Backends/Binaryen/RunPass.hs
+++ b/asterius/src/Asterius/Backends/Binaryen/RunPass.hs
@@ -1,0 +1,16 @@
+module Asterius.Backends.Binaryen.RunPass
+  ( runPass,
+  )
+where
+
+import qualified Asterius.Internals.Arena as A
+import Asterius.Internals.Marshal
+import qualified Binaryen.Module as Binaryen
+import qualified Data.ByteString as BS
+import Data.Traversable
+
+runPass :: Binaryen.Module -> [BS.ByteString] -> IO ()
+runPass m ps = A.with $ \a -> do
+  ps' <- for ps $ marshalBS a
+  (ps'', l) <- marshalV a ps'
+  Binaryen.runPasses m ps'' (fromIntegral l)

--- a/asterius/src/Asterius/Builtins/Primitive.hs
+++ b/asterius/src/Asterius/Builtins/Primitive.hs
@@ -85,7 +85,6 @@ primitiveMemcpy = runEDSL "hsprimitive_memcpy" $ do
   let arg1 = dst `addInt64` doff
       arg2 = src `addInt64` soff
   emit $ memcpy arg1 arg2 len
-  emit arg1
 
 -- | @void hsprimitive_memmove(void *dst, ptrdiff_t doff, void *src, ptrdiff_t soff, size_t len)@
 primitiveMemmove :: AsteriusModule
@@ -94,7 +93,6 @@ primitiveMemmove = runEDSL "hsprimitive_memmove" $ do
   let arg1 = dst `addInt64` doff
       arg2 = src `addInt64` soff
   emit $ memmove arg1 arg2 len
-  emit arg1
 
 -- | @int hsprimitive_memcmp(HsWord8 *s1, HsWord8 *s2, size_t n)@
 primitiveMemcmp :: AsteriusModule

--- a/asterius/src/Asterius/GHCi/Internals.hs
+++ b/asterius/src/Asterius/GHCi/Internals.hs
@@ -129,9 +129,13 @@ newGHCiSession = do
     newSession
       defaultConfig
         { nodeExtraArgs =
-            [ "--experimental-wasm-return-call",
+            [ "--experimental-modules",
+              "--experimental-wasi-unstable-preview1",
+              "--experimental-wasm-bigint",
+              "--experimental-wasm-return-call",
               "--no-wasm-bounds-checks",
               "--no-wasm-stack-checks",
+              "--unhandled-rejections=strict",
               "--wasm-lazy-compilation",
               "--wasm-lazy-validation",
               "--wasm-max-mem-pages=65536"

--- a/asterius/src/Asterius/JSGen/LibC.hs
+++ b/asterius/src/Asterius/JSGen/LibC.hs
@@ -33,10 +33,7 @@ defLibCOpts =
         [ "aligned_alloc",
           "free",
           "memchr",
-          "memcmp",
           "memcpy",
-          "memmove",
-          "memset",
           "strlen"
         ]
     }

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -163,7 +163,9 @@ genReq task LinkReport {..} =
     [ "import targetSpecificModule from './default.mjs';\n",
       -- export request object
       "export default {",
-      "jsffiFactory: ",
+      "progName: ",
+      stringUtf8 $ show $ takeBaseName $ inputHS task,
+      ", jsffiFactory: ",
       generateFFIImportObjectFactory bundledFFIMarshalState,
       ", exportsStaticOffsets: ",
       genExportStaticObj bundledFFIMarshalState staticsOffsetMap,

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -13,6 +13,7 @@ where
 
 import qualified Asterius.Backends.Binaryen
 import qualified Asterius.Backends.Binaryen as Binaryen
+import qualified Asterius.Backends.Binaryen.RunPass as Binaryen
 import Asterius.Binary.File
 import Asterius.Binary.NameCache
 import Asterius.BuildInfo
@@ -321,6 +322,7 @@ ahcDistMain logger task (final_m, report) = do
   when (optimizeLevel task > 0 || shrinkLevel task > 0) $ do
     logger "[INFO] Running binaryen optimization"
     Binaryen.optimize m_ref
+  Binaryen.runPass m_ref ["limit-segments"]
   when (validate task) $ do
     logger "[INFO] Validating binaryen IR"
     pass_validation <- Binaryen.validate m_ref


### PR DESCRIPTION
* For the node runtime, `wasi_snapshot_preview1` now comes from node's own `WASI` implementation. This also implies that wasm bigint integration is now mandatory.
* For the browser runtime, we now include placeholders of all wasi interfaces.
* Redundant export entries which aren't used by the JS runtime are now pruned.
* Fixes `--no-gc-section` test regression on the master branch.
* Fixes `primitive` shims validation error.

Open problem: how do we preserve our special handling of `stdout`/`stderr` once we start using vanilla libc file IO?