### PR TITLE
wasi: add an indirection layer in import object

### DIFF
--- a/asterius/rts/browser/rts.wasi.mjs
+++ b/asterius/rts/browser/rts.wasi.mjs
@@ -9,223 +9,273 @@ export class WASI {
 
   initialize() {}
 
-  args_get() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: args_get");
-  }
-
-  args_sizes_get() {
+  args_get(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: args_sizes_get"
+      `Unsupported wasi syscall: args_get(${args})`
     );
   }
 
-  environ_get() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: environ_get");
-  }
-
-  environ_sizes_get() {
+  args_sizes_get(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: environ_sizes_get"
+      `Unsupported wasi syscall: args_sizes_get(${args})`
     );
   }
 
-  clock_res_get() {
+  environ_get(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: clock_res_get"
+      `Unsupported wasi syscall: environ_get(${args})`
     );
   }
 
-  clock_time_get() {
+  environ_sizes_get(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: clock_time_get"
+      `Unsupported wasi syscall: environ_sizes_get(${args})`
     );
   }
 
-  fd_advise() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_advise");
-  }
-
-  fd_allocate() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_allocate");
-  }
-
-  fd_close() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_close");
-  }
-
-  fd_datasync() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_datasync");
-  }
-
-  fd_fdstat_get() {
+  clock_res_get(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: fd_fdstat_get"
+      `Unsupported wasi syscall: clock_res_get(${args})`
     );
   }
 
-  fd_fdstat_set_flags() {
+  clock_time_get(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: fd_fdstat_set_flags"
+      `Unsupported wasi syscall: clock_time_get(${args})`
     );
   }
 
-  fd_fdstat_set_rights() {
+  fd_advise(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: fd_fdstat_set_rights"
+      `Unsupported wasi syscall: fd_advise(${args})`
     );
   }
 
-  fd_filestat_get() {
+  fd_allocate(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: fd_filestat_get"
+      `Unsupported wasi syscall: fd_allocate(${args})`
     );
   }
 
-  fd_filestat_set_size() {
+  fd_close(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: fd_filestat_set_size"
+      `Unsupported wasi syscall: fd_close(${args})`
     );
   }
 
-  fd_filestat_set_times() {
+  fd_datasync(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: fd_filestat_set_times"
+      `Unsupported wasi syscall: fd_datasync(${args})`
     );
   }
 
-  fd_pread() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_pread");
-  }
-
-  fd_prestat_get() {
+  fd_fdstat_get(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: fd_prestat_get"
+      `Unsupported wasi syscall: fd_fdstat_get(${args})`
     );
   }
 
-  fd_prestat_dir_name() {
+  fd_fdstat_set_flags(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: fd_prestat_dir_name"
+      `Unsupported wasi syscall: fd_fdstat_set_flags(${args})`
     );
   }
 
-  fd_pwrite() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_pwrite");
-  }
-
-  fd_read() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_read");
-  }
-
-  fd_readdir() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_readdir");
-  }
-
-  fd_renumber() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_renumber");
-  }
-
-  fd_seek() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_seek");
-  }
-
-  fd_sync() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_sync");
-  }
-
-  fd_tell() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_tell");
-  }
-
-  fd_write() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: fd_write");
-  }
-
-  path_create_directory() {
+  fd_fdstat_set_rights(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: path_create_directory"
+      `Unsupported wasi syscall: fd_fdstat_set_rights(${args})`
     );
   }
 
-  path_filestat_get() {
+  fd_filestat_get(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: path_filestat_get"
+      `Unsupported wasi syscall: fd_filestat_get(${args})`
     );
   }
 
-  path_filestat_set_times() {
+  fd_filestat_set_size(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: path_filestat_set_times"
+      `Unsupported wasi syscall: fd_filestat_set_size(${args})`
     );
   }
 
-  path_link() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: path_link");
-  }
-
-  path_open() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: path_open");
-  }
-
-  path_readlink() {
+  fd_filestat_set_times(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: path_readlink"
+      `Unsupported wasi syscall: fd_filestat_set_times(${args})`
     );
   }
 
-  path_remove_directory() {
+  fd_pread(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: path_remove_directory"
+      `Unsupported wasi syscall: fd_pread(${args})`
     );
   }
 
-  path_rename() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: path_rename");
-  }
-
-  path_symlink() {
+  fd_prestat_get(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: path_symlink"
+      `Unsupported wasi syscall: fd_prestat_get(${args})`
     );
   }
 
-  path_unlink_file() {
+  fd_prestat_dir_name(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: path_unlink_file"
+      `Unsupported wasi syscall: fd_prestat_dir_name(${args})`
     );
   }
 
-  poll_oneoff() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: poll_oneoff");
-  }
-
-  proc_exit() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: proc_exit");
-  }
-
-  proc_raise() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: proc_raise");
-  }
-
-  sched_yield() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: sched_yield");
-  }
-
-  random_get() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: random_get");
-  }
-
-  sock_recv() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: sock_recv");
-  }
-
-  sock_send() {
-    throw new WebAssembly.RuntimeError("Unsupported wasi syscall: sock_send");
-  }
-
-  sock_shutdown() {
+  fd_pwrite(...args) {
     throw new WebAssembly.RuntimeError(
-      "Unsupported wasi syscall: sock_shutdown"
+      `Unsupported wasi syscall: fd_pwrite(${args})`
+    );
+  }
+
+  fd_read(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: fd_read(${args})`
+    );
+  }
+
+  fd_readdir(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: fd_readdir(${args})`
+    );
+  }
+
+  fd_renumber(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: fd_renumber(${args})`
+    );
+  }
+
+  fd_seek(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: fd_seek(${args})`
+    );
+  }
+
+  fd_sync(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: fd_sync(${args})`
+    );
+  }
+
+  fd_tell(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: fd_tell(${args})`
+    );
+  }
+
+  fd_write(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: fd_write(${args})`
+    );
+  }
+
+  path_create_directory(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: path_create_directory(${args})`
+    );
+  }
+
+  path_filestat_get(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: path_filestat_get(${args})`
+    );
+  }
+
+  path_filestat_set_times(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: path_filestat_set_times(${args})`
+    );
+  }
+
+  path_link(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: path_link(${args})`
+    );
+  }
+
+  path_open(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: path_open(${args})`
+    );
+  }
+
+  path_readlink(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: path_readlink(${args})`
+    );
+  }
+
+  path_remove_directory(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: path_remove_directory(${args})`
+    );
+  }
+
+  path_rename(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: path_rename(${args})`
+    );
+  }
+
+  path_symlink(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: path_symlink(${args})`
+    );
+  }
+
+  path_unlink_file(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: path_unlink_file(${args})`
+    );
+  }
+
+  poll_oneoff(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: poll_oneoff(${args})`
+    );
+  }
+
+  proc_exit(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: proc_exit(${args})`
+    );
+  }
+
+  proc_raise(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: proc_raise(${args})`
+    );
+  }
+
+  sched_yield(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: sched_yield(${args})`
+    );
+  }
+
+  random_get(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: random_get(${args})`
+    );
+  }
+
+  sock_recv(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: sock_recv(${args})`
+    );
+  }
+
+  sock_send(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: sock_send(${args})`
+    );
+  }
+
+  sock_shutdown(...args) {
+    throw new WebAssembly.RuntimeError(
+      `Unsupported wasi syscall: sock_shutdown(${args})`
     );
   }
 }

--- a/asterius/rts/node/rts.wasi.mjs
+++ b/asterius/rts/node/rts.wasi.mjs
@@ -8,11 +8,188 @@ export class WASI {
       preopens: { "/": "/" },
       returnOnExit: true,
     });
-    Object.freeze(this);
-  }
 
-  get wasiImport() {
-    return this.wasi.wasiImport;
+    this.wasiImport = {
+      args_get: (...args) => {
+        return this.wasi.wasiImport.args_get(...args);
+      },
+
+      args_sizes_get: (...args) => {
+        return this.wasi.wasiImport.args_sizes_get(...args);
+      },
+
+      environ_get: (...args) => {
+        return this.wasi.wasiImport.environ_get(...args);
+      },
+
+      environ_sizes_get: (...args) => {
+        return this.wasi.wasiImport.environ_sizes_get(...args);
+      },
+
+      clock_res_get: (...args) => {
+        return this.wasi.wasiImport.clock_res_get(...args);
+      },
+
+      clock_time_get: (...args) => {
+        return this.wasi.wasiImport.clock_time_get(...args);
+      },
+
+      fd_advise: (...args) => {
+        return this.wasi.wasiImport.fd_advise(...args);
+      },
+
+      fd_allocate: (...args) => {
+        return this.wasi.wasiImport.fd_allocate(...args);
+      },
+
+      fd_close: (...args) => {
+        return this.wasi.wasiImport.fd_close(...args);
+      },
+
+      fd_datasync: (...args) => {
+        return this.wasi.wasiImport.fd_datasync(...args);
+      },
+
+      fd_fdstat_get: (...args) => {
+        return this.wasi.wasiImport.fd_fdstat_get(...args);
+      },
+
+      fd_fdstat_set_flags: (...args) => {
+        return this.wasi.wasiImport.fd_fdstat_set_flags(...args);
+      },
+
+      fd_fdstat_set_rights: (...args) => {
+        return this.wasi.wasiImport.fd_fdstat_set_rights(...args);
+      },
+
+      fd_filestat_get: (...args) => {
+        return this.wasi.wasiImport.fd_filestat_get(...args);
+      },
+
+      fd_filestat_set_size: (...args) => {
+        return this.wasi.wasiImport.fd_filestat_set_size(...args);
+      },
+
+      fd_filestat_set_times: (...args) => {
+        return this.wasi.wasiImport.fd_filestat_set_times(...args);
+      },
+
+      fd_pread: (...args) => {
+        return this.wasi.wasiImport.fd_pread(...args);
+      },
+
+      fd_prestat_get: (...args) => {
+        return this.wasi.wasiImport.fd_prestat_get(...args);
+      },
+
+      fd_prestat_dir_name: (...args) => {
+        return this.wasi.wasiImport.fd_prestat_dir_name(...args);
+      },
+
+      fd_pwrite: (...args) => {
+        return this.wasi.wasiImport.fd_pwrite(...args);
+      },
+
+      fd_read: (...args) => {
+        return this.wasi.wasiImport.fd_read(...args);
+      },
+
+      fd_readdir: (...args) => {
+        return this.wasi.wasiImport.fd_readdir(...args);
+      },
+
+      fd_renumber: (...args) => {
+        return this.wasi.wasiImport.fd_renumber(...args);
+      },
+
+      fd_seek: (...args) => {
+        return this.wasi.wasiImport.fd_seek(...args);
+      },
+
+      fd_sync: (...args) => {
+        return this.wasi.wasiImport.fd_sync(...args);
+      },
+
+      fd_tell: (...args) => {
+        return this.wasi.wasiImport.fd_tell(...args);
+      },
+
+      fd_write: (...args) => {
+        return this.wasi.wasiImport.fd_write(...args);
+      },
+
+      path_create_directory: (...args) => {
+        return this.wasi.wasiImport.path_create_directory(...args);
+      },
+
+      path_filestat_get: (...args) => {
+        return this.wasi.wasiImport.path_filestat_get(...args);
+      },
+
+      path_filestat_set_times: (...args) => {
+        return this.wasi.wasiImport.path_filestat_set_times(...args);
+      },
+
+      path_link: (...args) => {
+        return this.wasi.wasiImport.path_link(...args);
+      },
+
+      path_open: (...args) => {
+        return this.wasi.wasiImport.path_open(...args);
+      },
+
+      path_readlink: (...args) => {
+        return this.wasi.wasiImport.path_readlink(...args);
+      },
+
+      path_remove_directory: (...args) => {
+        return this.wasi.wasiImport.path_remove_directory(...args);
+      },
+
+      path_rename: (...args) => {
+        return this.wasi.wasiImport.path_rename(...args);
+      },
+
+      path_symlink: (...args) => {
+        return this.wasi.wasiImport.path_symlink(...args);
+      },
+
+      path_unlink_file: (...args) => {
+        return this.wasi.wasiImport.path_unlink_file(...args);
+      },
+
+      poll_oneoff: (...args) => {
+        return this.wasi.wasiImport.poll_oneoff(...args);
+      },
+
+      proc_exit: (...args) => {
+        return this.wasi.wasiImport.proc_exit(...args);
+      },
+
+      proc_raise: (...args) => {
+        return this.wasi.wasiImport.proc_raise(...args);
+      },
+
+      sched_yield: (...args) => {
+        return this.wasi.wasiImport.sched_yield(...args);
+      },
+
+      random_get: (...args) => {
+        return this.wasi.wasiImport.random_get(...args);
+      },
+
+      sock_recv: (...args) => {
+        return this.wasi.wasiImport.sock_recv(...args);
+      },
+
+      sock_send: (...args) => {
+        return this.wasi.wasiImport.sock_send(...args);
+      },
+
+      sock_shutdown: (...args) => {
+        return this.wasi.wasiImport.sock_shutdown(...args);
+      },
+    };
   }
 
   initialize(i) {


### PR DESCRIPTION
We used to use `wasi.wasiImport` directly as the import object for wasi, which is efficient but doesn't allow us to override the behavior of certain syscalls. This PR adds the missing indirection layer. Starting from here we can unify some existing runtime logic (especially filesystem/stdio stuff, pretty chaotic atm)