### PR TITLE
Enable --cross-compile for hsc2hs

### DIFF
--- a/asterius/app/ahc-cabal.hs
+++ b/asterius/app/ahc-cabal.hs
@@ -20,6 +20,7 @@ main = do
       <> (dataDir </> ".boot" </> "asterius_lib")
       <> "\nprogram-locations\n  ar-location: "
       <> ahcAr
+      <> "\nprogram-default-options\n  hsc2hs-options: --cross-compile"
       <> "\nwith-compiler: "
       <> ahc
       <> "\nwith-hc-pkg: "

--- a/asterius/src/Asterius/Boot.hs
+++ b/asterius/src/Asterius/Boot.hs
@@ -75,6 +75,7 @@ defaultBootArgs = BootArgs
        "--with-ghc=" <> ahc,
        "--with-ghc-pkg=" <> ahcPkg,
        "--with-ar=" <> ahcAr,
+       "--hsc2hs-option=--cross-compile",
        "--ghc-option=-v1",
        "--ghc-option=-dsuppress-ticks"
       ],


### PR DESCRIPTION
This PR enables `hsc2hs --cross-compile` both during booting and later for `ahc-cabal`. `--via-asm` should make it faster, but given `hsc2hs` fails to parse `.s` file of `clang` when targetting `wasm32-wasi`, so not adding that one.

After running a full stackage build, these packages and their dependents fail to compile due to `hsc2hs` features unsupported in cross-compilation mode:

* `blake2-0.3.0`
* `lukko-0.1.1.2`
* `terminal-size-0.3.2.1`
* `unix-bytestring-0.3.7.3`
* `yoga-0.0.0.5`
* `mercury-api-0.1.0.2`

When we later finish all the 32-bit transition, we can propose patches to package upstream that fix their builds again.