### PR TITLE
Add missing sized variants of FFIValueTypeRep

### DIFF
--- a/asterius/src-types/Asterius/Types.hs
+++ b/asterius/src-types/Asterius/Types.hs
@@ -622,11 +622,19 @@ data RelooperRun
   deriving (Show, Data)
 
 data FFIValueTypeRep
-  = FFILiftedRep
+  = FFIJSValRep
+  | FFILiftedRep
   | FFIUnliftedRep
-  | FFIJSValRep
   | FFIIntRep
+  | FFIInt8Rep
+  | FFIInt16Rep
+  | FFIInt32Rep
+  | FFIInt64Rep
   | FFIWordRep
+  | FFIWord8Rep
+  | FFIWord16Rep
+  | FFIWord32Rep
+  | FFIWord64Rep
   | FFIAddrRep
   | FFIFloatRep
   | FFIDoubleRep

--- a/asterius/src/Asterius/Foreign/SupportedTypes.hs
+++ b/asterius/src/Asterius/Foreign/SupportedTypes.hs
@@ -27,7 +27,15 @@ ffiValueTypeSigned FFIValueType {..} = case ffiValueTypeRep of
   FFIUnliftedRep -> False
   FFIJSValRep -> False
   FFIIntRep -> True
+  FFIInt8Rep -> True
+  FFIInt16Rep -> True
+  FFIInt32Rep -> True
+  FFIInt64Rep -> True
   FFIWordRep -> False
+  FFIWord8Rep -> False
+  FFIWord16Rep -> False
+  FFIWord32Rep -> False
+  FFIWord64Rep -> False
   FFIAddrRep -> False
   FFIFloatRep -> True
   FFIDoubleRep -> True

--- a/asterius/src/Asterius/Foreign/SupportedTypes.hs
+++ b/asterius/src/Asterius/Foreign/SupportedTypes.hs
@@ -37,7 +37,13 @@ getFFIValueTypeRep tc = case GHC.tyConPrimRep tc of
   [GHC.LiftedRep] -> FFILiftedRep
   [GHC.UnliftedRep] -> FFIUnliftedRep
   [GHC.IntRep] -> FFIIntRep
+  [GHC.Int8Rep] -> FFIInt8Rep
+  [GHC.Int16Rep] -> FFIInt16Rep
+  [GHC.Int64Rep] -> FFIInt64Rep
   [GHC.WordRep] -> FFIWordRep
+  [GHC.Word8Rep] -> FFIWord8Rep
+  [GHC.Word16Rep] -> FFIWord16Rep
+  [GHC.Word64Rep] -> FFIWord64Rep
   [GHC.AddrRep] -> FFIAddrRep
   [GHC.FloatRep] -> FFIFloatRep
   [GHC.DoubleRep] -> FFIDoubleRep

--- a/asterius/src/Asterius/JSFFI.hs
+++ b/asterius/src/Asterius/JSFFI.hs
@@ -35,7 +35,15 @@ recoverWasmWrapperValueType FFIValueType {..} = case ffiValueTypeRep of
   FFIUnliftedRep -> I64
   FFIJSValRep -> I64
   FFIIntRep -> I64
+  FFIInt8Rep -> I32
+  FFIInt16Rep -> I32
+  FFIInt32Rep -> I32
+  FFIInt64Rep -> I64
   FFIWordRep -> I64
+  FFIWord8Rep -> I32
+  FFIWord16Rep -> I32
+  FFIWord32Rep -> I32
+  FFIWord64Rep -> I64
   FFIAddrRep -> I64
   FFIFloatRep -> F32
   FFIDoubleRep -> F64

--- a/asterius/src/Asterius/JSFFI.hs
+++ b/asterius/src/Asterius/JSFFI.hs
@@ -158,7 +158,15 @@ recoverCmmType dflags FFIValueType {..} = case ffiValueTypeRep of
   FFIUnliftedRep -> GHC.gcWord dflags
   FFIJSValRep -> GHC.gcWord dflags
   FFIIntRep -> GHC.bWord dflags
+  FFIInt8Rep -> GHC.b8
+  FFIInt16Rep -> GHC.b16
+  FFIInt32Rep -> GHC.b32
+  FFIInt64Rep -> GHC.b64
   FFIWordRep -> GHC.bWord dflags
+  FFIWord8Rep -> GHC.b8
+  FFIWord16Rep -> GHC.b16
+  FFIWord32Rep -> GHC.b32
+  FFIWord64Rep -> GHC.b64
   FFIAddrRep -> GHC.bWord dflags
   FFIFloatRep -> GHC.f32
   FFIDoubleRep -> GHC.f64


### PR DESCRIPTION
This PR adds 8/16/32/64-bit sized `FFIValueTypeRep`. This is a prerequisite for unifying our JSFFI runtime type information implementation.