### PR TITLE
Fix "cannot satisfy -package-id" regression in packages with exe targets

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -264,7 +264,7 @@ jobs:
             Cabal
           ahc-cabal v1-install -j2 \
             diagrams \
-            ghc-lib \
+            hlint \
             miso
 
           popd

--- a/asterius/app/ahc-dist.hs
+++ b/asterius/app/ahc-dist.hs
@@ -1,9 +1,11 @@
 import Asterius.Binary.File
 import Asterius.Binary.NameCache
+import Asterius.FixEnv
 import Asterius.Main
 
 main :: IO ()
 main = do
+  fixEnv
   ncu <- newNameCacheUpdater
   task <- getTask
   ld_result <- getFile ncu $ inputHS task

--- a/asterius/app/ahc-link.hs
+++ b/asterius/app/ahc-link.hs
@@ -1,4 +1,7 @@
+import Asterius.FixEnv
 import Asterius.Main
 
 main :: IO ()
-main = getTask >>= ahcLinkMain
+main = do
+  fixEnv
+  getTask >>= ahcLinkMain

--- a/asterius/app/ahc-pkg.hs
+++ b/asterius/app/ahc-pkg.hs
@@ -1,5 +1,4 @@
 import qualified Asterius.BuildInfo as A
-import qualified Asterius.FixEnv as A
 import System.Directory
 import System.Environment.Blank
 import System.FilePath
@@ -7,7 +6,6 @@ import System.Process (callProcess)
 
 main :: IO ()
 main = do
-  A.fixEnv
   Just ghcPkg <- findExecutable "ghc-pkg-asterius"
   args <- getArgs
   callProcess ghcPkg $

--- a/asterius/cabal/config
+++ b/asterius/cabal/config
@@ -25,7 +25,6 @@ split-objs: False
 executable-stripping: False
 library-stripping: False
 user-install: False
-deterministic: True
 tests: False
 coverage: False
 benchmarks: False

--- a/asterius/ghc-bin-asterius/Main.hs
+++ b/asterius/ghc-bin-asterius/Main.hs
@@ -134,8 +134,6 @@ main = do
             -- start our GHC session
             GHC.runGhc mbMinusB $ do
 
-            A.frontendPlugin
-
             dflags <- GHC.getSessionDynFlags
 
             case postStartupMode of
@@ -246,6 +244,9 @@ main' postLoadMode dflags0 args flagWarnings = do
 
   -- we've finished manipulating the DynFlags, update the session
   _ <- GHC.setSessionDynFlags dflags5
+
+  A.frontendPlugin
+
   dflags6 <- GHC.getSessionDynFlags
   hsc_env <- GHC.getSession
 

--- a/asterius/ghc-bin-asterius/Main.hs
+++ b/asterius/ghc-bin-asterius/Main.hs
@@ -79,7 +79,6 @@ import Data.Maybe
 import Prelude
 
 import qualified Asterius.BuildInfo as A
-import qualified Asterius.FixEnv as A
 import qualified Asterius.FrontendPlugin as A
 import Control.Exception
 import System.Process
@@ -98,7 +97,6 @@ import System.Process
 
 main :: IO ()
 main = do
-   A.fixEnv
    initGCStatistics -- See Note [-Bsymbolic and hooks]
    hSetBuffering stdout LineBuffering
    hSetBuffering stderr LineBuffering

--- a/asterius/src/Asterius/Boot.hs
+++ b/asterius/src/Asterius/Boot.hs
@@ -62,7 +62,6 @@ defaultBootArgs = BootArgs
        "--disable-split-objs",
        "--disable-split-sections",
        "--disable-library-stripping",
-       "--enable-deterministic",
        "--enable-relocatable",
        "-O2",
        "--prefix=" <> (bootDir defaultBootArgs </> "asterius_lib"),


### PR DESCRIPTION
* Fix "cannot satisfy -package-id" regression in packages with exe targets by moving our hook initialization logic in `ahc` to a later place.
* Don't cancel the `GHC_`/`HASKELL_` env vars in `ahc`/`ahc-pkg` since `ahc-cabal` may pass these. Do this in `ahc-link`/`ahc-dist` instead since they are likely invoked by `stack exec`.
* Remove `deterministic` related configure flags since we don't need them anyway.
* Add `hlint` to `ahc-cabal` CI test build for this particular case.