### PR TITLE
Use updated ghc branch with codeOutputHook

### DIFF
--- a/asterius/src/Asterius/CodeGen.hs
+++ b/asterius/src/Asterius/CodeGen.hs
@@ -1711,14 +1711,14 @@ marshalCmmDecl decl = case decl of
           Right f' -> f'
     pure $ mempty {functionMap = SM.singleton sym f}
 
-marshalHaskellIR :: GHC.Module -> HaskellIR -> CodeGen AsteriusModule
-marshalHaskellIR this_mod HaskellIR {..} = do
+marshalHaskellIR :: GHC.Module -> [GHC.SptEntry] -> CmmIR -> CodeGen AsteriusModule
+marshalHaskellIR this_mod spt_entries CmmIR {..} = do
   (dflags, _) <- ask
   let spt_map =
         SM.fromList
           [ (sym, (w0, w1))
             | GHC.SptEntry (idClosureSymbol dflags -> sym) (Fingerprint w0 w1) <-
-                sptEntries
+                spt_entries
           ]
   r <- marshalRawCmm this_mod cmmRaw
   pure r {sptMap = spt_map}

--- a/asterius/src/Asterius/GHCi/Internals.hs
+++ b/asterius/src/Asterius/GHCi/Internals.hs
@@ -469,7 +469,7 @@ asteriusHscCompileCoreExpr hsc_env srcspan ds_expr = do
       GHC.emptyCollectedCCs
       stg_binds2
       (GHC.emptyHpcInfo False)
-  raw_cmms <- GHC.cmmToRawCmm dflags (Just this_mod) cmms
+  raw_cmms <- GHC.cmmToRawCmm dflags cmms
   m <-
     runCodeGen (marshalRawCmm this_mod raw_cmms) dflags this_mod
       >>= either throwIO pure

--- a/ghc-toolkit/ghc-libdir/settings
+++ b/ghc-toolkit/ghc-libdir/settings
@@ -15,6 +15,8 @@
  ("ar flags", "q"),
  ("ar supports at file", "YES"),
  ("ranlib command", "ranlib"),
+ ("otool command", "otool"),
+ ("install_name_tool command", "install_name_tool"),
  ("touch command", "touch"),
  ("dllwrap command", "/bin/false"),
  ("windres command", "/bin/false"),

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Compiler.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Compiler.hs
@@ -14,33 +14,16 @@ import HscTypes
 import PipelineMonad
 import Stream (Stream)
 
-data HaskellIR
-  = HaskellIR
-      { sptEntries :: [SptEntry],
-        cmmRaw :: Stream IO Cmm.RawCmmGroup ()
-      }
+data HaskellIR = HaskellIR
+  { sptEntries :: [SptEntry],
+    cmmRaw :: Stream IO Cmm.RawCmmGroup ()
+  }
 
-newtype CmmIR
-  = CmmIR
-      { cmmRaw :: Stream IO Cmm.RawCmmGroup ()
-      }
+newtype CmmIR = CmmIR
+  { cmmRaw :: Stream IO Cmm.RawCmmGroup ()
+  }
 
-data Compiler
-  = Compiler
-      { withHaskellIR :: ModSummary -> HaskellIR -> FilePath -> CompPipeline (),
-        withCmmIR :: CmmIR -> FilePath -> CompPipeline ()
-      }
-
-instance Semigroup Compiler where
-  c0 <> c1 = Compiler
-    { withHaskellIR = \mod_summary hs_ir obj_path -> do
-        withHaskellIR c0 mod_summary hs_ir obj_path
-        withHaskellIR c1 mod_summary hs_ir obj_path,
-      withCmmIR = \cmm_ir obj_path -> do
-        withCmmIR c0 cmm_ir obj_path
-        withCmmIR c1 cmm_ir obj_path
-    }
-
-instance Monoid Compiler where
-  mempty =
-    Compiler {withHaskellIR = \_ _ _ -> pure (), withCmmIR = \_ _ -> pure ()}
+data Compiler = Compiler
+  { withHaskellIR :: ModSummary -> HaskellIR -> FilePath -> CompPipeline (),
+    withCmmIR :: DynFlags -> Module -> CmmIR -> FilePath -> IO ()
+  }

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Compiler.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Compiler.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE StrictData #-}
-
 module Language.Haskell.GHC.Toolkit.Compiler
   ( HaskellIR (..),
     CmmIR (..),
@@ -14,9 +11,8 @@ import HscTypes
 import PipelineMonad
 import Stream (Stream)
 
-data HaskellIR = HaskellIR
-  { sptEntries :: [SptEntry],
-    cmmRaw :: Stream IO Cmm.RawCmmGroup ()
+newtype HaskellIR = HaskellIR
+  { cgGuts :: CgGuts
   }
 
 newtype CmmIR = CmmIR
@@ -24,6 +20,6 @@ newtype CmmIR = CmmIR
   }
 
 data Compiler = Compiler
-  { withHaskellIR :: ModSummary -> HaskellIR -> FilePath -> CompPipeline (),
+  { withHaskellIR :: DynFlags -> Module -> HaskellIR -> FilePath -> IO (),
     withCmmIR :: DynFlags -> Module -> CmmIR -> FilePath -> IO ()
   }

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Hooks.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Hooks.hs
@@ -11,6 +11,7 @@ import qualified DriverPhases as GHC
 import qualified DriverPipeline as GHC
 import qualified Hooks as GHC
 import qualified HscMain as GHC
+import qualified HscTypes as GHC
 import Language.Haskell.GHC.Toolkit.Compiler
 import qualified PipelineMonad as GHC
 
@@ -24,6 +25,12 @@ hooksFromCompiler Compiler {..} h =
         GHC.runPhaseHook = Just $ \phase input_fn dflags -> case phase of
           GHC.HscOut _ _ (GHC.HscRecomp cgguts mod_summary) -> do
             output_fn <- GHC.phaseOutputFilename GHC.StopLn
+            liftIO $
+              withHaskellIR
+                dflags
+                (GHC.ms_mod mod_summary)
+                (HaskellIR cgguts)
+                output_fn
             GHC.PipeState {hsc_env = hsc_env} <- GHC.getPipeState
             (_, _, _) <-
               liftIO $

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Hooks.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Hooks.hs
@@ -6,75 +6,34 @@ module Language.Haskell.GHC.Toolkit.Hooks
   )
 where
 
-import qualified CmmInfo as GHC
 import Control.Monad.IO.Class
-import Data.Functor
-import Data.IORef
 import qualified DriverPhases as GHC
 import qualified DriverPipeline as GHC
-import qualified DynFlags as GHC
 import qualified Hooks as GHC
 import qualified HscMain as GHC
-import qualified HscTypes as GHC
 import Language.Haskell.GHC.Toolkit.Compiler
-import qualified Module as GHC
 import qualified PipelineMonad as GHC
 
 hooksFromCompiler :: Compiler -> GHC.Hooks -> IO GHC.Hooks
-hooksFromCompiler Compiler {..} h = do
-  cmm_raw_map_ref <- newIORef GHC.emptyModuleEnv
-  let cmm_raw_ref_err = error "Language.Haskell.GHC.Toolkit.Hooks: unreachable"
-  cmm_raw_ref <- newIORef cmm_raw_ref_err
+hooksFromCompiler Compiler {..} h =
   pure
     h
-      { GHC.cmmToRawCmmHook = Just $ \dflags maybe_ms_mod cmms -> do
-          rawcmms <- GHC.cmmToRawCmm dflags maybe_ms_mod cmms
-          case maybe_ms_mod of
-            Just ms_mod -> do
-              let store :: IORef (GHC.ModuleEnv v) -> v -> IO ()
-                  store ref v = atomicModifyIORef' ref $
-                    \env -> (GHC.extendModuleEnv env ms_mod v, ())
-              store cmm_raw_map_ref rawcmms
-            _ -> writeIORef cmm_raw_ref rawcmms
-          pure rawcmms,
+      { GHC.codeOutputHook = Just $ \dflags this_mod filenm _ _ _ _ cmm_stream -> do
+          withCmmIR dflags this_mod (CmmIR cmm_stream) filenm
+          pure (filenm, (False, Nothing), []),
         GHC.runPhaseHook = Just $ \phase input_fn dflags -> case phase of
-          GHC.HscOut src_flavour _ (GHC.HscRecomp cgguts mod_summary@GHC.ModSummary {..}) ->
-            do
-              (spt_entries, obj_output_fn) <- do
-                output_fn <-
-                  GHC.phaseOutputFilename
-                    $ GHC.hscPostBackendPhase dflags src_flavour
-                    $ GHC.hscTarget dflags
-                GHC.PipeState {GHC.hsc_env = hsc_env'} <- GHC.getPipeState
-                void $ liftIO $
-                  GHC.hscGenHardCode
-                    hsc_env'
-                    cgguts
-                    mod_summary
-                    output_fn
-                GHC.setForeignOs []
-                obj_output_fn <- GHC.phaseOutputFilename GHC.StopLn
-                pure (GHC.cg_spt_entries cgguts, obj_output_fn)
-              let fetch :: IORef (GHC.ModuleEnv v) -> IO v
-                  fetch ref =
-                    atomicModifyIORef'
-                      ref
-                      ( \env ->
-                          let Just v = GHC.lookupModuleEnv env ms_mod
-                           in (GHC.delModuleEnv env ms_mod, v)
-                      )
-              ir <- liftIO $ HaskellIR spt_entries <$> fetch cmm_raw_map_ref
-              withHaskellIR mod_summary ir obj_output_fn
-              pure (GHC.RealPhase GHC.StopLn, obj_output_fn)
-          GHC.RealPhase GHC.Cmm -> do
-            void $ GHC.runPhase phase input_fn dflags
-            ir <-
+          GHC.HscOut _ _ (GHC.HscRecomp cgguts mod_summary) -> do
+            output_fn <- GHC.phaseOutputFilename GHC.StopLn
+            GHC.PipeState {hsc_env = hsc_env} <- GHC.getPipeState
+            (_, _, _) <-
               liftIO $
-                CmmIR
-                  <$> readIORef cmm_raw_ref
-                  <* writeIORef cmm_raw_ref cmm_raw_ref_err
-            obj_output_fn <- GHC.phaseOutputFilename GHC.StopLn
-            withCmmIR ir obj_output_fn
-            pure (GHC.RealPhase GHC.StopLn, obj_output_fn)
+                GHC.hscGenHardCode hsc_env cgguts mod_summary output_fn
+            GHC.setForeignOs []
+            pure (GHC.RealPhase GHC.StopLn, output_fn)
+          GHC.RealPhase GHC.Cmm -> do
+            output_fn <- GHC.phaseOutputFilename GHC.StopLn
+            GHC.PipeState {hsc_env = hsc_env} <- GHC.getPipeState
+            liftIO $ GHC.hscCompileCmmFile hsc_env input_fn output_fn
+            pure (GHC.RealPhase GHC.StopLn, output_fn)
           _ -> GHC.runPhase phase input_fn dflags
       }

--- a/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Run.hs
+++ b/ghc-toolkit/src/Language/Haskell/GHC/Toolkit/Run.hs
@@ -40,7 +40,7 @@ runCmm Config {..} cmm_fns write_obj_cont = do
     liftIO $
       hooksFromCompiler
         ( Compiler
-            { withHaskellIR = \_ _ _ -> pure (),
+            { withHaskellIR = \_ _ _ _ -> pure (),
               withCmmIR = \_ _ ir obj_path -> liftIO $ write_obj_cont obj_path ir
             }
         )

--- a/utils/make-packages.py
+++ b/utils/make-packages.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 
 ghc_repo_url = "https://github.com/TerrorJack/ghc.git"
-ghc_repo_branch = "asterius-8.8"
+ghc_repo_branch = "asterius-8.8-staging"
 workdir = os.getcwd()
 ghc_repo_path = os.path.join(workdir, "ghc")
 hadrian_path = os.path.join(ghc_repo_path, "hadrian", "build.stack.sh")


### PR DESCRIPTION
This PR is a prerequisite for the `ahc -c` fixing work. One more step towards a less hacky ghc frontend.

* Uses `asterius-8.8-staging` branch which removes legacy `stgCmmHook`/`cmmToRawCmmHook` and adds `codeOutputHook`. `codeOutputHook` is a better way of working with raw Cmm for Haskell/Cmm inputs uniformly.
* Minor fix in the `settings` file since the staging branch is rebased on latest upstream `ghc-8.8` which invalidates our earlier `settings`