### PR TITLE
Adjust cabal/ahc flags

### DIFF
--- a/asterius/cabal/config
+++ b/asterius/cabal/config
@@ -17,7 +17,7 @@ library-vanilla: True
 shared: False
 executable-dynamic: False
 profiling: False
-optimization: True
+optimization: 2
 debug-info: False
 library-for-ghci: False
 split-sections: False

--- a/asterius/cabal/config
+++ b/asterius/cabal/config
@@ -25,6 +25,7 @@ split-objs: False
 executable-stripping: False
 library-stripping: False
 user-install: False
+deterministic: True
 tests: False
 coverage: False
 benchmarks: False

--- a/asterius/src/Asterius/Main.hs
+++ b/asterius/src/Asterius/Main.hs
@@ -257,12 +257,8 @@ ahcLink task = do
   putStrLn $ "[INFO] Compiling " <> inputHS task <> " to WebAssembly"
   callProcess ahc $
     [ "--make",
-      "-O",
-      "-i" <> takeDirectory (inputHS task),
-      "-fexternal-interpreter",
-      "-pgml" <> ahcLd,
-      "-clear-package-db",
-      "-global-package-db"
+      "-O2",
+      "-i" <> takeDirectory (inputHS task)
     ]
       <> concat [["-no-hs-main", "-optl--no-main"] | not $ hasMain task]
       <> ["-optl--debug" | debug task]

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -6,8 +6,6 @@ ARG NODE_VER=15.0.1
 
 ENV \
   LANG=C.UTF-8 \
-  LC_ALL=C.UTF-8 \
-  LC_CTYPE=C.UTF-8 \
   PATH=/root/.asterius-local-install-root/bin:/root/.asterius-snapshot-install-root/bin:/root/.asterius-compiler-bin:/root/.local/bin:/root/.nvm/versions/node/v${NODE_VER}/bin:${PATH} \
   WASI_SDK_PATH=/opt/wasi-sdk
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -7,8 +7,6 @@ ARG NODE_VER=15.0.1
 ENV \
   BROWSER=echo \
   LANG=C.UTF-8 \
-  LC_ALL=C.UTF-8 \
-  LC_CTYPE=C.UTF-8 \
   PATH=/root/.local/bin:/root/.nvm/versions/node/v${NODE_VER}/bin:${PATH} \
   WASI_SDK_PATH=/opt/wasi-sdk
 

--- a/dev.rootless.Dockerfile
+++ b/dev.rootless.Dockerfile
@@ -43,8 +43,6 @@ ARG NODE_VER=15.0.1
 ENV \
   BROWSER=echo \
   LANG=C.UTF-8 \
-  LC_ALL=C.UTF-8 \
-  LC_CTYPE=C.UTF-8 \
   PATH=/home/${USERNAME}/.local/bin:/home/${USERNAME}/.nvm/versions/node/v${NODE_VER}/bin:${PATH} \
   WASI_SDK_PATH=/opt/wasi-sdk
 


### PR DESCRIPTION
* Enable `-O2` by default in `ahc-cabal`/`ahc-link`
* Remove redundant `ahc` arguments in `ahc-link`
