### PR TITLE
documentation fix

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -18,7 +18,8 @@ jobs:
         run: |
           pip install \
             recommonmark \
-            sphinx
+            sphinx \
+            "docutils>=0.14,<0.18"
 
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR intends to fix this [build failure for the doc](https://github.com/tweag/asterius/actions/runs/1395452058), which happens because sphinx is [not compatible yet](https://github.com/sphinx-doc/sphinx/issues/9777) with `docutils-0.18`, so the `docutils` version is now pinned to `>=0.14,<0.18`.

One thing I do not understand: In the case of [rules_haskell](https://github.com/tweag/rules_haskell/pull/1620) (which builds on readthedocs), pinning sphinx to `4.2.0` prevented `docutils-0.18` from being installed, but this did not work here (in fact `sphinx-4.2.0` was already the version used).
