### PR TITLE
Fix default cabal flags of bitvec

### DIFF
--- a/ghc-toolkit/boot-libs/cabal.config
+++ b/ghc-toolkit/boot-libs/cabal.config
@@ -5,6 +5,8 @@ constraints:
   NineP -bytestring-in-base,
   Rasterific -embed_linear,
   aeson +cffi,
+  bitvec -integer-gmp,
+  bitvec -libgmp,
   blaze-textual +integer-simple,
   brick +demos,
   bson -_old-network,

--- a/utils/gen-pkgs.hs
+++ b/utils/gen-pkgs.hs
@@ -100,6 +100,18 @@ asteriusSnapshot raw_loc = do
         "aeson"
     $ M.adjust
         (\pkg_info -> pkg_info
+          { flagsOff = C.ordNub $ "integer-gmp" : flagsOff pkg_info
+          }
+        )
+        "bitvec"
+    $ M.adjust
+        (\pkg_info -> pkg_info
+          { flagsOff = C.ordNub $ "libgmp" : flagsOff pkg_info
+          }
+        )
+        "bitvec"
+    $ M.adjust
+        (\pkg_info -> pkg_info
           { flagsOn = C.ordNub $ "integer-simple" : flagsOn pkg_info
           }
         )


### PR DESCRIPTION
We don't include `libgmp` in our `wasi-sdk` builds yet, so `gmp`-related flags need to be turned off.