### PR TITLE
Fix Tweag logo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ documentation for details.
 ## Contributors
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-[<img src="./docs/tweag-logo.svg" height="65">](https://tweag.io)
+[<img src="./docs/src/tweag-logo.svg" height="65">](https://tweag.io)
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 [<img src="https://i.imgur.com/tAag5MD.jpg" height="65">](https://iohk.io)
 


### PR DESCRIPTION
The link was broken in #885.