### PR TITLE
Cleanup predefined root symbols

### DIFF
--- a/asterius/src/Asterius/Ld.hs
+++ b/asterius/src/Asterius/Ld.hs
@@ -54,32 +54,16 @@ loadTheWorld LinkTask {..} = do
 rtsUsedSymbols :: SS.SymbolSet
 rtsUsedSymbols =
   SS.fromList
-    [ "barf",
-      "base_AsteriusziTopHandler_runIO_closure",
+    [ "base_AsteriusziTopHandler_runIO_closure",
       "base_AsteriusziTopHandler_runNonIO_closure",
       "base_AsteriusziTypesziJSException_mkJSException_closure",
-      "base_GHCziPtr_Ptr_con_info",
-      "ghczmprim_GHCziTypes_Czh_con_info",
-      "ghczmprim_GHCziTypes_Dzh_con_info",
-      "ghczmprim_GHCziTypes_False_closure",
-      "ghczmprim_GHCziTypes_Izh_con_info",
-      "ghczmprim_GHCziTypes_True_closure",
-      "ghczmprim_GHCziTypes_Wzh_con_info",
-      "ghczmprim_GHCziTypes_ZC_con_info",
-      "ghczmprim_GHCziTypes_ZMZN_closure",
       "MainCapability",
-      "stg_ARR_WORDS_info",
-      "stg_BLACKHOLE_info",
       "stg_WHITEHOLE_info",
       "stg_IND_info",
-      "stg_DEAD_WEAK_info",
-      "stg_marked_upd_frame_info",
-      "stg_NO_FINALIZER_closure",
       "stg_raise_info",
       "stg_raise_ret_info",
       "stg_JSVAL_info",
-      "stg_STABLE_NAME_info",
-      "stg_WEAK_info"
+      "stg_STABLE_NAME_info"
     ]
 
 rtsPrivateSymbols :: SS.SymbolSet

--- a/asterius/test/rtsapi/rtsapi.mjs
+++ b/asterius/test/rtsapi/rtsapi.mjs
@@ -29,12 +29,6 @@ module
       )
     );
     console.log(i.exports.rts_getInt(i.exports.getTSOret(tid_p1)));
-    console.log(
-      i.exports.rts_getBool(i.symbolTable.addressOf("ghczmprim_GHCziTypes_False_closure"))
-    );
-    console.log(
-      i.exports.rts_getBool(i.symbolTable.addressOf("ghczmprim_GHCziTypes_True_closure"))
-    );
     console.log(i.exports.rts_getBool(i.exports.rts_mkBool(0)));
     console.log(i.exports.rts_getBool(i.exports.rts_mkBool(42)));
     const x0 = Math.random();


### PR DESCRIPTION
This PR cleans up the set of predefined root symbols, since the runtime doesn't actually need a lot of these. In the distant future, we should be using ` __attribute__((export_name(<name>)))` of `clang` and get rid of this hack.