### PR TITLE
Toolchain update

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -22,7 +22,7 @@ jobs:
       - name: setup-node-15
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 15.5.1
+          node-version: 15.6.0
 
       - name: checkout
         uses: actions/checkout@v2
@@ -88,7 +88,7 @@ jobs:
       - name: setup-node-15
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 15.5.1
+          node-version: 15.6.0
 
       - name: checkout
         uses: actions/checkout@v2
@@ -180,7 +180,7 @@ jobs:
       - name: setup-node-15
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 15.5.1
+          node-version: 15.6.0
 
       - name: checkout
         uses: actions/checkout@v2
@@ -227,7 +227,7 @@ jobs:
       - name: setup-node-15
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 15.5.1
+          node-version: 15.6.0
 
       - name: checkout
         uses: actions/checkout@v2
@@ -320,7 +320,7 @@ jobs:
       - name: setup-node-15
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 15.5.1
+          node-version: 15.6.0
 
       - name: setup-deps
         run: |

--- a/.github/workflows/setup-deps.sh
+++ b/.github/workflows/setup-deps.sh
@@ -20,4 +20,4 @@ sudo dpkg -i /tmp/binaryen.deb
 rm /tmp/binaryen.deb
 
 sudo mkdir -p /opt/wasi-sdk
-curl -L https://github.com/TerrorJack/wasi-sdk/releases/download/201202/wasi-sdk-11.9gb368b8b12ee6-linux.tar.gz | sudo tar xz -C /opt/wasi-sdk --strip-components=1
+curl -L https://github.com/TerrorJack/wasi-sdk/releases/download/210113/wasi-sdk-12.1g41fa3294474c-linux.tar.gz | sudo tar xz -C /opt/wasi-sdk --strip-components=1

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -2,7 +2,7 @@ FROM debian:sid-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG NODE_VER=15.5.1
+ARG NODE_VER=15.6.0
 
 ENV \
   LANG=C.UTF-8 \
@@ -29,7 +29,7 @@ RUN \
     python3-minimal \
     zlib1g-dev && \
   mkdir -p ${WASI_SDK_PATH} && \
-  (curl -L https://github.com/TerrorJack/wasi-sdk/releases/download/201202/wasi-sdk-11.9gb368b8b12ee6-linux.tar.gz | tar xz -C ${WASI_SDK_PATH} --strip-components=1) && \
+  (curl -L https://github.com/TerrorJack/wasi-sdk/releases/download/210113/wasi-sdk-12.1g41fa3294474c-linux.tar.gz | tar xz -C ${WASI_SDK_PATH} --strip-components=1) && \
   cp \
     /etc/skel/.bash_logout \
     /etc/skel/.bashrc \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -2,12 +2,12 @@ FROM debian:sid
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG NODE_VER=15.5.1
+ARG NODE_VER=15.6.0
 
 ENV \
   BROWSER=echo \
   LANG=C.UTF-8 \
-  PATH=/root/.local/bin:/root/.nvm/versions/node/v${NODE_VER}/bin:${PATH} \
+  PATH=/root/.local/bin:${PATH} \
   WASI_SDK_PATH=/opt/wasi-sdk
 
 RUN \
@@ -39,7 +39,7 @@ RUN \
     zlib1g-dev \
     zstd && \
   mkdir -p ${WASI_SDK_PATH} && \
-  (curl -L https://github.com/TerrorJack/wasi-sdk/releases/download/201202/wasi-sdk-11.9gb368b8b12ee6-linux.tar.gz | tar xz -C ${WASI_SDK_PATH} --strip-components=1) && \
+  (curl -L https://github.com/TerrorJack/wasi-sdk/releases/download/210113/wasi-sdk-12.1g41fa3294474c-linux.tar.gz | tar xz -C ${WASI_SDK_PATH} --strip-components=1) && \
   apt autoremove --purge -y && \
   apt clean && \
   rm -rf -v /var/lib/apt/lists/* && \
@@ -70,7 +70,7 @@ RUN \
 
 RUN \
   stack --no-terminal update && \
-  stack --no-terminal --resolver lts-16.28 install \
+  stack --no-terminal --resolver lts-16.29 install \
     brittany \
     ghcid \
     ormolu \

--- a/dev.rootless.Dockerfile
+++ b/dev.rootless.Dockerfile
@@ -38,12 +38,12 @@ ARG DEBIAN_FRONTEND
 ARG USERNAME
 ARG UID
 
-ARG NODE_VER=15.5.1
+ARG NODE_VER=15.6.0
 
 ENV \
   BROWSER=echo \
   LANG=C.UTF-8 \
-  PATH=/home/${USERNAME}/.local/bin:/home/${USERNAME}/.nvm/versions/node/v${NODE_VER}/bin:${PATH} \
+  PATH=/home/${USERNAME}/.local/bin:${PATH} \
   WASI_SDK_PATH=/opt/wasi-sdk
 
 RUN \
@@ -74,7 +74,7 @@ RUN \
     zlib1g-dev \
     zstd && \
   sudo mkdir -p ${WASI_SDK_PATH} && \
-  (curl -L https://github.com/TerrorJack/wasi-sdk/releases/download/201202/wasi-sdk-11.9gb368b8b12ee6-linux.tar.gz | sudo tar xz -C ${WASI_SDK_PATH} --strip-components=1) && \
+  (curl -L https://github.com/TerrorJack/wasi-sdk/releases/download/210113/wasi-sdk-12.1g41fa3294474c-linux.tar.gz | sudo tar xz -C ${WASI_SDK_PATH} --strip-components=1) && \
   sudo apt autoremove --purge -y && \
   sudo apt clean && \
   sudo rm -rf -v \
@@ -98,7 +98,7 @@ RUN \
 
 RUN \
   stack --no-terminal update && \
-  stack --no-terminal --resolver lts-16.28 install \
+  stack --no-terminal --resolver lts-16.29 install \
     brittany \
     ghcid \
     ormolu \

--- a/ghc-toolkit/boot-libs/cabal.config
+++ b/ghc-toolkit/boot-libs/cabal.config
@@ -1,4 +1,4 @@
-index-state: 2021-01-08T00:00:00Z
+index-state: 2021-01-13T00:00:00Z
 
 constraints:
   HsOpenSSL -fast-bignum,
@@ -1008,7 +1008,7 @@ constraints:
   greskell-core ==0.1.3.5,
   greskell-websocket ==0.1.2.5,
   groom ==0.1.2.1,
-  group-by-date ==0.1.0.3,
+  group-by-date ==0.1.0.4,
   groups ==0.4.1.0,
   gtk-sni-tray ==0.1.6.0,
   gtk-strut ==0.1.3.0,
@@ -1882,7 +1882,7 @@ constraints:
   relational-schemas ==0.1.8.0,
   relude ==0.7.0.0,
   renderable ==0.2.0.1,
-  replace-attoparsec ==1.4.2.0,
+  replace-attoparsec ==1.4.4.0,
   replace-megaparsec ==1.4.4.0,
   repline ==0.2.2.0,
   req ==3.2.0,
@@ -2061,7 +2061,7 @@ constraints:
   soap ==0.2.3.6,
   soap-tls ==0.1.1.4,
   socks ==0.6.1,
-  some ==1.0.1,
+  some ==1.0.2,
   sop-core ==0.5.0.1,
   sort ==1.0.0.0,
   sorted-list ==0.2.1.0,

--- a/stack-profile.yaml
+++ b/stack-profile.yaml
@@ -4,7 +4,7 @@ build:
   library-profiling: true
   executable-profiling: true
 
-resolver: lts-16.28
+resolver: lts-16.29
 extra-deps:
   - binaryen-0.0.6.0
   - url: https://github.com/tweag/inline-js/archive/ef675745e84d23d51c50660d40acf9e684fbb2d6.tar.gz

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.28
+resolver: lts-16.29
 extra-deps:
   - binaryen-0.0.6.0
   - url: https://github.com/tweag/inline-js/archive/ef675745e84d23d51c50660d40acf9e684fbb2d6.tar.gz

--- a/utils/gen-pkgs.hs
+++ b/utils/gen-pkgs.hs
@@ -1,6 +1,6 @@
 #!/usr/bin/env stack
 {-
-  stack --resolver lts-16.28 script
+  stack --resolver lts-16.29 script
     --package Cabal
     --package containers
     --package pantry

--- a/utils/make-packages.py
+++ b/utils/make-packages.py
@@ -101,7 +101,7 @@ def ghc_configure():
 def patch_hadrian():
     with open(os.path.join(ghc_repo_path, "hadrian", "stack.yaml"),
               mode="w") as f:
-        f.write("resolver: lts-16.28\n")
+        f.write("resolver: lts-16.29\n")
     with open(os.path.join(ghc_repo_path, "hadrian", "src", "Oracles",
                            "Setting.hs"),
               mode="r") as h:


### PR DESCRIPTION
* Update stackage snapshot to `lts-16.29`
* Update `wasi-sdk`, use non-threaded variant of the CI build
* Update `node` to `15.6.0`, fix `nvm` in dev images