### PR TITLE
Added note for SElinux enabled distros (in README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ terrorjack@hostname:/project$ podman run -it --rm -v $(pwd):/workspace -w /works
 root@hostname:/workspace#
 ```
 
+Note that SELinux might be preventing your source files to be visible in the container. If that is the case you can add `--security-opt label=disable` to the podman command.
+
 There are a lot of link-time options available to `ahc-link`, e.g. targeting
 the browser platform instead of `node`, adding extra GHC options or setting
 runtime parameters. Check the [documentation](https://asterius.netlify.app/) for


### PR DESCRIPTION
Fedora (among other distros) has SElinux enabled by default. If that's the case, the guide won't work.

The issue can be fixed by adding `--security-opt label=disable` to the podman command.